### PR TITLE
Stop the set sieves erasing from the range they iterate

### DIFF
--- a/include/opt/set/sieve.hpp
+++ b/include/opt/set/sieve.hpp
@@ -28,14 +28,33 @@ struct generate_candidates
         }
 };
 
+// Both sieves iterate a snapshot rather than primes itself, because sift()
+// erases from primes and the range-for has already cached that container's
+// end(). For a node-based X -- std::set -- erasing invalidates only the erased
+// element, and m is always composite while p is not, so the cached end()
+// survives. For a vector-backed X -- std::flat_set -- every erase shifts the
+// tail and the cached end() is stale from the first sift onwards. MSVC's
+// _ITERATOR_DEBUG_LEVEL=2 rejects the comparison outright ("vector iterators
+// incompatible", <vector>:203); libstdc++ has no such check, so the MinGW
+// legs walk past the real end and segfault, and the Linux legs read
+// still-allocated memory and pass.
+//
+// The contains() guard restores what iterating the shrinking container gave
+// for free: p skips values already sifted out. Without it the snapshot also
+// offers composite p, whose multiples are all sifted already -- the same
+// result for strictly more work.
 template<class X>
 auto sift_primes0(std::size_t n)
 {
         auto primes = generate_candidates<X>()(n);
+        auto const candidates = primes;
         for (auto p
-                : primes
+                : candidates
                 | std::views::take_while([&](auto x) { return x * x < n; })
         ) {
+                if (not primes.contains(p)) {
+                        continue;
+                }
                 for (auto m
                         : std::views::iota(p * p, n)
                         | std::views::stride(p)
@@ -50,8 +69,12 @@ template<class X>
 auto sift_primes1(std::size_t n)
 {
         auto primes = generate_candidates<X>()(n);
-        for (auto p : primes) {
+        auto const candidates = primes;
+        for (auto p : candidates) {
                 if (auto m = p * p; m < n) {
+                        if (not primes.contains(p)) {
+                                continue;
+                        }
                         do {
                                 sift(primes, m);
                                 m += p;


### PR DESCRIPTION
One of the four MinGW Debug segfaults, and it turns out not to be a MinGW problem at all — it is the only one of the four that is red on **three** Windows toolchains, and MSVC says why.

## What MSVC Debug reports

`test.set.sieve` is the single failing test on `msvc / 2026 Debug`, and `_ITERATOR_DEBUG_LEVEL=2` names the instantiation:

```
in "Sieve/Format<std__flat_set<unsigned __int64, std__less<...>, std__vector<...>>>":
  ...\VC\Tools\MSVC\14.51.36231\include\vector(203):
  Assertion failed: vector iterators incompatible
test\src\set\sieve.cpp(26): last checkpoint: "Format" test entry
```

## The defect

`sift_primes0` and `sift_primes1` erase from `primes` while a range-for iterates it. The loop caches that container's `end()` once; `sift()` invalidates it.

```cpp
auto primes = generate_candidates<X>()(n);
for (auto p : primes | std::views::take_while(...)) {   // end() cached here
    for (auto m : ...) {
        sift(primes, m);                                 // primes.erase(m)
    }
}
```

| X | erase invalidates | outcome |
| --- | --- | --- |
| `std::set` | only the erased element — and `m` is composite, `p` prime, so never the current one | fine |
| `std::flat_set` | vector-backed: every erase shifts the tail, cached `end()` stale from the first sift | **undefined** |
| `xstd::bit_set` | clears a bit, no iterators move | fine |

MSVC's checked iterators are the only configuration that says so out loud. libstdc++ has no equivalent check, so the same defect is silent there: on MinGW Debug it segfaults, and on Linux Debug it reads memory the vector has shrunk out of but not freed, and passes.

That accounts for the exact spread. `test.set.sieve` is red on MSVC Debug, Clang-CL Debug and MinGW Debug at once, while `test.bitset.sieve` is green everywhere — its type list is `dynamic_bitset`, `std::bitset`, `xstd::bitset`, `xstd::bit_set`, none of them vector-backed. `opt/bitset/sieve.hpp` is a different implementation that clears bits and does not have this shape, so it needs no change.

## The fix

Iterate a snapshot. The `contains()` guard restores what iterating the shrinking container gave for free — `p` skips values already sifted out. Without it the snapshot also offers composite `p`, whose multiples have all been sifted already: the same result for strictly more work.

## Verification

This container needs libstdc++ 15 and this machine has 13, so the library itself could not be built here. What was done instead:

**Reproduced the defect.** A reduced vector-backed sorted set, which is what `std::flat_set` is, run under the loop as written on `main`: for `n = 100` it takes **4** outer iterations where the same sieve over a snapshot takes **8**. The cached `end()` drifts as the vector shrinks. ASan stays quiet, because `erase` frees nothing — which is precisely why the Linux legs pass.

**Checked the fix changes no result.** Both old formulations and both new ones, over `std::set` and that vector-backed stand-in, against an independent bit-array sieve, for `n` in `{2, 3, 4, 10, 100, 1000, 5000}`. All four agree with the reference at every `n`. So this is not a behaviour change, only a defined one.

## What this does not fix

The other three MinGW Debug segfaults — `test.bitset.o1`, `test.set.o0`, `test.set.o2` — are a separate problem, and this pull request does not touch them. They **pass** under MSVC Debug and Clang-CL Debug, which is exactly what makes them unlike this one. Ruled out as the discriminator so far: `fmt` (`test.bitset.sieve` uses it and passes), `__uint128_t` (`test.bitset.o0` uses it five times and passes), `std::flat_set` (`test.set.o1`/`o3`/`o4` use it and pass), and `-Wa,-mbig-obj` (#48 established the crash reproduces without it).

Nothing in the source separates those three from their passing neighbours, so the next step for them is a backtrace rather than another hypothesis — running them under `gdb --batch -ex run -ex bt` on the MinGW legs. So `mingw / all` stays red after this lands; it should go from four failures to three.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ef1rfKHEMHutpEeV1R6ga)_