### PR TITLE
Repin to cpp-ci v0.5.1

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -26,4 +26,4 @@ jobs:
   # is now most of what a stub can contain. No inputs: the defaults lint
   # .github/workflows with shellcheck on.
   actionlint:
-    uses: rhalbersma/cpp-ci/.github/workflows/actionlint.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0
+    uses: rhalbersma/cpp-ci/.github/workflows/actionlint.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -26,4 +26,4 @@ jobs:
   # is now most of what a stub can contain. No inputs: the defaults lint
   # .github/workflows with shellcheck on.
   actionlint:
-    uses: rhalbersma/cpp-ci/.github/workflows/actionlint.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1
+    uses: rhalbersma/cpp-ci/.github/workflows/actionlint.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -26,4 +26,4 @@ jobs:
   # is now most of what a stub can contain. No inputs: the defaults lint
   # .github/workflows with shellcheck on.
   actionlint:
-    uses: rhalbersma/cpp-ci/.github/workflows/actionlint.yml@d42a31ce27a752910b7b76cc6e3368735c8a1115 # v0.4.1
+    uses: rhalbersma/cpp-ci/.github/workflows/actionlint.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0

--- a/.github/workflows/appleclang.yml
+++ b/.github/workflows/appleclang.yml
@@ -32,4 +32,4 @@ jobs:
   # the badge URL in the README is the workflow's path, so renaming it would
   # break the badge and every link to a past run.
   apple_clang:
-    uses: rhalbersma/cpp-ci/.github/workflows/apple-clang.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0
+    uses: rhalbersma/cpp-ci/.github/workflows/apple-clang.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1

--- a/.github/workflows/appleclang.yml
+++ b/.github/workflows/appleclang.yml
@@ -32,4 +32,4 @@ jobs:
   # the badge URL in the README is the workflow's path, so renaming it would
   # break the badge and every link to a past run.
   apple_clang:
-    uses: rhalbersma/cpp-ci/.github/workflows/apple-clang.yml@d42a31ce27a752910b7b76cc6e3368735c8a1115 # v0.4.1
+    uses: rhalbersma/cpp-ci/.github/workflows/apple-clang.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0

--- a/.github/workflows/appleclang.yml
+++ b/.github/workflows/appleclang.yml
@@ -32,4 +32,4 @@ jobs:
   # the badge URL in the README is the workflow's path, so renaming it would
   # break the badge and every link to a past run.
   apple_clang:
-    uses: rhalbersma/cpp-ci/.github/workflows/apple-clang.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1
+    uses: rhalbersma/cpp-ci/.github/workflows/apple-clang.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1

--- a/.github/workflows/clang-cl.yml
+++ b/.github/workflows/clang-cl.yml
@@ -31,7 +31,7 @@ jobs:
   # leg for that gap is enough; a second adds a runner and no information.
   # 2026-Preview is a gain: the local workflow tested VS 2026 alone.
   clang_cl:
-    uses: rhalbersma/cpp-ci/.github/workflows/visual-studio.yml@d42a31ce27a752910b7b76cc6e3368735c8a1115 # v0.4.1
+    uses: rhalbersma/cpp-ci/.github/workflows/visual-studio.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0
     with:
       tiers: qualification,development
       toolset: ClangCL,host=x64

--- a/.github/workflows/clang-cl.yml
+++ b/.github/workflows/clang-cl.yml
@@ -31,7 +31,7 @@ jobs:
   # leg for that gap is enough; a second adds a runner and no information.
   # 2026-Preview is a gain: the local workflow tested VS 2026 alone.
   clang_cl:
-    uses: rhalbersma/cpp-ci/.github/workflows/visual-studio.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0
+    uses: rhalbersma/cpp-ci/.github/workflows/visual-studio.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1
     with:
       tiers: qualification,development
       toolset: ClangCL,host=x64

--- a/.github/workflows/clang-cl.yml
+++ b/.github/workflows/clang-cl.yml
@@ -31,7 +31,7 @@ jobs:
   # leg for that gap is enough; a second adds a runner and no information.
   # 2026-Preview is a gain: the local workflow tested VS 2026 alone.
   clang_cl:
