### PR TITLE
Keep the synopsis convention, silence duplicate-include at the site

### DIFF
--- a/include/xstd/bit_array.hpp
+++ b/include/xstd/bit_array.hpp
@@ -35,6 +35,10 @@ using bit_array = xstd::bit_array<xstd::aligned_size(std::numeric_limits<Block>:
 }       // namespace aligned
 }       // namespace xstd
 
+// The synopsis above and the implementation below each list the headers that
+// section needs, mirroring the layout of the standard itself. The overlap
+// between the two lists is deliberate: neither is complete without it.
+// NOLINTBEGIN(readability-duplicate-include): deliberate, see above
 #include <xstd/bit/array.hpp>   // array
 #include <xstd/proxy.hpp>       // begin, end, iterator, reference
 #include <xstd/memory.hpp>      // aligned_size
@@ -51,6 +55,7 @@ using bit_array = xstd::bit_array<xstd::aligned_size(std::numeric_limits<Block>:
 #include <stdexcept>            // out_of_range
 #include <type_traits>          // conditional_t
 #include <utility>              // pair
+// NOLINTEND(readability-duplicate-include)
 
 // Class template array                                                  [array]
 // Overview                                                     [array.overview]

--- a/include/xstd/bit_set.hpp
+++ b/include/xstd/bit_set.hpp
@@ -38,6 +38,10 @@ using bit_set = xstd::bit_set<xstd::aligned_size(std::numeric_limits<Block>::dig
 }       // namespace aligned
 }       // namespace xstd
 
+// The synopsis above and the implementation below each list the headers that
+// section needs, mirroring the layout of the standard itself. The overlap
+// between the two lists is deliberate: neither is complete without it.
+// NOLINTBEGIN(readability-duplicate-include): deliberate, see above
 #include <xstd/bit/array.hpp>           // array
 #include <xstd/proxy.hpp>               // const_iterator, const_reference
 #include <boost/hash2/fnv1a.hpp>        // fnv1a_64
@@ -56,6 +60,7 @@ using bit_set = xstd::bit_set<xstd::aligned_size(std::numeric_limits<Block>::dig
                                         // input_range
 #include <type_traits>                  // conditional_t
 #include <utility>                      // forward, move, pair
+// NOLINTEND(readability-duplicate-include)
 
 // Class template set                                                      [set]
 // Overview                                                       [set.overview]


### PR DESCRIPTION
`bit_array.hpp` and `bit_set.hpp` mirror the layout of the standard itself: a synopsis section that declares the interface, then an implementation section that defines it, each listing the headers *that section* needs. Eleven headers appear in both lists, and `readability-duplicate-include` flags every one, so the Clang-Tidy job fails on both files.

The duplication is the convention, not an accident — dropping either copy leaves that section's include list incomplete. So this fences the implementation include block with `NOLINTBEGIN` / `NOLINTEND` and records why, rather than disabling the check in `.clang-tidy`. Same posture as `bugprone-std-namespace-modification` in xstd: suppress at the site with a reason, keep the check live everywhere else.

## Findings suppressed

| File | Duplicated in both lists |
| --- | --- |
| `include/xstd/bit_array.hpp` | `<xstd/memory.hpp>`, `<compare>`, `<concepts>`, `<cstddef>`, `<initializer_list>`, `<limits>` |
| `include/xstd/bit_set.hpp` | `<compare>`, `<concepts>`, `<cstddef>`, `<initializer_list>`, `<limits>` |

`bitset.hpp` has a synopsis block too, but no overlap between its two lists, so it needs no annotation.

## Verification

Ran `readability-duplicate-include` locally over every public header, before and after:

- **Before:** 11 warnings — 6 in `bit_array.hpp`, 5 in `bit_set.hpp`.
- **After:** 0, in all nine public headers (`bit/array.hpp`, `bit/intrin.hpp`, `bit/pred.hpp`, `bit_array.hpp`, `bit_set.hpp`, `bitset.hpp`, `proxy.hpp`, `proxy/bidirectional.hpp`, `proxy/random_access.hpp`).

The suppression is scoped to the implementation include block, so a genuinely accidental duplicate anywhere else in these files — or in any other header — still fails the job.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ef1rfKHEMHutpEeV1R6ga)_