### PR TITLE
Follow aligned_size to its new header, and pin xstd

### DIFF
--- a/.github/workflows/consumption.yml
+++ b/.github/workflows/consumption.yml
@@ -61,7 +61,12 @@ jobs:
       # xstd for bit_set's own --install step to produce a valid package.
       - name: Install xstd
         run: |
-          git clone --depth 1 https://github.com/rhalbersma/xstd.git xstd-src
+          # The same revision CMakeLists.txt pins. This clone is the one that
+          # matters in CI: it installs xstd, so bit_set's find_package finds it
+          # and the pinned FetchContent fallback never runs. Left on main, this
+          # step alone would keep the dependency floating.
+          git clone --no-checkout https://github.com/rhalbersma/xstd.git xstd-src
+          git -C xstd-src checkout --detach 7f7cbdd6e4174107ea062484f31c81fbfe220f7a
           cmake -S xstd-src -B xstd-build \
             -DCMAKE_C_COMPILER=gcc-15 \
             -DCMAKE_CXX_COMPILER=g++-15 \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,12 @@ if(NOT xstd_FOUND)
     FetchContent_Declare(
         xstd
         GIT_REPOSITORY https://github.com/rhalbersma/xstd.git
-        GIT_TAG main
+        # Pinned, not main. This is the only first-party dependency here and it
+        # moved under us: aligned_size left <xstd/utility.hpp> for
+        # <xstd/memory.hpp>, and every compiling job went red with no commit in
+        # this repository. Bump this deliberately, fixing whatever the bump
+        # renames, rather than discovering it from CI.
+        GIT_TAG 7f7cbdd6e4174107ea062484f31c81fbfe220f7a
     )
     FetchContent_MakeAvailable(xstd)
 endif()

--- a/include/xstd/bit/array.hpp
+++ b/include/xstd/bit/array.hpp
@@ -8,7 +8,7 @@
 
 #include <xstd/bit/intrin.hpp>                  // countl_zero, countr_zero, popcount
 #include <xstd/bit/pred.hpp>                    // intersects, is_subset_of, not_equal_to
-#include <xstd/utility.hpp>                     // aligned_size
+#include <xstd/memory.hpp>                      // aligned_size
 #include <boost/hash2/hash_append_fwd.hpp>      // hash_append, hash_append_tag
 #include <algorithm>                            // all_of, any_of, copy, fill_n, find_if, fold_left, max, shift_left, shift_right
 #include <array>                                // array