-    uses: rhalbersma/cpp-ci/.github/workflows/visual-studio.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1
+    uses: rhalbersma/cpp-ci/.github/workflows/visual-studio.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1
     with:
       tiers: qualification,development
       toolset: ClangCL,host=x64

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -28,7 +28,7 @@ jobs:
   # Its own tier, deliberately left at stable: a formatter release reformats
   # the code base, which is not something a compiler bump should decide.
   clang_format:
-    uses: rhalbersma/cpp-ci/.github/workflows/clang-format.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1
+    uses: rhalbersma/cpp-ci/.github/workflows/clang-format.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1
     with:
       # benchmark/ too: the shared default is "include test", but this
       # repository also carries a benchmark tree of hand-written sources.

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -28,7 +28,7 @@ jobs:
   # Its own tier, deliberately left at stable: a formatter release reformats
   # the code base, which is not something a compiler bump should decide.
   clang_format:
-    uses: rhalbersma/cpp-ci/.github/workflows/clang-format.yml@d42a31ce27a752910b7b76cc6e3368735c8a1115 # v0.4.1
+    uses: rhalbersma/cpp-ci/.github/workflows/clang-format.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0
     with:
       # benchmark/ too: the shared default is "include test", but this
       # repository also carries a benchmark tree of hand-written sources.

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -28,7 +28,7 @@ jobs:
   # Its own tier, deliberately left at stable: a formatter release reformats
   # the code base, which is not something a compiler bump should decide.
   clang_format:
-    uses: rhalbersma/cpp-ci/.github/workflows/clang-format.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0
+    uses: rhalbersma/cpp-ci/.github/workflows/clang-format.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1
     with:
       # benchmark/ too: the shared default is "include test", but this
       # repository also carries a benchmark tree of hand-written sources.

--- a/.github/workflows/clang-libc++.yml
+++ b/.github/workflows/clang-libc++.yml
@@ -30,4 +30,4 @@ jobs:
   # missed. The old single "23-SVN libc++" leg is what this replaces; running
   # the whole ladder is what makes "which rung fixed it" answerable.
   clang_libcxx:
-    uses: rhalbersma/cpp-ci/.github/workflows/clang-libc++.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0
+    uses: rhalbersma/cpp-ci/.github/workflows/clang-libc++.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1

--- a/.github/workflows/clang-libc++.yml
+++ b/.github/workflows/clang-libc++.yml
@@ -30,4 +30,4 @@ jobs:
   # missed. The old single "23-SVN libc++" leg is what this replaces; running
   # the whole ladder is what makes "which rung fixed it" answerable.
   clang_libcxx:
-    uses: rhalbersma/cpp-ci/.github/workflows/clang-libc++.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1
+    uses: rhalbersma/cpp-ci/.github/workflows/clang-libc++.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1

--- a/.github/workflows/clang-libc++.yml
+++ b/.github/workflows/clang-libc++.yml
@@ -30,4 +30,4 @@ jobs:
   # missed. The old single "23-SVN libc++" leg is what this replaces; running
   # the whole ladder is what makes "which rung fixed it" answerable.
   clang_libcxx:
-    uses: rhalbersma/cpp-ci/.github/workflows/clang-libc++.yml@d42a31ce27a752910b7b76cc6e3368735c8a1115 # v0.4.1
+    uses: rhalbersma/cpp-ci/.github/workflows/clang-libc++.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   clang_tidy:
-    uses: rhalbersma/cpp-ci/.github/workflows/clang-tidy.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0
+    uses: rhalbersma/cpp-ci/.github/workflows/clang-tidy.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1
     with:
       # The generated per-header units alone, as run-clang-tidy matches them
       # against the compile database's absolute paths. No sources_regex: the

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   clang_tidy:
-    uses: rhalbersma/cpp-ci/.github/workflows/clang-tidy.yml@d42a31ce27a752910b7b76cc6e3368735c8a1115 # v0.4.1
+    uses: rhalbersma/cpp-ci/.github/workflows/clang-tidy.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0
     with:
       # The generated per-header units alone, as run-clang-tidy matches them
       # against the compile database's absolute paths. No sources_regex: the

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   clang_tidy:
-    uses: rhalbersma/cpp-ci/.github/workflows/clang-tidy.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1
+    uses: rhalbersma/cpp-ci/.github/workflows/clang-tidy.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1
     with:
       # The generated per-header units alone, as run-clang-tidy matches them
       # against the compile database's absolute paths. No sources_regex: the

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -30,4 +30,4 @@ jobs:
   # Clang rung with a matching GCC rung for that libstdc++ rather than
   # pointing every rung at one version of it.
   clang:
-    uses: rhalbersma/cpp-ci/.github/workflows/clang.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1
+    uses: rhalbersma/cpp-ci/.github/workflows/clang.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -30,4 +30,4 @@ jobs:
   # Clang rung with a matching GCC rung for that libstdc++ rather than
   # pointing every rung at one version of it.
   clang:
-    uses: rhalbersma/cpp-ci/.github/workflows/clang.yml@d42a31ce27a752910b7b76cc6e3368735c8a1115 # v0.4.1
+    uses: rhalbersma/cpp-ci/.github/workflows/clang.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -30,4 +30,4 @@ jobs:
   # Clang rung with a matching GCC rung for that libstdc++ rather than
   # pointing every rung at one version of it.
   clang:
-    uses: rhalbersma/cpp-ci/.github/workflows/clang.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0
+    uses: rhalbersma/cpp-ci/.github/workflows/clang.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,4 +26,4 @@ jobs:
   # No inputs: c-cpp with security-extended is what the local job ran and
   # what the shared workflow defaults to.
   codeql:
-    uses: rhalbersma/cpp-ci/.github/workflows/codeql.yml@d42a31ce27a752910b7b76cc6e3368735c8a1115 # v0.4.1
+    uses: rhalbersma/cpp-ci/.github/workflows/codeql.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,4 +26,4 @@ jobs:
   # No inputs: c-cpp with security-extended is what the local job ran and
   # what the shared workflow defaults to.
   codeql:
-    uses: rhalbersma/cpp-ci/.github/workflows/codeql.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1
+    uses: rhalbersma/cpp-ci/.github/workflows/codeql.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,4 +26,4 @@ jobs:
   # No inputs: c-cpp with security-extended is what the local job ran and
   # what the shared workflow defaults to.
   codeql:
-    uses: rhalbersma/cpp-ci/.github/workflows/codeql.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0
+    uses: rhalbersma/cpp-ci/.github/workflows/codeql.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1

--- a/.github/workflows/consumption.yml
+++ b/.github/workflows/consumption.yml
@@ -29,7 +29,7 @@ jobs:
   # run of the stub. Both inputs default to off for the callers that need
   # neither.
   consumption:
-    uses: rhalbersma/cpp-ci/.github/workflows/consumption.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0
+    uses: rhalbersma/cpp-ci/.github/workflows/consumption.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1
     with:
       # CMakeLists.txt does an unconditional
       # find_package(boost_hash2 CONFIG REQUIRED), so even the

--- a/.github/workflows/consumption.yml
+++ b/.github/workflows/consumption.yml
@@ -29,7 +29,7 @@ jobs:
   # run of the stub. Both inputs default to off for the callers that need
   # neither.
   consumption:
-    uses: rhalbersma/cpp-ci/.github/workflows/consumption.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1
+    uses: rhalbersma/cpp-ci/.github/workflows/consumption.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1
     with:
       # CMakeLists.txt does an unconditional
       # find_package(boost_hash2 CONFIG REQUIRED), so even the

--- a/.github/workflows/consumption.yml
+++ b/.github/workflows/consumption.yml
@@ -29,7 +29,7 @@ jobs:
   # run of the stub. Both inputs default to off for the callers that need
   # neither.
   consumption:
-    uses: rhalbersma/cpp-ci/.github/workflows/consumption.yml@d42a31ce27a752910b7b76cc6e3368735c8a1115 # v0.4.1
+    uses: rhalbersma/cpp-ci/.github/workflows/consumption.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0
     with:
       # CMakeLists.txt does an unconditional
       # find_package(boost_hash2 CONFIG REQUIRED), so even the

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   coverage:
-    uses: rhalbersma/cpp-ci/.github/workflows/coverage.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0
+    uses: rhalbersma/cpp-ci/.github/workflows/coverage.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1
     with:
       # benchmark/ as well as the shared default: unlike xstd, this
       # repository ships a benchmark tree, which measures the library rather

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   coverage:
-    uses: rhalbersma/cpp-ci/.github/workflows/coverage.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1
+    uses: rhalbersma/cpp-ci/.github/workflows/coverage.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1
     with:
       # benchmark/ as well as the shared default: unlike xstd, this
       # repository ships a benchmark tree, which measures the library rather

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   coverage:
-    uses: rhalbersma/cpp-ci/.github/workflows/coverage.yml@d42a31ce27a752910b7b76cc6e3368735c8a1115 # v0.4.1
+    uses: rhalbersma/cpp-ci/.github/workflows/coverage.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0
     with:
       # benchmark/ as well as the shared default: unlike xstd, this
       # repository ships a benchmark tree, which measures the library rather

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -27,4 +27,4 @@ jobs:
   # x64-linux-gcc-trunk overlay triplet that rebuilt the dependencies with
   # the trunk snapshot's own libstdc++.
   gcc:
