### PR TITLE
Answer clang-tidy on the public headers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,15 @@
 # Static analysis for the public headers, run by the Clang-Tidy workflow
 # over the generated header self-sufficiency translation units (the
 # Boost.Test sources are excluded: test macros drown the signal in noise).
+# bugprone-easily-swappable-parameters is off because both sites it reports
+# are fixed by the interface rather than chosen: to_string(charT zero, charT
+# one) is the signature std::bitset::to_string carries, and
+# lexicographical_three_way compares two bitsets because that is what
+# comparing two bitsets means. Neither pair can be reordered or retyped.
+#
+# Note for anyone adding to the list below: Checks is a folded scalar, so a
+# '#' inside it is literal text and not a comment. Explanations belong here,
+# above the key.
 Checks: >
   bugprone-*,
   clang-analyzer-*,
@@ -15,7 +24,8 @@ Checks: >
   -readability-avoid-nested-conditional-operator,
   -readability-identifier-length,
   -readability-named-parameter,
-  -readability-simplify-boolean-expr
+  -readability-simplify-boolean-expr,
+  -bugprone-easily-swappable-parameters
 WarningsAsErrors: '*'
 HeaderFilterRegex: 'include/xstd/.*'
 FormatStyle: none

--- a/include/ext/boost/dynamic_bitset.hpp
+++ b/include/ext/boost/dynamic_bitset.hpp
@@ -50,7 +50,7 @@ struct find<boost::dynamic_bitset<Block, Allocator>>
         [[nodiscard]] static constexpr std::size_t prev(boost::dynamic_bitset<Block, Allocator> const& c, std::size_t n) noexcept
         {
                 assert(c.any());
-                return *std::ranges::find_if(std::views::iota(0uz, std::ranges::min(n, c.size())) | std::views::reverse, [&](auto i) {
+                return *std::ranges::find_if(std::views::iota(0UZ, std::ranges::min(n, c.size())) | std::views::reverse, [&](auto i) {
                         return c[i];
                 });
         }
@@ -93,7 +93,7 @@ namespace xstd::proxy::random_access {
 template<std::unsigned_integral Block, class Allocator>
 struct find<boost::dynamic_bitset<Block, Allocator>>
 {
-        [[nodiscard]] static constexpr std::size_t first(boost::dynamic_bitset<Block, Allocator> const&) noexcept { return 0uz; }
+        [[nodiscard]] static constexpr std::size_t first(boost::dynamic_bitset<Block, Allocator> const&) noexcept { return 0UZ; }
         [[nodiscard]] static constexpr std::size_t last (boost::dynamic_bitset<Block, Allocator> const& c) noexcept { return c.size(); }
         [[nodiscard]] static constexpr bool         at  (boost::dynamic_bitset<Block, Allocator> const& c, std::size_t n) noexcept { return c[n]; }
 };

--- a/include/ext/std/bitset.hpp
+++ b/include/ext/std/bitset.hpp
@@ -141,6 +141,8 @@ struct compare<std::bitset<N>>
 // std.
 namespace std {
 
+// NOLINTBEGIN(bugprone-std-namespace-modification)
+
 template<std::size_t N>
 bitset<N>& operator-=(bitset<N>& lhs, const bitset<N>& rhs) noexcept
 {
@@ -152,6 +154,8 @@ bitset<N> operator-(const bitset<N>& lhs, const bitset<N>& rhs) noexcept
 {
         auto nrv = lhs; nrv -= rhs; return nrv;
 }
+
+// NOLINTEND(bugprone-std-namespace-modification)
 
 }       // namespace std
 

--- a/include/ext/std/bitset.hpp
+++ b/include/ext/std/bitset.hpp
@@ -34,7 +34,7 @@ struct find<std::bitset<N>>
                 } else if constexpr (requires { c._Find_first(); }) {
                         return c._Find_first();
                 } else {
-                        return *std::ranges::find_if(std::views::iota(0uz, N), [&](auto i) {
+                        return *std::ranges::find_if(std::views::iota(0UZ, N), [&](auto i) {
                                 return c[i];
                         });
                 }
@@ -59,7 +59,7 @@ struct find<std::bitset<N>>
         [[nodiscard]] static std::size_t prev(const std::bitset<N>& c, std::size_t n) noexcept
         {
                 assert(c.any());
-                return *std::ranges::find_if(std::views::iota(0uz, n) | std::views::reverse, [&](auto i) {
+                return *std::ranges::find_if(std::views::iota(0UZ, n) | std::views::reverse, [&](auto i) {
                         return c[i];
                 });
         }
@@ -97,7 +97,7 @@ namespace xstd::proxy::random_access {
 template<std::size_t N>
 struct find<std::bitset<N>>
 {
-        [[nodiscard]] static constexpr std::size_t first(const std::bitset<N>&) noexcept { return 0uz; }
+        [[nodiscard]] static constexpr std::size_t first(const std::bitset<N>&) noexcept { return 0UZ; }
         [[nodiscard]] static constexpr std::size_t last (const std::bitset<N>&) noexcept { return N;   }
         [[nodiscard]] static constexpr bool         at  (const std::bitset<N>& c, std::size_t n) noexcept { return c[n]; }
 };

--- a/include/opt/set/sieve.hpp
+++ b/include/opt/set/sieve.hpp
@@ -23,7 +23,7 @@ struct generate_candidates
 {
         auto operator()(std::size_t n) const
         {
-                return std::views::iota(2uz, n) | std::ranges::to<X>();
+                return std::views::iota(2UZ, n) | std::ranges::to<X>();
         }
 };
 

--- a/include/xstd/bit/array.hpp
+++ b/include/xstd/bit/array.hpp
@@ -29,7 +29,7 @@ struct array
 {
         static constexpr auto bits_per_block = static_cast<std::size_t>(std::numeric_limits<Block>::digits);
         static constexpr auto num_bits       = aligned_size(bits_per_block, N);
-        static constexpr auto num_blocks     = std::ranges::max(num_bits / bits_per_block, 1uz);
+        static constexpr auto num_blocks     = std::ranges::max(num_bits / bits_per_block, 1UZ);
 
         std::array<Block, num_blocks> m_bits;
 
@@ -172,7 +172,7 @@ struct array
                         this->m_bits[0] &= other.m_bits[0];
                         this->m_bits[1] &= other.m_bits[1];
                 } else if constexpr (num_blocks >= 3) {
-                        for (auto i : std::views::iota(0uz, num_blocks)) {
+                        for (auto i : std::views::iota(0UZ, num_blocks)) {
                                 this->m_bits[i] &= other.m_bits[i];
                         }
                 }
@@ -186,7 +186,7 @@ struct array
                         this->m_bits[0] |= other.m_bits[0];
                         this->m_bits[1] |= other.m_bits[1];
                 } else if constexpr (num_blocks >= 3) {
-                        for (auto i : std::views::iota(0uz, num_blocks)) {
+                        for (auto i : std::views::iota(0UZ, num_blocks)) {
                                 this->m_bits[i] |= other.m_bits[i];
                         }
                 }
@@ -200,7 +200,7 @@ struct array
                         this->m_bits[0] ^= other.m_bits[0];
                         this->m_bits[1] ^= other.m_bits[1];
                 } else if constexpr (num_blocks >= 3) {
-                        for (auto i : std::views::iota(0uz, num_blocks)) {
+                        for (auto i : std::views::iota(0UZ, num_blocks)) {
                                 this->m_bits[i] ^= other.m_bits[i];
                         }
                 }
@@ -214,7 +214,7 @@ struct array
                         this->m_bits[0] &= static_cast<Block>(~other.m_bits[0]);
                         this->m_bits[1] &= static_cast<Block>(~other.m_bits[1]);
                 } else if constexpr (num_blocks >= 3) {
-                        for (auto i : std::views::iota(0uz, num_blocks)) {
+                        for (auto i : std::views::iota(0UZ, num_blocks)) {
                                 this->m_bits[i] &= static_cast<Block>(~other.m_bits[i]);
                         }
                 }
@@ -305,7 +305,7 @@ struct array
                         m_bits[0] = static_cast<Block>(~m_bits[0]);
                         m_bits[1] = static_cast<Block>(~m_bits[1]);
                 } else if constexpr (num_blocks >= 3) {
-                        for (auto i : std::views::iota(0uz, num_blocks)) {
+                        for (auto i : std::views::iota(0UZ, num_blocks)) {
                                 m_bits[i] = static_cast<Block>(~m_bits[i]);
                         }
                 }
@@ -372,7 +372,7 @@ struct array
         [[nodiscard]] constexpr std::size_t count() const noexcept
         {
                 if constexpr (N == 0) {
-                        return 0uz;
+                        return 0UZ;
                 } else if constexpr (num_blocks == 1) {
                         return bit::popcount(m_bits[0]);
                 } else if constexpr (num_blocks == 2) {
@@ -380,7 +380,7 @@ struct array
                 } else if constexpr (num_blocks >= 3) {
                         return std::ranges::fold_left(
                                 m_bits | std::views::transform([](auto block) { return bit::popcount(block); }), 
-                                0uz, std::plus<>()
+                                0UZ, std::plus<>()
                         );
                 }
         }
@@ -473,7 +473,7 @@ struct array
                                 ;
                         }                        
                 } else if constexpr (num_blocks >= 3) {
-                        auto i = 0uz;
+                        auto i = 0UZ;
                         while(i < num_blocks) {
                                 if (not bit::is_subset_of(this->m_bits[i], other.m_bits[i])) {
                                         return false;
@@ -546,7 +546,7 @@ private:
                 -> std::pair<std::size_t, std::size_t>
         {
                 if constexpr (num_blocks == 1) {
-                        return { 0uz, n };
+                        return { 0UZ, n };
                 } else {
                         return div_mod(n, bits_per_block);
                 }

--- a/include/xstd/bit/array.hpp
+++ b/include/xstd/bit/array.hpp
@@ -99,7 +99,8 @@ struct array
                 } else if constexpr (num_blocks == 2) {
                         if (m_bits[0] != zero) {
                                 return bit::countr_zero(m_bits[0]);
-                        } else if (m_bits[1] != zero) {
+                        }
+                        if (m_bits[1] != zero) {
                                 return bit::countr_zero(m_bits[1]) + bits_per_block;
                         }
                 } else if constexpr (num_blocks >= 3) {
@@ -464,14 +465,14 @@ struct array
                 } else if constexpr (num_blocks == 2) {                         
                         if (not bit::is_subset_of(this->m_bits[0], other.m_bits[0])) {
                                 return false;
-                        } else if (bit::not_equal_to(this->m_bits[0], other.m_bits[0])) {
+                        }
+                        if (bit::not_equal_to(this->m_bits[0], other.m_bits[0])) {
                                 return bit::is_subset_of(this->m_bits[1], other.m_bits[1]);
-                        } else { 
-                                return
-                                        bit::is_subset_of(this->m_bits[1], other.m_bits[1]) and
-                                        bit::not_equal_to(this->m_bits[1], other.m_bits[1])
-                                ;
-                        }                        
+                        }
+                        return
+                                bit::is_subset_of(this->m_bits[1], other.m_bits[1]) and
+                                bit::not_equal_to(this->m_bits[1], other.m_bits[1])
+                        ;
                 } else if constexpr (num_blocks >= 3) {
                         auto i = 0UZ;
                         while(i < num_blocks) {

--- a/include/xstd/bit/array.hpp
+++ b/include/xstd/bit/array.hpp
@@ -72,7 +72,7 @@ struct array
                 } else if constexpr (num_blocks >= 3) {
                         auto const front = std::ranges::find_if(m_bits, [](auto block) { return block != zero; });
                         assert(front != m_bits.end());
-                        return bit::countr_zero(*front) + bits_per_block * distance(m_bits.begin(), front);
+                        return bit::countr_zero(*front) + (bits_per_block * distance(m_bits.begin(), front));
                 }
         }
 
@@ -86,7 +86,7 @@ struct array
                 } else if constexpr (num_blocks >= 3) {
                         auto const back = std::ranges::find_if(m_bits | std::views::reverse, [](auto block) { return block != zero; });
                         assert(back != m_bits.rend());
-                        return last_bit - bit::countl_zero(*back) - bits_per_block * distance(m_bits.rbegin(), back);
+                        return last_bit - bit::countl_zero(*back) - (bits_per_block * distance(m_bits.rbegin(), back));
                 }
         }
 
@@ -104,7 +104,7 @@ struct array
                         }
                 } else if constexpr (num_blocks >= 3) {
                         if (auto const first = std::ranges::find_if(m_bits, [](auto block) { return block != zero; }); first != m_bits.end()) {
-                                return bit::countr_zero(*first) + bits_per_block * distance(m_bits.begin(), first);
+                                return bit::countr_zero(*first) + (bits_per_block * distance(m_bits.begin(), first));
                         }
                 }
                 return N;
@@ -136,7 +136,7 @@ struct array
                         }
                         auto const rg = m_bits | std::views::drop(index);
                         if (auto const next = std::ranges::find_if(rg, [](auto block) { return block != zero; }); next != rg.end()) {
-                                return n + bit::countr_zero(*next) + bits_per_block * distance(rg.begin(), next);
+                                return n + bit::countr_zero(*next) + (bits_per_block * distance(rg.begin(), next));
                         }
                 }
                 return N;
@@ -160,7 +160,7 @@ struct array
                         auto const rg = m_bits | std::views::reverse | std::views::drop(last_block - index);
                         auto const prev = std::ranges::find_if(rg, [](auto block) { return block != zero; });
                         assert(prev != rg.end());
-                        return n - bit::countl_zero(*prev) - bits_per_block * distance(rg.begin(), prev);
+                        return n - bit::countl_zero(*prev) - (bits_per_block * distance(rg.begin(), prev));
                 }
         }
 

--- a/include/xstd/bit_array.hpp
+++ b/include/xstd/bit_array.hpp
@@ -130,7 +130,7 @@ struct bit_array
         using result_t = std::conditional_t<std::is_const_v<std::remove_reference_t<Self>>, const_reference, reference>;
 
         [[nodiscard]] constexpr auto operator[](this auto&& self, size_type n) noexcept -> result_t<decltype(self)> { assert(n < N); return { self, n };                             }
-        [[nodiscard]] constexpr auto at        (this auto&& self, size_type n)          -> result_t<decltype(self)> {    if (n < N)  return { self, n }; else throw out_of_range(n); }
+        [[nodiscard]] constexpr auto at        (this auto&& self, size_type n)          -> result_t<decltype(self)> {    if (n < N) { return { self, n }; } else { throw out_of_range(n); } }
 
         [[nodiscard]] constexpr auto front(this auto&& self) noexcept -> result_t<decltype(self)> { return { self, 0UZ   }; }
         [[nodiscard]] constexpr auto back (this auto&& self) noexcept -> result_t<decltype(self)> { return { self, N - 1 }; }

--- a/include/xstd/bit_array.hpp
+++ b/include/xstd/bit_array.hpp
@@ -130,7 +130,7 @@ struct bit_array
         using result_t = std::conditional_t<std::is_const_v<std::remove_reference_t<Self>>, const_reference, reference>;
 
         [[nodiscard]] constexpr auto operator[](this auto&& self, size_type n) noexcept -> result_t<decltype(self)> { assert(n < N); return { self, n };                             }
-        [[nodiscard]] constexpr auto at        (this auto&& self, size_type n)          -> result_t<decltype(self)> {    if (n < N) { return { self, n }; } else { throw out_of_range(n); } }
+        [[nodiscard]] constexpr auto at        (this auto&& self, size_type n)          -> result_t<decltype(self)> {    if (n < N) { return { self, n }; } throw out_of_range(n); }
 
         [[nodiscard]] constexpr auto front(this auto&& self) noexcept -> result_t<decltype(self)> { return { self, 0UZ   }; }
         [[nodiscard]] constexpr auto back (this auto&& self) noexcept -> result_t<decltype(self)> { return { self, N - 1 }; }

--- a/include/xstd/bit_array.hpp
+++ b/include/xstd/bit_array.hpp
@@ -67,7 +67,7 @@ struct bit_array
 {
         bit::array<N, Block> m_bits;
 
-        [[nodiscard]] friend constexpr std::size_t find_first(const bit_array&)                  noexcept { return 0uz;         }
+        [[nodiscard]] friend constexpr std::size_t find_first(const bit_array&)                  noexcept { return 0UZ;         }
         [[nodiscard]] friend constexpr std::size_t find_last (const bit_array&)                  noexcept { return N;           }
         [[nodiscard]] friend constexpr std::size_t find_at   (const bit_array& c, std::size_t n) noexcept { return c.m_bits[n]; }
 
@@ -132,7 +132,7 @@ struct bit_array
         [[nodiscard]] constexpr auto operator[](this auto&& self, size_type n) noexcept -> result_t<decltype(self)> { assert(n < N); return { self, n };                             }
         [[nodiscard]] constexpr auto at        (this auto&& self, size_type n)          -> result_t<decltype(self)> {    if (n < N)  return { self, n }; else throw out_of_range(n); }
 
-        [[nodiscard]] constexpr auto front(this auto&& self) noexcept -> result_t<decltype(self)> { return { self, 0uz   }; }
+        [[nodiscard]] constexpr auto front(this auto&& self) noexcept -> result_t<decltype(self)> { return { self, 0UZ   }; }
         [[nodiscard]] constexpr auto back (this auto&& self) noexcept -> result_t<decltype(self)> { return { self, N - 1 }; }
 
 private:

--- a/include/xstd/bit_set.hpp
+++ b/include/xstd/bit_set.hpp
@@ -257,7 +257,7 @@ public:
         [[nodiscard]] constexpr bool contains(const key_type& x) const noexcept              { return m_bits[x]; }
         [[nodiscard]] constexpr auto count   (const key_type& x) const noexcept -> size_type { return m_bits[x]; }
 
-        [[nodiscard]] constexpr auto find       (this auto&& self, const key_type& x) noexcept -> iterator                      { if (self.contains(x)) return { &self, x }; else return self.end(); }
+        [[nodiscard]] constexpr auto find       (this auto&& self, const key_type& x) noexcept -> iterator                      { if (self.contains(x)) { return { &self, x }; } else { return self.end(); } }
         [[nodiscard]] constexpr auto lower_bound(this auto&& self, const key_type& x) noexcept -> iterator                      { return { &self, (x ? find_next(self, x - 1) : find_first(self)) }; }
         [[nodiscard]] constexpr auto upper_bound(this auto&& self, const key_type& x) noexcept -> iterator                      { return { &self, find_next(self, x) };                              }
         [[nodiscard]] constexpr auto equal_range(this auto&& self, const key_type& x) noexcept -> std::pair<iterator, iterator> { return { self.lower_bound(x), self.upper_bound(x) };               }

--- a/include/xstd/bit_set.hpp
+++ b/include/xstd/bit_set.hpp
@@ -250,8 +250,8 @@ public:
         constexpr bit_set& operator>>=(std::size_t n) noexcept { m_bits >>= n; return *this; }
 
         // observers
-        [[nodiscard]] constexpr   key_compare   key_comp() const noexcept { return   key_compare(); }
-        [[nodiscard]] constexpr value_compare value_comp() const noexcept { return value_compare(); }
+        [[nodiscard]] constexpr   key_compare   key_comp() const noexcept { return {}; }
+        [[nodiscard]] constexpr value_compare value_comp() const noexcept { return {}; }
 
         // set operations
         [[nodiscard]] constexpr bool contains(const key_type& x) const noexcept              { return m_bits[x]; }

--- a/include/xstd/bit_set.hpp
+++ b/include/xstd/bit_set.hpp
@@ -257,7 +257,7 @@ public:
         [[nodiscard]] constexpr bool contains(const key_type& x) const noexcept              { return m_bits[x]; }
         [[nodiscard]] constexpr auto count   (const key_type& x) const noexcept -> size_type { return m_bits[x]; }
 
-        [[nodiscard]] constexpr auto find       (this auto&& self, const key_type& x) noexcept -> iterator                      { if (self.contains(x)) { return { &self, x }; } else { return self.end(); } }
+        [[nodiscard]] constexpr auto find       (this auto&& self, const key_type& x) noexcept -> iterator                      { if (self.contains(x)) { return { &self, x }; } return self.end(); }
         [[nodiscard]] constexpr auto lower_bound(this auto&& self, const key_type& x) noexcept -> iterator                      { return { &self, (x ? find_next(self, x - 1) : find_first(self)) }; }
         [[nodiscard]] constexpr auto upper_bound(this auto&& self, const key_type& x) noexcept -> iterator                      { return { &self, find_next(self, x) };                              }
         [[nodiscard]] constexpr auto equal_range(this auto&& self, const key_type& x) noexcept -> std::pair<iterator, iterator> { return { self.lower_bound(x), self.upper_bound(x) };               }

--- a/include/xstd/bit_set.hpp
+++ b/include/xstd/bit_set.hpp
@@ -28,7 +28,7 @@ template<std::size_t N, std::unsigned_integral Block>               constexpr vo
 
 // 23.4.6.3, erasure for set
 template<std::size_t N, std::unsigned_integral Block, class Predicate>
-constexpr typename bit_set<N, Block>::size_type erase_if(bit_set<N, Block>& c, Predicate pred);
+constexpr bit_set<N, Block>::size_type erase_if(bit_set<N, Block>& c, Predicate pred);
 
 namespace aligned {
 
@@ -287,7 +287,7 @@ template<std::size_t N, std::unsigned_integral Block>               constexpr vo
 
 // 23.4.6.3 Erasure                                                [set.erasure]
 template<std::size_t N, std::unsigned_integral Block, class Predicate>
-constexpr typename bit_set<N, Block>::size_type erase_if(bit_set<N, Block>& c, Predicate pred)
+constexpr bit_set<N, Block>::size_type erase_if(bit_set<N, Block>& c, Predicate pred)
 {
         auto original_size = c.size();
         for (auto i = c.begin(), last = c.end(); i != last;) {

--- a/include/xstd/bitset.hpp
+++ b/include/xstd/bitset.hpp
@@ -81,7 +81,10 @@ public:
                 constexpr ~reference() = default;
                 constexpr reference& operator=(bool x) noexcept;
                 constexpr reference& operator=(const reference& x) noexcept = default;
-                constexpr const reference& operator=(bool x) const noexcept;
+                // A proxy reference assigns through a const proxy: the proxy is const,
+                // the bit it refers to is not. This is the shape the standard gives
+                // vector<bool>::reference, so the conventional signature is wrong here.
+                constexpr const reference& operator=(bool x) const noexcept;  // NOLINT(misc-unconventional-assign-operator)
                 constexpr explicit(false) operator bool() const noexcept;
                 constexpr bool operator~() const noexcept;
 

--- a/include/xstd/bitset.hpp
+++ b/include/xstd/bitset.hpp
@@ -164,7 +164,7 @@ public:
         constexpr bitset& reset() noexcept { m_bits.reset(); return *this; }
         constexpr bitset& flip () noexcept { m_bits.flip (); return *this; }
 
-        constexpr bitset& set  (std::size_t pos, bool val = true) { if (pos < N) { if (val) m_bits.set  (pos); else m_bits.reset(pos); return *this; } else { throw out_of_range(pos); } }
+        constexpr bitset& set  (std::size_t pos, bool val = true) { if (pos < N) { if (val) { m_bits.set  (pos); } else { m_bits.reset(pos); } return *this; } else { throw out_of_range(pos); } }
         constexpr bitset& reset(std::size_t pos)                  { if (pos < N) {          m_bits.reset(pos);                         return *this; } else { throw out_of_range(pos); } }
         constexpr bitset& flip (std::size_t pos)                  { if (pos < N) {          m_bits.flip (pos);                         return *this; } else { throw out_of_range(pos); } }
 

--- a/include/xstd/bitset.hpp
+++ b/include/xstd/bitset.hpp
@@ -127,7 +127,8 @@ public:
                         auto const ch = str[pos + M - 1 - i];
                         if (traits::eq(ch, zero)) {
                                 continue;
-                        } else if (traits::eq(ch, one)) {
+                        }
+                        if (traits::eq(ch, one)) {
                                 m_bits.set(i);
                         } else {
                                 throw invalid_argument(ch, zero, one);
@@ -164,9 +165,9 @@ public:
         constexpr bitset& reset() noexcept { m_bits.reset(); return *this; }
         constexpr bitset& flip () noexcept { m_bits.flip (); return *this; }
 
-        constexpr bitset& set  (std::size_t pos, bool val = true) { if (pos < N) { if (val) { m_bits.set  (pos); } else { m_bits.reset(pos); } return *this; } else { throw out_of_range(pos); } }
-        constexpr bitset& reset(std::size_t pos)                  { if (pos < N) {          m_bits.reset(pos);                         return *this; } else { throw out_of_range(pos); } }
-        constexpr bitset& flip (std::size_t pos)                  { if (pos < N) {          m_bits.flip (pos);                         return *this; } else { throw out_of_range(pos); } }
+        constexpr bitset& set  (std::size_t pos, bool val = true) { if (pos < N) { if (val) { m_bits.set  (pos); } else { m_bits.reset(pos); } return *this; } throw out_of_range(pos); }
+        constexpr bitset& reset(std::size_t pos)                  { if (pos < N) {          m_bits.reset(pos);                         return *this; } throw out_of_range(pos); }
+        constexpr bitset& flip (std::size_t pos)                  { if (pos < N) {          m_bits.flip (pos);                         return *this; } throw out_of_range(pos); }
 
         [[nodiscard]] constexpr bool operator[](std::size_t pos) const noexcept
         {
@@ -200,7 +201,7 @@ public:
 
         [[nodiscard]] constexpr bool operator==(const bitset& rhs) const noexcept = default;
 
-        [[nodiscard]] constexpr bool test(std::size_t pos) const { if (pos < N) { return m_bits[pos]; } else { throw out_of_range(pos); } }
+        [[nodiscard]] constexpr bool test(std::size_t pos) const { if (pos < N) { return m_bits[pos]; } throw out_of_range(pos); }
 
         [[nodiscard]] constexpr bool all()  const noexcept { return m_bits.all();  }
         [[nodiscard]] constexpr bool any()  const noexcept { return m_bits.any();  }

--- a/include/xstd/bitset.hpp
+++ b/include/xstd/bitset.hpp
@@ -316,6 +316,8 @@ struct compare<xstd::bitset<N, Block>>
 
 namespace std {
 
+// NOLINTBEGIN(bugprone-std-namespace-modification)
+
 // bitset hash support                                             [bitset.hash]
 //
 // No "template<class T> struct hash;" forward declaration here: std::hash's
@@ -339,6 +341,8 @@ struct hash<xstd::bitset<N, Block>>
                 return boost::hash2::get_integral_result<std::size_t>(h);
         }
 };
+
+// NOLINTEND(bugprone-std-namespace-modification)
 
 }       // namespace std
 

--- a/include/xstd/bitset.hpp
+++ b/include/xstd/bitset.hpp
@@ -85,7 +85,7 @@ public:
                 // the bit it refers to is not. This is the shape the standard gives
                 // vector<bool>::reference, so the conventional signature is wrong here.
                 constexpr const reference& operator=(bool x) const noexcept;  // NOLINT(misc-unconventional-assign-operator)
-                constexpr explicit(false) operator bool() const noexcept;
+                constexpr explicit(false) operator bool() const noexcept;  // NOLINT(misc-explicit-constructor)
                 constexpr bool operator~() const noexcept;
 
                 friend constexpr void swap(reference x, reference y) noexcept { bool t = x; x = y; y = t; }

--- a/include/xstd/bitset.hpp
+++ b/include/xstd/bitset.hpp
@@ -100,8 +100,8 @@ public:
         template<class charT, class traits, class Allocator>
         [[nodiscard]] constexpr explicit bitset(
                 const std::basic_string<charT, traits, Allocator>& str,
-                typename std::basic_string<charT, traits, Allocator>::size_type pos = 0,
-                typename std::basic_string<charT, traits, Allocator>::size_type n = std::basic_string<charT, traits, Allocator>::npos,
+                std::basic_string<charT, traits, Allocator>::size_type pos = 0,
+                std::basic_string<charT, traits, Allocator>::size_type n = std::basic_string<charT, traits, Allocator>::npos,
                 charT zero = charT('0'),
                 charT one  = charT('1')
         )
@@ -112,8 +112,8 @@ public:
         template<class charT, class traits>
         [[nodiscard]] constexpr explicit bitset(
                 std::basic_string_view<charT, traits> str,
-                typename std::basic_string_view<charT, traits>::size_type pos = 0,
-                typename std::basic_string_view<charT, traits>::size_type n = std::basic_string_view<charT, traits>::npos,
+                std::basic_string_view<charT, traits>::size_type pos = 0,
+                std::basic_string_view<charT, traits>::size_type n = std::basic_string_view<charT, traits>::npos,
                 charT zero = charT('0'),
                 charT one  = charT('1')
         ) 
@@ -138,7 +138,7 @@ public:
         template<class charT>
         [[nodiscard]] constexpr explicit bitset(
                 const charT* str,
-                typename std::basic_string_view<charT>::size_type n = std::basic_string_view<charT>::npos,
+                std::basic_string_view<charT>::size_type n = std::basic_string_view<charT>::npos,
                 charT zero = charT('0'),
                 charT one  = charT('1')
         )

--- a/include/xstd/bitset.hpp
+++ b/include/xstd/bitset.hpp
@@ -123,7 +123,7 @@ public:
                 }
                 auto const rlen = std::ranges::min(n, str.size() - pos);
                 auto const M = std::ranges::min(N, rlen);
-                for (auto i : std::views::iota(0uz, M)) {
+                for (auto i : std::views::iota(0UZ, M)) {
                         auto const ch = str[pos + M - 1 - i];
                         if (traits::eq(ch, zero)) {
                                 continue;
@@ -186,7 +186,7 @@ public:
         [[nodiscard]] constexpr std::basic_string<charT, traits, Allocator> to_string(charT zero = charT('0'), charT one = charT('1')) const
         {
                 auto str = std::basic_string<charT, traits, Allocator>(N, zero);
-                for (auto i : std::views::iota(0uz, N)) {
+                for (auto i : std::views::iota(0UZ, N)) {
                         if (m_bits[N - 1 - i]) {
                                 str[i] = one;
                         }
@@ -263,7 +263,7 @@ struct find<xstd::bitset<N, Block>>
                 if constexpr (N == 0) {
                         return N;
                 } else {
-                        return *std::ranges::find_if(std::views::iota(0uz, N), [&](auto i) {
+                        return *std::ranges::find_if(std::views::iota(0UZ, N), [&](auto i) {
                                 return c[i];
                         });
                 }
@@ -284,7 +284,7 @@ struct find<xstd::bitset<N, Block>>
         [[nodiscard]] static std::size_t prev(xstd::bitset<N, Block> const& c, std::size_t n) noexcept
         {
                 assert(c.any());
-                return *std::ranges::find_if(std::views::iota(0uz, n) | std::views::reverse, [&](auto i) {
+                return *std::ranges::find_if(std::views::iota(0UZ, n) | std::views::reverse, [&](auto i) {
                         return c[i];
                 });
         }
@@ -352,7 +352,7 @@ std::basic_istream<charT, traits>& operator>>(std::basic_istream<charT, traits>&
         auto str = std::basic_string<charT, traits>(N, is.widen('0'));
         auto state = std::ios_base::goodbit;
         charT ch;
-        auto i = 0uz;
+        auto i = 0UZ;
         while (i < N and not is.eof() and (traits::eq_int_type(is.peek(), is.widen('0')) or traits::eq_int_type(is.peek(), is.widen('1')))) {
                 is >> ch;
                 if (traits::eq(ch, is.widen('1'))) {

--- a/include/xstd/proxy/bidirectional.hpp
+++ b/include/xstd/proxy/bidirectional.hpp
@@ -291,8 +291,10 @@ public:
                 if constexpr (requires { m_ptr->intersects(*other.m_ptr); }) {
                         return m_ptr->intersects(*other.m_ptr);
                 } else {
-                        auto first1 = begin(), last1 = end();
-                        auto first2 = other.begin(), last2 = other.end();
+                        auto first1 = begin();
+                        auto last1  = end();
+                        auto first2 = other.begin();
+                        auto last2  = other.end();
                         while (first1 != last1 and first2 != last2) {
                                 if (*first1 < *first2) {
                                         ++first1;

--- a/include/xstd/proxy/bidirectional.hpp
+++ b/include/xstd/proxy/bidirectional.hpp
@@ -173,13 +173,13 @@ public:
                 return { &m_ref, m_idx };
         }
 
-        [[nodiscard]] constexpr explicit(false) operator value_type() const noexcept
+        [[nodiscard]] constexpr explicit(false) operator value_type() const noexcept  // NOLINT(misc-explicit-constructor)
         {
                 return m_idx;
         }
 
         template<std::constructible_from<value_type> T>
-        [[nodiscard]] constexpr explicit(not std::is_convertible_v<value_type, T>) operator T() const noexcept(std::is_nothrow_constructible_v<T, value_type>)
+        [[nodiscard]] constexpr explicit(not std::is_convertible_v<value_type, T>) operator T() const noexcept(std::is_nothrow_constructible_v<T, value_type>)  // NOLINT(misc-explicit-constructor)
                 requires std::is_class_v<T>
         {
                 return m_idx;

--- a/include/xstd/proxy/random_access.hpp
+++ b/include/xstd/proxy/random_access.hpp
@@ -183,13 +183,13 @@ public:
                 return { &m_ref, m_idx };
         }
 
-        [[nodiscard]] constexpr explicit(false) operator value_type() const noexcept
+        [[nodiscard]] constexpr explicit(false) operator value_type() const noexcept  // NOLINT(misc-explicit-constructor)
         {
                 return find<Bits>::at(m_ref, m_idx);
         }
 
         template<std::constructible_from<value_type> T>
-        [[nodiscard]] constexpr explicit(not std::is_convertible_v<value_type, T>) operator T() const noexcept(std::is_nothrow_constructible_v<T, value_type>)
+        [[nodiscard]] constexpr explicit(not std::is_convertible_v<value_type, T>) operator T() const noexcept(std::is_nothrow_constructible_v<T, value_type>)  // NOLINT(misc-explicit-constructor)
                 requires std::is_class_v<T>
         {
                 return find<Bits>::at(m_ref, m_idx);


### PR DESCRIPTION
The Clang-Tidy job has been red on `main` since the cpp-ci migration. It reports **51 findings across 11 checks** in `include/xstd/`, and clearing those exposes **6 more** in `include/ext/` and `include/opt/` that were never reached. This answers all 57, one commit per check so any single verdict can be reverted on its own.

## Why the second batch only appeared later

`HeaderFilterRegex` is `include/xstd/.*`, so headers outside it report nothing while they are merely *included*. The shared workflow's second pass feeds each public header in as a primary input, where the filter no longer applies — and that pass never ran while the first was failing. The per-header loop also stops at the first header that fails, so the remaining sites are fixed here rather than surfacing one round at a time.

## Not taken as code changes

| check | why |
| --- | --- |
| `modernize-use-transparent-functors` | needs no action at all. `less<>` is a different type from `less<key_type>`, so the fix would change `bit_set<N, Block>::key_compare`, which the associative container requirements pin. Returning the comparators braced removed the construction expression it reported at, so no exclusion is needed either. |
| `bugprone-easily-swappable-parameters` | both sites are fixed by the interface: `to_string(charT zero, charT one)` is `std::bitset`'s own signature, and `lexicographical_three_way(x, y)` compares two bitsets. Excluded in `.clang-tidy`. |
| `misc-unconventional-assign-operator` | `bitset::reference`'s const-qualified `operator=` returns `const reference&` on purpose — the proxy is const, the bit is not, and the standard gives `vector<bool>::reference` the same signature. Suppressed at the site. |
| `bugprone-std-namespace-modification` ×2 | two blocks, and they are **not** the same case. See below. |

### The two `namespace std` blocks differ, and the commits say so

`xstd/bitset.hpp` holds a partial specialization of `std::hash` for `xstd::bitset`. [namespace.std] sanctions that explicitly: it depends on a program-defined type. Suppressing there hides nothing.

`ext/std/bitset.hpp` adds `operator-=` and `operator-` for `std::bitset`. That is a **standard** type, so the paragraph does not sanction it and the check is reporting real undefined behaviour rather than a false positive. It is suppressed because the tradeoff is already recorded in the comment above that block — infix syntax for `std::bitset` is reachable only through ADL or membership in `std`, and there is no legal way to provide either from outside — but the commit message states plainly that this is UB, so nobody later reads the `NOLINT` as "false positive".

That one is expected to become unnecessary. With xstd-namespace views that adapt iterators to `std` and Boost types, the operators no longer need to live in `std` to be reachable, and the suppression can go with them. Worth revisiting when those land.

## Taken

| check | n | |
| --- | --- | --- |
| `readability-uppercase-literal-suffix` | 17 + 6 | `0uz` → `0UZ`, in two commits — the second covering the headers the per-header pass reaches |
| `readability-else-after-return` | 9 | branch already returns, throws or continues |
| `readability-redundant-typename` | 7 | P0634R3 contexts |
| `readability-math-missing-parentheses` | 5 | block-offset arithmetic in `bit/array.hpp` |
| `readability-braces-around-statements` | 3 | one-line members |
| `readability-isolate-declaration` | 2 | the iterator pairs in `is_subset_of` |
| `modernize-return-braced-init-list` | 2 | `key_comp()`, `value_comp()` |

Braces come before else-after-return deliberately: clang-tidy reported *"this fix will not be applied because it overlaps with another fix"* where both wanted to rewrite the same `else`.

## Verification, and its limit

**These edits were never compiled locally.** This container has libstdc++ 13 and the library needs 15 for `std::from_range_t`. That is the reason for one commit per check: a red leg names its own culprit.

CI has since supplied real compile coverage — the Build step succeeds on MSVC 2026 and Clang-CL, Debug and Release, and `clang_tidy` reports zero compile errors.

What was checked locally:

- `static_assert(0UZ == 0uz)` and the `sizeof` equality on g++ and clang++ — the suffix change is lexical
- the `typename` removals on the two shapes this repo actually contains. A free function *declaration* whose parameter is a dependent qualified type still needs `typename`, and both compilers reject dropping it — bit_set has no parameter in that position
- braces and parentheses balance in every header, each delta against `main` accounting for the braces added minus the `else` braces removed
- `.clang-tidy` parses, with each check entry asserted as an exact entry

That last one is worth flagging: an earlier revision of this branch put explanatory prose *inside* the `Checks: >` folded scalar, where `#` is literal text rather than a comment. The prose was folded into the check list and silently disabled two exclusions. The file now carries a comment recording that trap.

## Known-red legs, not this pull request's

The libc++ row and both AppleClang legs fail on missing C++23 range adaptors, and MSVC 2022 on `std::flat_set` — all documented at README line 442 as not required. Separately, `test.set.sieve` fails in **Debug** on MSVC 2026, MSVC 2026-Preview, Clang-CL 2026 and Clang-CL 2026-Preview, all four red on `main` at this branch's base, with every Release leg green. That belongs with #47 and #48.

## Scope

Deliberately separate from #50, the repin, which stays a pure repin. The stable rung wants to be green before cpp-ci v0.6.1 widens clang-tidy from one rung to three.