### PR TITLE
Answer the last two clang-tidy findings, in ext/

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -30,15 +30,26 @@ jobs:
       # header is a primary input either way, and .clang-tidy sets
       # WarningsAsErrors, so any finding fails the job.
       self_sufficiency_regex: ${{ github.workspace }}/build/test/header_self_sufficiency/.*
-      # ext/boost/dynamic_bitset.hpp adapts a library that is not on the
-      # include path of the per-header pass: that pass compiles each header
-      # standalone with -I<header_dir> alone, not from the compile database,
-      # so <boost/dynamic_bitset.hpp> is not found and clang-tidy reports a
-      # clang-diagnostic-error rather than a finding. Both candidate install
-      # directories are named because the vcpkg-install action installs to the
-      # workspace root while vcpkg's CMake toolchain defaults to the build
-      # tree; the workflow adds -isystem only for directories that exist, so
-      # naming both is how this stays right either way.
+      # The per-header pass compiles each header standalone with
+      # -I<header_dir> alone, not from the compile database, so anything a
+      # header includes from outside this repository is not found and
+      # clang-tidy reports a clang-diagnostic-error rather than a finding.
+      # Two libraries are needed:
+      #
+      #   xstd, which bit/array.hpp and others include directly, and which
+      #   CMakeLists.txt fetches with FetchContent when it is not already
+      #   installed. FetchContent puts it at ${CMAKE_BINARY_DIR}/_deps/<name>-src,
+      #   the same shape xstd's own stub names for the libraries its ext/
+      #   headers adapt.
+      #
+      #   Boost, for ext/boost/dynamic_bitset.hpp and the hash2 headers, which
+      #   vcpkg installs. Both candidate directories are named because the
+      #   vcpkg-install action installs to the workspace root while vcpkg's
+      #   CMake toolchain defaults to the build tree.
+      #
+      # The workflow adds -isystem only for a directory that exists, so naming
+      # a candidate that turns out not to be used costs nothing.
       adapted_dirs: >-
+        build/_deps/xstd-src/include
         vcpkg_installed/x64-linux/include
         build/vcpkg_installed/x64-linux/include

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -30,3 +30,15 @@ jobs:
       # header is a primary input either way, and .clang-tidy sets
       # WarningsAsErrors, so any finding fails the job.
       self_sufficiency_regex: ${{ github.workspace }}/build/test/header_self_sufficiency/.*
+      # ext/boost/dynamic_bitset.hpp adapts a library that is not on the
+      # include path of the per-header pass: that pass compiles each header
+      # standalone with -I<header_dir> alone, not from the compile database,
+      # so <boost/dynamic_bitset.hpp> is not found and clang-tidy reports a
+      # clang-diagnostic-error rather than a finding. Both candidate install
+      # directories are named because the vcpkg-install action installs to the
+      # workspace root while vcpkg's CMake toolchain defaults to the build
+      # tree; the workflow adds -isystem only for directories that exist, so
+      # naming both is how this stays right either way.
+      adapted_dirs: >-
+        vcpkg_installed/x64-linux/include
+        build/vcpkg_installed/x64-linux/include

--- a/include/ext/boost/dynamic_bitset.hpp
+++ b/include/ext/boost/dynamic_bitset.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef EXT_BOOST_DYNAMIC_BITSET_HPP
+#define EXT_BOOST_DYNAMIC_BITSET_HPP
 
 //          Copyright Rein Halbersma 2014-2025.
 // Distributed under the Boost Software License, Version 1.0.
@@ -118,3 +119,5 @@ struct compare<boost::dynamic_bitset<Block, Allocator>>
 };
 
 }       // namespace xstd::proxy::random_access
+
+#endif  // include guard

--- a/include/opt/bitset/sieve.hpp
+++ b/include/opt/bitset/sieve.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef OPT_BITSET_SIEVE_HPP
+#define OPT_BITSET_SIEVE_HPP
 
 //          Copyright Rein Halbersma 2014-2025.
 // Distributed under the Boost Software License, Version 1.0.
@@ -123,3 +124,5 @@ auto filter_twins(X const& primes)
 }
 
 }       // namespace xstd
+
+#endif  // include guard

--- a/include/opt/set/sieve.hpp
+++ b/include/opt/set/sieve.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef OPT_SET_SIEVE_HPP
+#define OPT_SET_SIEVE_HPP
 
 //          Copyright Rein Halbersma 2014-2025.
 // Distributed under the Boost Software License, Version 1.0.
@@ -74,3 +75,5 @@ auto filter_twins(X const& primes)
 }
 
 }       // namespace xstd
+
+#endif  // include guard


### PR DESCRIPTION
#51 took clang-tidy from 51 findings to 2. This takes it to 0.

Both remaining findings are in `ext/boost/dynamic_bitset.hpp`, and neither was visible until #51 landed — the per-header pass never ran while the first pass was failing, and it stops at the first header that fails.

| check | fix |
| --- | --- |
| `portability-avoid-pragma-once` | include guards, matching the eleven headers that already have them |
| `clang-diagnostic-error` | `adapted_dirs` on the caller stub — see below |

## The second one is not about the code

```
ext/boost/dynamic_bitset.hpp:10: error: 'boost/dynamic_bitset.hpp' file not found
```

The per-header pass compiles each public header standalone with `-I<header_dir>` and nothing else. That is deliberate: a header that only compiles as part of some translation unit is exactly what the pass exists to catch. But a header adapting a third-party library needs that library on the path, and this is the only header here adapting something vcpkg installs rather than something the repository owns.

`adapted_dirs` exists for this, and xstd's stub already uses it for the two libraries its own `ext/` headers adapt. The directories go in with `-isystem`, so nothing inside Boost is analysed.

Two paths are named because the install location differs between halves of the job — the `vcpkg-install` action runs `vcpkg install` from the workspace root, writing `vcpkg_installed/` there, while the Configure step hands CMake vcpkg's toolchain, whose manifest mode defaults to the build tree. The workflow adds `-isystem` only for a directory that exists, so naming both is what makes this correct rather than a guess about which wins.

Checked before pushing: `adapted_dirs` is declared in the shared workflow at **both** the pin `main` currently carries (v0.4.1) and the pin #50 moves to (v0.6.1), so the stub is valid before and after that lands. Passing an undeclared input is a hard workflow error, which would have been a poor way to find out.

## The other two `#pragma once` files come too

Only `ext/boost/dynamic_bitset.hpp` has been reported, because the loop stops at the first failure. `opt/bitset/sieve.hpp` and `opt/set/sieve.hpp` would each have surfaced a round later, so all three are converted here. Macro names follow the existing convention and are unique across all fourteen headers.

## Verification

`actionlint` clean. Guards checked for uniqueness across every header. As with #51, the source edits were not compiled locally — this container has libstdc++ 13 and the library needs 15 — though an include guard replacing `#pragma once` is about as inert as a change gets.

Once this and #50 are in, bit_set should be green on all three clang-tidy rungs.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ef1rfKHEMHutpEeV1R6ga)_