### PR TITLE
Give the consumption models real CMake projects

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -137,7 +137,13 @@ endforeach()
 
 set(current_include_dir ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set(current_src_dir ${CMAKE_CURRENT_SOURCE_DIR}/src)
-file(GLOB_RECURSE targets RELATIVE ${current_src_dir} *.cpp)
+# The pattern is anchored to current_src_dir. RELATIVE only controls how
+# the results are reported, not where the search runs: an unanchored
+# *.cpp resolves against CMAKE_CURRENT_SOURCE_DIR, i.e. test/ rather than
+# test/src/, and so swept up every .cpp anywhere under test/ -- including
+# test/consumer/main.cpp, which then compiled with BOOST_TEST_MAIN and
+# collided with the main Boost.Test generates.
+file(GLOB_RECURSE targets RELATIVE ${current_src_dir} ${current_src_dir}/*.cpp)
 
 cmake_path(GET CMAKE_CURRENT_SOURCE_DIR FILENAME target_source_dir)
 foreach(t ${targets})

--- a/test/consumer/add_subdirectory/CMakeLists.txt
+++ b/test/consumer/add_subdirectory/CMakeLists.txt
@@ -1,0 +1,18 @@
+#          Copyright Rein Halbersma 2014-2026.
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+cmake_minimum_required(VERSION 3.28)
+project(consumer_add_subdirectory LANGUAGES CXX)
+
+# The repository root, found by walking up rather than through the
+# environment, so this consumer configures outside CI too. The heredoc this
+# replaces reached it through $ENV{GITHUB_WORKSPACE} and configured nowhere
+# else.
+get_filename_component(bit_set_root "${CMAKE_CURRENT_SOURCE_DIR}/../../.." ABSOLUTE)
+
+add_subdirectory("${bit_set_root}" bit_set-build)
+
+add_executable(main ../main.cpp)
+target_link_libraries(main PRIVATE bit_set::bit_set)

--- a/test/consumer/fetch_content/CMakeLists.txt
+++ b/test/consumer/fetch_content/CMakeLists.txt
@@ -1,0 +1,19 @@
+#          Copyright Rein Halbersma 2014-2026.
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+cmake_minimum_required(VERSION 3.28)
+project(consumer_fetch_content LANGUAGES CXX)
+
+include(FetchContent)
+
+# The repository root, found by walking up rather than through the
+# environment, so this consumer configures outside CI too.
+get_filename_component(bit_set_root "${CMAKE_CURRENT_SOURCE_DIR}/../../.." ABSOLUTE)
+
+FetchContent_Declare(bit_set SOURCE_DIR "${bit_set_root}")
+FetchContent_MakeAvailable(bit_set)
+
+add_executable(main ../main.cpp)
+target_link_libraries(main PRIVATE bit_set::bit_set)

--- a/test/consumer/find_package/CMakeLists.txt
+++ b/test/consumer/find_package/CMakeLists.txt
@@ -1,0 +1,16 @@
+#          Copyright Rein Halbersma 2014-2026.
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+cmake_minimum_required(VERSION 3.28)
+project(consumer_find_package LANGUAGES CXX)
+
+# CMAKE_PREFIX_PATH names the install trees the caller populated. Three of
+# them, unlike a library with no dependencies: bit_set's own, xstd's --
+# bit_setConfig.cmake find_dependency()s it -- and vcpkg's, for the
+# Boost.Hash2 that bit_set's headers hash_append through.
+find_package(bit_set 0.1.0 CONFIG REQUIRED)
+
+add_executable(main ../main.cpp)
+target_link_libraries(main PRIVATE bit_set::bit_set)

--- a/test/consumer/main.cpp
+++ b/test/consumer/main.cpp
@@ -1,0 +1,16 @@
+//          Copyright Rein Halbersma 2014-2026.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include <xstd/bit_set.hpp>
+
+int main()
+{
+        constexpr auto N = 100;
+        auto s = xstd::bit_set<N>();
+        s.insert(1);
+        s.insert(2);
+        s.insert(3);
+        return s.size() == 3 ? 0 : 1;
+}


### PR DESCRIPTION
The three consumers live as heredocs inside `consumption.yml`, where no compiler sees them until CI runs. They are projects under `test/consumer` now, one per model, sharing a single `main.cpp` — mirroring [rhalbersma/tabula#45](https://github.com/rhalbersma/tabula/pull/45).

As in tabula, all three heredocs held the same program character for character, so nothing had to be reconciled and the source here is theirs unchanged. The reason to move them is the other one: `add_subdirectory` and `fetch_content` reached the repository root through `$ENV{GITHUB_WORKSPACE}`, so they configured inside CI and nowhere else. They walk up from their own directory now.

## What was verified, and what wasn't

Verified locally rather than on a runner, which is the point of the change — but only partly, and it's worth being precise:

- **`add_subdirectory` and `fetch_content` both resolve the repository root** and configure bit_set itself as far as its `find_package(boost_hash2 CONFIG REQUIRED)`. That is the walk-up doing its job, which is the load-bearing part of this change.
- **Neither could be built and run here.** This container has no Boost headers at all, and Boost.Hash2 needs `boost/config`, `mp11`, `describe` and `container_hash` in turn. `find_package` additionally needs an installed bit_set and xstd. CI covers all three.

## This does not yet unblock the consumption stub

Worth flagging before the CI migration lands on top: **the shared `consumption.yml` cannot call these as it stands.** It configures the library with no vcpkg toolchain and no `CMAKE_PREFIX_PATH` beyond its own install tree, which suits a library that depends on nothing — tabula's case, which is what it was written against.

bit_set is not that:

- its root `CMakeLists.txt` calls `find_package(boost_hash2 CONFIG REQUIRED)` **unconditionally**, not gated on `PROJECT_IS_TOP_LEVEL` or `BUILD_TESTING`, so even the shared workflow's own Configure step would fail;
- its installed package `find_dependency()`s xstd, so `find_package` needs an installed xstd, which the existing workflow clones and installs by hand;
- all three models therefore need prefixes the shared workflow has no input for.

That is a `cpp-ci` change — new inputs, a release and a repin — not one this repository can make. This PR is still worth having on its own merits: the consumers become real projects that configure outside CI, which is true whether or not the workflow ever calls them.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ef1rfKHEMHutpEeV1R6ga)_