--- a/include/xstd/bit/array.hpp
+++ b/include/xstd/bit/array.hpp
@@ -28,7 +28,7 @@ template<std::size_t N, std::unsigned_integral Block>
 struct array
 {
         static constexpr auto bits_per_block = static_cast<std::size_t>(std::numeric_limits<Block>::digits);
-        static constexpr auto num_bits       = aligned_size(N, bits_per_block);
+        static constexpr auto num_bits       = aligned_size(bits_per_block, N);
         static constexpr auto num_blocks     = std::ranges::max(num_bits / bits_per_block, 1uz);
 
         std::array<Block, num_blocks> m_bits;

--- a/include/xstd/bit_array.hpp
+++ b/include/xstd/bit_array.hpp
@@ -11,7 +11,7 @@
 #include <compare>              // strong_ordering
 #include <initializer_list>     // initializer_list
 
-#include <xstd/utility.hpp>     // aligned_size
+#include <xstd/memory.hpp>      // aligned_size
 #include <concepts>             // unsigned_integral
 #include <cstddef>              // size_t
 #include <limits>               // digits
@@ -37,7 +37,7 @@ using bit_array = xstd::bit_array<xstd::aligned_size(N, std::numeric_limits<Bloc
 
 #include <xstd/bit/array.hpp>   // array
 #include <xstd/proxy.hpp>       // begin, end, iterator, reference
-#include <xstd/utility.hpp>     // aligned_size
+#include <xstd/memory.hpp>      // aligned_size
 #include <algorithm>            // lexicographical_compare_three_way
 #include <cassert>              // assert
 #include <compare>              // strong_ordering

--- a/include/xstd/bit_array.hpp
+++ b/include/xstd/bit_array.hpp
@@ -30,7 +30,7 @@ template<std::size_t N, std::unsigned_integral Block>               constexpr vo
 namespace aligned {
 
 template<std::size_t N, std::unsigned_integral Block = std::size_t>
-using bit_array = xstd::bit_array<xstd::aligned_size(N, std::numeric_limits<Block>::digits), Block>;
+using bit_array = xstd::bit_array<xstd::aligned_size(std::numeric_limits<Block>::digits, N), Block>;
 
 }       // namespace aligned
 }       // namespace xstd

--- a/include/xstd/bit_set.hpp
+++ b/include/xstd/bit_set.hpp
@@ -33,7 +33,7 @@ constexpr typename bit_set<N, Block>::size_type erase_if(bit_set<N, Block>& c, P
 namespace aligned {
 
 template<std::size_t N, std::unsigned_integral Block = std::size_t>
-using bit_set = xstd::bit_set<xstd::aligned_size(N, std::numeric_limits<Block>::digits), Block>;
+using bit_set = xstd::bit_set<xstd::aligned_size(std::numeric_limits<Block>::digits, N), Block>;
 
 }       // namespace aligned
 }       // namespace xstd

--- a/include/xstd/bit_set.hpp
+++ b/include/xstd/bit_set.hpp
@@ -11,7 +11,7 @@
 #include <compare>              // strong_ordering
 #include <initializer_list>     // initializer_list
 
-#include <xstd/utility.hpp>     // aligned_size
+#include <xstd/memory.hpp>      // aligned_size
 #include <concepts>             // unsigned_integral
 #include <cstddef>              // size_t
 #include <limits>               // digits


### PR DESCRIPTION
Every compiling job on `main` is red:

```
include/xstd/bit_set.hpp:36: error: 'aligned_size' is not a member of 'xstd'
include/xstd/bit/array.hpp:31: error: use of undeclared identifier 'aligned_size'
```

**xstd moved `aligned_size` out of `<xstd/utility.hpp>` and into `<xstd/memory.hpp>`.** Nothing changed here; the dependency moved underneath, because both places that obtain xstd tracked `main`.

## Four include sites, not two

My first pass named two. `bit_array.hpp` has it twice — once in its synopsis block and once in the implementation block below:

```
include/xstd/bit_set.hpp:14
include/xstd/bit/array.hpp:11
include/xstd/bit_array.hpp:14
include/xstd/bit_array.hpp:40
```

## Both fetches pinned, not just the obvious one

`CMakeLists.txt`'s `FetchContent` fallback is the one you'd think of. But **the clone in `consumption.yml` is what actually decides which xstd CI builds against**: it installs xstd, so `find_package(xstd 0.1.0 CONFIG QUIET)` succeeds and the fallback never runs. Pinning only the CMake side would have left the dependency floating exactly where it floated this time.

Both now name `7f7cbdd6e4174107ea062484f31c81fbfe220f7a`. The workflow clone drops `--depth 1` and checks out that commit, since a shallow clone can't check out an arbitrary SHA.

Pinned by **commit rather than tag because xstd publishes none.** Bump it deliberately, fixing whatever the bump renames, rather than learning about the rename from a red matrix — which matters more now than it used to, since this library is set to lean on xstd further, starting with `xstd::unsigned_integer` replacing `std::unsigned_integral`.

## Verified against the pinned revision

Not assumed. A translation unit including `<xstd/memory.hpp>` at `7f7cbdd` resolves `xstd::aligned_size` and satisfies:

```cpp
static_assert(xstd::aligned_size(64, 100) == 128);
static_assert(xstd::aligned_size(64, 128) == 128);
```

while the same call through `<xstd/utility.hpp>` reproduces the error above. `actionlint` clean.

Full build and test could not be run locally — this container has no Boost headers at all, and Boost.Hash2 needs `boost/config`, `mp11`, `describe` and `container_hash` in turn. CI covers that.

## Note on [#42](https://github.com/rhalbersma/bit_set/pull/42)

That PR (the `test/consumer` tree) is red for this reason and nothing of its own. It should go green once this merges and it picks up `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ef1rfKHEMHutpEeV1R6ga)_