### PR TITLE
Point the Scorecard badge at the host that still rescans

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Clang-CL](https://github.com/rhalbersma/bit_set/actions/workflows/clang-cl.yml/badge.svg)](https://github.com/rhalbersma/bit_set/actions/workflows/clang-cl.yml)
 [![MSVC](https://github.com/rhalbersma/bit_set/actions/workflows/msvc.yml/badge.svg)](https://github.com/rhalbersma/bit_set/actions/workflows/msvc.yml)
 [![Coverage](https://codecov.io/gh/rhalbersma/bit_set/branch/main/graph/badge.svg)](https://codecov.io/gh/rhalbersma/bit_set)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/rhalbersma/bit_set/badge)](https://securityscorecards.dev/viewer/?uri=github.com/rhalbersma/bit_set)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/rhalbersma/bit_set/badge)](https://scorecard.dev/viewer/?uri=github.com/rhalbersma/bit_set)
 
 `xstd::bit_set<N>` is a modern and opinionated reimagining of `std::bitset<N>`, keeping what time has proven to be effective, and throwing out what is not. `xstd::bit_set` is a **fixed-size ordered set of integers** that is compact and fast. It does less work than `std::bitset` (e.g. no bounds-checking and no throwing of `out_of_range` exceptions) yet offers more (e.g. fulll `constexpr`-ness and bidirectional iterators over individual 1-bits). This enables **fixed-size bit-twiddling with set-like syntax** (identical to `std::set<int>`), typically leading to cleaner, more expressive code that seamlessly interacts with the rest of the Standard Library.
 


### PR DESCRIPTION
The README's OpenSSF badge and its link both named `api.securityscorecards.dev` / `securityscorecards.dev`, the legacy host. That host has stopped rescanning this repository:

| Host | Commit | Scanned | Score |
| --- | --- | --- | --- |
| `api.securityscorecards.dev` (badge was here) | `8a4f99d1` | 2026-08-17 05:06 | 6.7 |
| `api.scorecard.dev` (badge now here) | `e39cdb14` | 2026-08-28 09:54 | 6.6 |

**Eleven days stale**, and it would have stayed that way — it reports a tree from before the cpp-ci migration, so none of the pinning that migration did is visible in it. On the current host this repository already scores **10/10 on Pinned-Dependencies**; the badge was showing a snapshot from before that was true.

cpp-ci made this same change to its own badge when it was set up, and its commit message noted at the time that xstd and this repository were due it. xstd and tabula have since been moved; this was the last one left on the old host, and `securityscorecards` now appears nowhere in the tree.

The score itself is unaffected. Analysis runs from this repository's `scorecard.yml` either way and publishing already targets the current dataset — this changes only which host the README reads back from.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ef1rfKHEMHutpEeV1R6ga)_