-    uses: rhalbersma/cpp-ci/.github/workflows/gcc.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1
+    uses: rhalbersma/cpp-ci/.github/workflows/gcc.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -27,4 +27,4 @@ jobs:
   # x64-linux-gcc-trunk overlay triplet that rebuilt the dependencies with
   # the trunk snapshot's own libstdc++.
   gcc:
-    uses: rhalbersma/cpp-ci/.github/workflows/gcc.yml@d42a31ce27a752910b7b76cc6e3368735c8a1115 # v0.4.1
+    uses: rhalbersma/cpp-ci/.github/workflows/gcc.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -27,4 +27,4 @@ jobs:
   # x64-linux-gcc-trunk overlay triplet that rebuilt the dependencies with
   # the trunk snapshot's own libstdc++.
   gcc:
-    uses: rhalbersma/cpp-ci/.github/workflows/gcc.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0
+    uses: rhalbersma/cpp-ci/.github/workflows/gcc.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -26,4 +26,4 @@ jobs:
   # been published between stable branches - now lives in cpp-ci's
   # install-winlibs action.
   mingw:
-    uses: rhalbersma/cpp-ci/.github/workflows/mingw.yml@d42a31ce27a752910b7b76cc6e3368735c8a1115 # v0.4.1
+    uses: rhalbersma/cpp-ci/.github/workflows/mingw.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -26,4 +26,4 @@ jobs:
   # been published between stable branches - now lives in cpp-ci's
   # install-winlibs action.
   mingw:
-    uses: rhalbersma/cpp-ci/.github/workflows/mingw.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1
+    uses: rhalbersma/cpp-ci/.github/workflows/mingw.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -26,4 +26,4 @@ jobs:
   # been published between stable branches - now lives in cpp-ci's
   # install-winlibs action.
   mingw:
-    uses: rhalbersma/cpp-ci/.github/workflows/mingw.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0
+    uses: rhalbersma/cpp-ci/.github/workflows/mingw.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -32,4 +32,4 @@ jobs:
   #
   # The toolset input is left at its default, which is the MSVC one.
   msvc:
-    uses: rhalbersma/cpp-ci/.github/workflows/visual-studio.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1
+    uses: rhalbersma/cpp-ci/.github/workflows/visual-studio.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -32,4 +32,4 @@ jobs:
   #
   # The toolset input is left at its default, which is the MSVC one.
   msvc:
-    uses: rhalbersma/cpp-ci/.github/workflows/visual-studio.yml@d42a31ce27a752910b7b76cc6e3368735c8a1115 # v0.4.1
+    uses: rhalbersma/cpp-ci/.github/workflows/visual-studio.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -32,4 +32,4 @@ jobs:
   #
   # The toolset input is left at its default, which is the MSVC one.
   msvc:
-    uses: rhalbersma/cpp-ci/.github/workflows/visual-studio.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0
+    uses: rhalbersma/cpp-ci/.github/workflows/visual-studio.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -25,7 +25,7 @@ jobs:
   # libraries, and turns leak detection on - the local ASan leg ran with
   # detect_leaks=0.
   sanitizers:
-    uses: rhalbersma/cpp-ci/.github/workflows/sanitizers.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1
+    uses: rhalbersma/cpp-ci/.github/workflows/sanitizers.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1
     with:
       # No ASan libc++ leg. Not because the sanitizer says anything different
       # there, but because this library does not compile against libc++ at all

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -25,7 +25,7 @@ jobs:
   # libraries, and turns leak detection on - the local ASan leg ran with
   # detect_leaks=0.
   sanitizers:
