### PR TITLE
Spell the single-block shift truncation, rather than suppress it

### DIFF
--- a/include/xstd/bit/array.hpp
+++ b/include/xstd/bit/array.hpp
@@ -224,17 +224,17 @@ struct array
         {
                 assert(is_valid(n));
                 if constexpr (num_blocks == 1) {
-                        // GCC's -Wconversion flags this compound shift-assign
-                        // at -O0 (its value-range propagation, which proves
-                        // the shift never truncates, only runs at -O1+).
-                        #if defined(__GNUC__)
-                        #pragma GCC diagnostic push
-                        #pragma GCC diagnostic ignored "-Wconversion"
-                        #endif
-                        m_bits[0] <<= n;
-                        #if defined(__GNUC__)
-                        #pragma GCC diagnostic pop
-                        #endif
+                        // The cast is the truncation, written down. A shift
+                        // can carry bits past the top of a single-block array,
+                        // and dropping them is what a fixed-width shift means;
+                        // Block being narrower than the int its operands
+                        // promote to is what makes that a conversion at all.
+                        // Left implicit it draws GCC's -Wconversion at -O0 and
+                        // Clang's -fsanitize=implicit-conversion at run time,
+                        // and the sanitizer has no pragma to silence it - only
+                        // this. Explicit, it matches how the multi-block path
+                        // below already spells every one of its narrowings.
+                        m_bits[0] = static_cast<Block>(m_bits[0] << n);
                 } else if constexpr (num_blocks >= 2) {
                         auto const [ n_blocks, L_shift ] = div_mod(n, bits_per_block);
                         if (L_shift == 0) {
@@ -258,15 +258,8 @@ struct array
         {
                 assert(is_valid(n));
                 if constexpr (num_blocks == 1) {
-                        // See operator<<= above for why this is guarded.
-                        #if defined(__GNUC__)
-                        #pragma GCC diagnostic push
-                        #pragma GCC diagnostic ignored "-Wconversion"
-                        #endif
-                        m_bits[0] >>= n;
-                        #if defined(__GNUC__)
-                        #pragma GCC diagnostic pop
-                        #endif
+                        // See operator<<= above for why this is cast.
+                        m_bits[0] = static_cast<Block>(m_bits[0] >> n);
                 } else if constexpr (num_blocks >= 2) {
                         auto const [ n_blocks, R_shift ] = div_mod(n, bits_per_block);
                         if (R_shift == 0) {


### PR DESCRIPTION
`bit::array`'s single-block `operator<<=` and `operator>>=` narrowed implicitly: `Block` is narrower than the `int` its operands promote to, so a shift carrying bits past the top of the array converted back on assignment. Dropping those bits is what a fixed-width shift *means* — but implicit is the wrong way to say so, and `-fsanitize=implicit-conversion` said so on all three Clang rungs:

```
include/xstd/bit/array.hpp:234: runtime error: implicit conversion from type 'int'
of value 256 (32-bit, signed) to type 'value_type' (aka 'unsigned char')
changed the value to 0 (8-bit, unsigned)
```

Unlike `-Wconversion` there is no pragma that silences a sanitizer — the cast is the only in-source answer short of an attribute on the whole function. It is also the one the surrounding code already uses: the multi-block path below spells every one of its own narrowings, `static_cast<Block>(first << L_shift)` and the rest.

Both `#pragma GCC diagnostic` blocks go with it. `-Wconversion` warns about *implicit* conversions, so it has nothing left to say here.

## On reopening #33

#33 reverted exactly this rewrite in favour of the pragma. That decision was about a **static** false positive at `-O0`; this is a **run-time** report, and the pragma has no equivalent for it. That is what changed, and it's why this comes back rather than staying reverted.

## Verification

**Behaviour-preserving, measured rather than argued from the standard.** A program comparing `b <<= n` against `b = static_cast<Block>(b << n)`, and the same for `>>`:

| Block | Coverage | Result |
| :-- | :-- | :-- |
| `unsigned char` | exhaustive — all 256 values × all 8 shifts | identical |
| `unsigned short` | exhaustive — all 65536 values × all 16 shifts | identical |
| `unsigned int` | sampled across the range × all 32 shifts | identical |
| `unsigned long long` | sampled across the range × all 64 shifts | identical |

**One thing I could not verify locally, stated plainly:** that the original `-Wconversion` diagnostic still fires on the old form. This container has g++ 13, and a reduced case reproduces nothing at either `-O0` or `-O2`, where the comment being removed reported GCC 15 at `-O0`. So that claim is untested here in both directions — I am not asserting the pragma was unnecessary. What makes *removing* it safe is narrower and doesn't depend on it: an explicit cast cannot draw `-Wconversion` at all. The GCC 15, 16 and 17-SVN legs settle it either way.

## Expected effect

The three `sanitizers / Implicit conversion / Clang` legs should go green, taking `sanitizers / all` with them — the ASan libc++ legs were already removed from that gate by cpp-ci's `libcxx_tiers`, so implicit-conversion was the only thing left holding it red.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ef1rfKHEMHutpEeV1R6ga)_