### PR TITLE
Make the Windows and MinGW Debug legs mean something

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -78,8 +78,20 @@ set(cxx_compile_options_optimization
     >
 )
 
+get_property(bit_set_is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+
+# Deliberately not applied to Debug, as an experiment - see the pull request.
+# Every MinGW Debug leg segfaults in the same five tests on all three rungs,
+# deterministically, while every MinGW Release leg passes; Debug is also the
+# first configuration this repository has ever built on MinGW, and the only
+# thing it adds to this translation unit is -g. Big COFF objects combined
+# with DWARF have a history of bad relocations in binutils, which surfaces as
+# a runtime crash rather than a link error. Dropping the flag in Debug tests
+# that: if those legs go green the interaction is the cause and this is the
+# fix; if they fail to assemble or link instead, the flag is load-bearing
+# there and the answer is -g1 or split DWARF rather than removal.
 set(cxx_compile_options_mbig_obj
-    $<$<AND:$<CXX_COMPILER_ID:GNU>,$<PLATFORM_ID:Windows>>:
+    $<$<AND:$<CXX_COMPILER_ID:GNU>,$<PLATFORM_ID:Windows>,$<NOT:$<CONFIG:Debug>>>:
 	    -Wa,-mbig-obj
     >
 )
@@ -117,5 +129,27 @@ foreach(t ${targets})
         ${cxx_compile_options_mbig_obj}
     )
 
-    add_test(${target_id} ${target_id})
+    # Release only. A benchmark measures the library rather than verifying
+    # it, and an unoptimised measurement is meaningless anyway - which is why
+    # #32 moved every leg to Release in the first place. Registering it in
+    # Debug costs 25 minutes per Windows leg to learn nothing: the MSVC STL's
+    # _ITERATOR_DEBUG_LEVEL=2 makes the sieve's repeated flat_set erase about
+    # 60x slower, and benchmark.set.sieve then trips ctest's 1500s per-test
+    # timeout.
+    #
+    # Two spellings, because neither works on both generator kinds:
+    #
+    # - Multi-config (the Visual Studio generator) leaves CMAKE_BUILD_TYPE
+    #   empty, so an if() on it would register these in every configuration,
+    #   Debug included. CONFIGURATIONS is the only thing that discriminates.
+    # - Single-config (Ninja, Makefiles) does set CMAKE_BUILD_TYPE, but
+    #   CONFIGURATIONS is matched by ctest against the -C it was given, and
+    #   the GCC, Clang and MinGW legs invoke a bare "ctest --test-dir build"
+    #   with no -C. There it matches nothing, and the benchmarks would
+    #   silently stop running anywhere at all rather than in Debug only.
+    if(bit_set_is_multi_config)
+        add_test(NAME ${target_id} CONFIGURATIONS Release COMMAND ${target_id})
+    elseif(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+        add_test(NAME ${target_id} COMMAND ${target_id})
+    endif()
 endforeach()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -84,8 +84,18 @@ set(cxx_compile_options_optimization
     >
 )
 
+# Deliberately not applied to Debug, as an experiment - see the pull request.
+# Every MinGW Debug leg segfaults in the same five tests on all three rungs,
+# deterministically, while every MinGW Release leg passes; Debug is also the
+# first configuration this repository has ever built on MinGW, and the only
+# thing it adds to this translation unit is -g. Big COFF objects combined
+# with DWARF have a history of bad relocations in binutils, which surfaces as
+# a runtime crash rather than a link error. Dropping the flag in Debug tests
+# that: if those legs go green the interaction is the cause and this is the
+# fix; if they fail to assemble or link instead, the flag is load-bearing
+# there and the answer is -g1 or split DWARF rather than removal.
 set(cxx_compile_options_mbig_obj
-    $<$<AND:$<CXX_COMPILER_ID:GNU>,$<PLATFORM_ID:Windows>>:
+    $<$<AND:$<CXX_COMPILER_ID:GNU>,$<PLATFORM_ID:Windows>,$<NOT:$<CONFIG:Debug>>>:
 	    -Wa,-mbig-obj
     >
 )


### PR DESCRIPTION
Every leg built Release and only Release until the cpp-ci migration; the shared workflows default to `Release,Debug`, so Debug is new coverage everywhere. It found two things on Windows. This addresses both — one as a fix, one as a deliberate experiment.

## 1. Benchmarks stop being ctest tests outside Release

`benchmark.set.sieve` trips ctest's 1500 s per-test timeout on every Windows Debug leg. The MSVC STL's `_ITERATOR_DEBUG_LEVEL=2` makes the sieve's repeated `flat_set` erase roughly **60× slower**:

| Leg | Test step |
| :-- | --: |
| MSVC 2026 Release | 25 s |
| MSVC 2026 **Debug** | 25 m 27 s |
| Clang-CL 2026 **Debug** | 1519 s → timeout |

A benchmark measures the library rather than verifying it, and an unoptimised measurement is meaningless anyway — which is exactly why #32 moved every leg to Release after hitting this same timeout. Registering it in Debug costs 25 minutes per leg to learn nothing.

### The part that nearly went wrong

This needs **two spellings**, because neither works on both generator kinds:

- **`CONFIGURATIONS Release`** is the only thing that discriminates under the Visual Studio generator, which is multi-config and leaves `CMAKE_BUILD_TYPE` empty. An `if()` there would register the benchmarks in *every* configuration, Debug included — no fix at all.
- But ctest matches `CONFIGURATIONS` against the `-C` **it was given**, and only cpp-ci's `visual-studio.yml` passes one. The GCC, Clang and MinGW legs run a bare `ctest --test-dir build`. There, `CONFIGURATIONS Release` matches nothing — so using it alone would not have scoped the benchmarks to Release on those legs, it would have **stopped running them anywhere, in any configuration, silently.**

I wrote the `CONFIGURATIONS`-only version first and caught this by probing the actual semantics rather than assuming them. Both branches are verified on a scratch project:

| Generator | Invocation | Tests listed |
| :-- | :-- | :-- |
| single-config | `ctest` (Debug build) | `unit` |
| single-config | `ctest` (Release build) | `bench`, `unit` |
| multi-config | `ctest -C Debug` | `unit` |
| multi-config | `ctest -C Release` | `bench`, `unit` |

## 2. `-Wa,-mbig-obj` stops being applied to Debug — as an experiment

**This hunk is a question, not an answer.** All three MinGW Debug rungs segfault in the same five tests, deterministically, while all three Release rungs pass. `-g` is the only thing Debug adds to those translation units, and big COFF objects combined with DWARF have a history of bad relocations in binutils — which surfaces as a runtime crash rather than a link error, matching what we see (`benchmark.set.sieve` printed its full results table and *then* died).

- **If the MinGW Debug legs go green**, the interaction is the cause and this is the fix.
- **If they instead fail to assemble or link**, the flag is load-bearing in Debug and the answer is `-g1` or split DWARF rather than removal. That outcome is worth one cycle to learn, and this hunk gets rewritten.

The flag is present and correctly guarded otherwise; nothing was lost in the migration.

## The two changes stay separable in the results

- **MSVC and Clang-CL** never see `-Wa,-mbig-obj` (it's `GNU AND Windows`), so their Debug legs answer for the benchmark change alone.
- **MinGW**'s `benchmark.set.sieve` is removed by the benchmark change, but the four unit tests that also crash there — `test.bitset.o1`, `test.set.o0`, `test.set.o2`, `test.set.sieve` — are untouched by it and answer for the flag alone.

So a green MinGW Debug leg means both worked; a MinGW Debug leg still failing those four means only the first did.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ef1rfKHEMHutpEeV1R6ga)_