-    uses: rhalbersma/cpp-ci/.github/workflows/sanitizers.yml@d42a31ce27a752910b7b76cc6e3368735c8a1115 # v0.4.1
+    uses: rhalbersma/cpp-ci/.github/workflows/sanitizers.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0
     with:
       # No ASan libc++ leg. Not because the sanitizer says anything different
       # there, but because this library does not compile against libc++ at all

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -25,7 +25,7 @@ jobs:
   # libraries, and turns leak detection on - the local ASan leg ran with
   # detect_leaks=0.
   sanitizers:
-    uses: rhalbersma/cpp-ci/.github/workflows/sanitizers.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0
+    uses: rhalbersma/cpp-ci/.github/workflows/sanitizers.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1
     with:
       # No ASan libc++ leg. Not because the sanitizer says anything different
       # there, but because this library does not compile against libc++ at all

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,4 +32,4 @@ jobs:
       security-events: write
       id-token: write
       actions: read
-    uses: rhalbersma/cpp-ci/.github/workflows/scorecard.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1
+    uses: rhalbersma/cpp-ci/.github/workflows/scorecard.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,4 +32,4 @@ jobs:
       security-events: write
       id-token: write
       actions: read
-    uses: rhalbersma/cpp-ci/.github/workflows/scorecard.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0
+    uses: rhalbersma/cpp-ci/.github/workflows/scorecard.yml@0033891bc09c0ba200d597a3e5a619796c93e578 # v0.5.1

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,4 +32,4 @@ jobs:
       security-events: write
       id-token: write
       actions: read
-    uses: rhalbersma/cpp-ci/.github/workflows/scorecard.yml@d42a31ce27a752910b7b76cc6e3368735c8a1115 # v0.4.1
+    uses: rhalbersma/cpp-ci/.github/workflows/scorecard.yml@76c73148793d7700b98b703f437e80d1eb0b1295 # v0.5.0


### PR DESCRIPTION
`d42a31c # v0.4.1` → `0033891 # v0.5.1`, in all fifteen stubs. No stub edits were needed; only the pin moves.

This landed on v0.5.0 first, hit a bug in it, and now points at the patch release. The branch name still says v0.5.0 — renaming it would mean a new PR, which is not worth it.

## What reaches here

**`codeql.yml` stops reporting on code this repository does not own.** vcpkg manifest mode had been installing into `build/vcpkg_installed/`, inside the checkout, which is CodeQL's source root and therefore the rule for what gets reported. Dependencies now install to `RUNNER_TEMP`, outside it, so their findings are filtered out the same way libstdc++'s always were. Any open alert against a header under `build/vcpkg_installed/` should close on the next CodeQL run after this merges.

**`msvc-analyze.yml` now exists** in cpp-ci — MSVC's `/analyze` as its own workflow. Nothing calls it; adding a stub is a separate decision, and worth weighing carefully here given this repository's MSVC legs have their own open failures.

**v0.5.1 fixes a bug v0.5.0 introduced here.** Every `apple_clang` leg failed on the first run of this branch:

```
/Users/runner/work/_temp/....sh: line 3: extra[@]: unbound variable
```

macOS ships bash 3.2, which treats `"${arr[@]}"` on an empty array under `set -u` as an unbound variable rather than as zero words — relaxed in bash 4.4, which is why every Linux and Windows leg ran the identical line without complaint. Fixed in [cpp-ci#20](https://github.com/rhalbersma/cpp-ci/pull/20), released as v0.5.1.

## The other red legs are this repository's own

None of these is affected by the repin, and all are red on `main` under v0.4.1 too:

| leg | cause |
| :-- | :---- |
| `msvc / 2022` (both configs) | MSVC 2022 has no `<flat_set>` — `C1083` at compile time, not a test failure |
| `msvc` / `clang_cl` Debug | MSVC STL `_ITERATOR_DEBUG_LEVEL=2`, "vector iterators incompatible" |
| `mingw` Debug | segfault in `test.bitset.o1`, `test.set.o0`, `test.set.o2`, `test.set.sieve` |
| `clang_libcxx` (all six) | libc++ lacks `views::cartesian_product` (P2374R4, unimplemented on trunk) in `test/include/bitset/exhaustive.hpp`; the 22 rung additionally lacks `views::stride` (P1899R3, shipped in libc++ 23) in `benchmark/src/bitset/sieve.cpp` |
| `clang_tidy` | the parked findings |