### PR TITLE
Apply -Wa,-mbig-obj to MinGW Debug again; the experiment answered

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -80,18 +80,24 @@ set(cxx_compile_options_optimization
 
 get_property(bit_set_is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 
-# Deliberately not applied to Debug, as an experiment - see the pull request.
-# Every MinGW Debug leg segfaults in the same five tests on all three rungs,
-# deterministically, while every MinGW Release leg passes; Debug is also the
-# first configuration this repository has ever built on MinGW, and the only
-# thing it adds to this translation unit is -g. Big COFF objects combined
-# with DWARF have a history of bad relocations in binutils, which surfaces as
-# a runtime crash rather than a link error. Dropping the flag in Debug tests
-# that: if those legs go green the interaction is the cause and this is the
-# fix; if they fail to assemble or link instead, the flag is load-bearing
-# there and the answer is -g1 or split DWARF rather than removal.
+# Required in every configuration, Debug included. #47 withheld it from Debug
+# to test whether -Wa,-mbig-obj combined with -g was what makes the MinGW
+# Debug legs segfault. Both halves of that experiment answered at once, and
+# the answer is no:
+#
+#   GCC 15 Debug    assembler: 'file too big' on test/src/set/o0.cpp.obj
+#   GCC 17-SVN Debug  same, on set/o0, set/o2 and bitset/o0
+#   GCC 16 Debug    assembles, then segfaults in exactly the four tests the
+#                   flag was suspected of breaking - test.bitset.o1,
+#                   test.set.o0, test.set.o2, test.set.sieve
+#
+# Two rungs out of three cannot even assemble these objects without the flag,
+# so it is load-bearing. The third assembles without it and crashes anyway,
+# so the flag is not what causes the crash. -g1 and split DWARF were the
+# remedies for the interaction hypothesis; there is no interaction to remedy.
+# The MinGW Debug segfaults remain open and are unrelated to this line.
 set(cxx_compile_options_mbig_obj
-    $<$<AND:$<CXX_COMPILER_ID:GNU>,$<PLATFORM_ID:Windows>,$<NOT:$<CONFIG:Debug>>>:
+    $<$<AND:$<CXX_COMPILER_ID:GNU>,$<PLATFORM_ID:Windows>>:
 	    -Wa,-mbig-obj
     >
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -84,18 +84,24 @@ set(cxx_compile_options_optimization
     >
 )
 
-# Deliberately not applied to Debug, as an experiment - see the pull request.
-# Every MinGW Debug leg segfaults in the same five tests on all three rungs,
-# deterministically, while every MinGW Release leg passes; Debug is also the
-# first configuration this repository has ever built on MinGW, and the only
-# thing it adds to this translation unit is -g. Big COFF objects combined
-# with DWARF have a history of bad relocations in binutils, which surfaces as
-# a runtime crash rather than a link error. Dropping the flag in Debug tests
-# that: if those legs go green the interaction is the cause and this is the
-# fix; if they fail to assemble or link instead, the flag is load-bearing
-# there and the answer is -g1 or split DWARF rather than removal.
+# Required in every configuration, Debug included. #47 withheld it from Debug
+# to test whether -Wa,-mbig-obj combined with -g was what makes the MinGW
+# Debug legs segfault. Both halves of that experiment answered at once, and
+# the answer is no:
+#
+#   GCC 15 Debug    assembler: 'file too big' on test/src/set/o0.cpp.obj
+#   GCC 17-SVN Debug  same, on set/o0, set/o2 and bitset/o0
+#   GCC 16 Debug    assembles, then segfaults in exactly the four tests the
+#                   flag was suspected of breaking - test.bitset.o1,
+#                   test.set.o0, test.set.o2, test.set.sieve
+#
+# Two rungs out of three cannot even assemble these objects without the flag,
+# so it is load-bearing. The third assembles without it and crashes anyway,
+# so the flag is not what causes the crash. -g1 and split DWARF were the
+# remedies for the interaction hypothesis; there is no interaction to remedy.
+# The MinGW Debug segfaults remain open and are unrelated to this line.
 set(cxx_compile_options_mbig_obj
-    $<$<AND:$<CXX_COMPILER_ID:GNU>,$<PLATFORM_ID:Windows>,$<NOT:$<CONFIG:Debug>>>:
+    $<$<AND:$<CXX_COMPILER_ID:GNU>,$<PLATFORM_ID:Windows>>:
 	    -Wa,-mbig-obj
     >
 )


### PR DESCRIPTION
#47 withheld `-Wa,-mbig-obj` from Debug to test whether the flag combined with `-g` was what makes every MinGW Debug leg segfault. That commit named both outcomes in advance: green legs would mean the interaction is the cause and the change is the fix; an assemble or link failure would mean the flag is load-bearing in Debug and the hunk gets rewritten.

Both outcomes fired at once, on different rungs of the same ladder.

## Result

Run [33161035335](https://github.com/rhalbersma/bit_set/actions/runs/33161035335) on `main` at `e39cdb1`:

| Leg | Outcome |
| --- | --- |
| `mingw / 15 Debug` | ❌ Build — assembler `Fatal error: ... 'file too big'` on `test/src/set/o0.cpp.obj` |
| `mingw / 16 Debug` | ❌ Test — assembles, then 4 SEGFAULTs |
| `mingw / 17-SVN Debug` | ❌ Build — same `'file too big'`, on `set/o0`, `set/o2` and `bitset/o0` |
| `mingw / 15 Release` | ✅ |
| `mingw / 17-SVN Release` | ✅ |

`'file too big'` is precisely the error `-Wa,-mbig-obj` exists to prevent: the COFF section count overflows without it. Two rungs out of three cannot assemble these translation units at all in Debug without the flag, so it is **load-bearing**, and this restores the condition the flag has carried since c91bdd5.

The third rung is the interesting one. GCC 16's Debug objects land just under the limit, so it assembles **without** the flag — and then segfaults in exactly the four tests #47 identified as answering for the flag alone:

```
The following tests FAILED:
	 12 - test.bitset.o1 (SEGFAULT)
	 21 - test.set.o0 (SEGFAULT)
	 23 - test.set.o2 (SEGFAULT)
	 26 - test.set.sieve (SEGFAULT)
```

A crash that reproduces with the flag absent is not caused by the flag. **The hypothesis is falsified.** `-g1` and split DWARF were the remedies proposed for the big-COFF-plus-DWARF interaction; there is no interaction left to remedy, so neither is applied here.

## What this does and does not fix

It fixes the two rungs that could not build. It does **not** turn MinGW Debug green — the segfaults are a separate, real bug, and after this change all three rungs should assemble and all three should fail the same four tests, instead of two failing to build and masking the third. That is a cleaner signal than the current state, not a green one.

Debug is the first configuration this repository has ever built on MinGW; every leg was Release-only until the cpp-ci migration. It has found something Release does not show, and that stays open.

## Verification

The generator expression was checked on a scratch project by reading the compile line CMake actually emits, in both configurations:

```
Debug    old genex: flag absent   new genex: flag present
Release  old genex: flag present  new genex: flag present
```

The change is the deletion of one `$<NOT:$<CONFIG:Debug>>` term from the `AND` in `test/CMakeLists.txt` and `benchmark/CMakeLists.txt`, plus the comment above each rewritten to record the result rather than the pending question.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ef1rfKHEMHutpEeV1R6ga)_