### PR TITLE
Cap vector width on MinGW in every configuration, not only Debug

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -112,16 +112,44 @@ set(cxx_compile_options_optimization
     # keeps AVX2 and its 128-bit VEX instructions (vpaddq, vpshufb and the rest);
     # only 256-bit vectors go.
     #
-    # Scoped to Debug, where the crash lives and where vector width buys nothing
-    # anyway. Release keeps the full 256-bit -march=native, which is the only
-    # configuration whose measurements depend on it.
+    # Every configuration, not only Debug. #54 scoped this to Debug because that
+    # was where the crashes were, and said the scoping rested on an observation
+    # rather than a guarantee: Release was green because -O2 usually keeps these
+    # values in registers, but register pressure can spill a ymm to a 32-byte
+    # slot at any optimisation level.
     #
-    # That scoping rests on an observation rather than a guarantee. Release was
-    # green throughout because -O2 keeps these values in registers instead of
-    # spilling them - but register pressure can spill a ymm to a 32-byte slot at
-    # any optimisation level. If a Release leg ever faults on a vmovdqa, the
-    # answer is to widen this to every configuration.
-    $<$<AND:$<CXX_COMPILER_ID:GNU>,$<PLATFORM_ID:Windows>,$<CONFIG:Debug>>:
+    # It does. Scanning the built objects with cpp-ci's Windows stack-ABI check
+    # found the instruction in Release, on all three WinLibs rungs, with no
+    # workaround applied:
+    #
+    #   15.3.0    15 aligned 32-byte stack accesses, 0 functions realigned
+    #   16.2.0    12
+    #   17-SVN    14
+    #
+    # for example, in a function no test names and no crash ever reached:
+    #
+    #   fmt::v12::detail::value<context>::format_custom<std::set<unsigned long long, ...>>
+    #     207: vmovdqa %ymm0,0x60(%rsp)
+    #
+    # 0x60(%rsp) is 16-byte aligned but not 32-byte aligned, so it faults on
+    # every entry where rsp happens to land on a 32-byte boundary and not on the
+    # others. Release was never correct; it was lucky, and only about half the
+    # time per entry. Note also that none of the types involved is over-aligned:
+    # std::set, std::bitset and std::flat_set all have alignof 8. GCC invented
+    # the 32-byte requirement on its own.
+    #
+    # Capping the width is the only remedy this target has. -mstackrealign
+    # realigns to the *preferred* stack boundary, and mingw-w64 refuses to let
+    # that boundary exceed 16 bytes - measured on GCC 13, 15.3.0 and the 17
+    # snapshot, all three rejecting "-mpreferred-stack-boundary=5" as "not
+    # between 3 and 4", where Linux x86-64 accepts it. So the frame cannot be
+    # aligned to 32 by any means, and the only fix is to stop generating code
+    # that needs it. Nothing to wait for upstream either: GCC PR target/49001
+    # has been open on this since 2011.
+    #
+    # The cost is 256-bit vectors in Release. That is a real loss for the
+    # benchmarks, and it is not optional.
+    $<$<AND:$<CXX_COMPILER_ID:GNU>,$<PLATFORM_ID:Windows>>:
         -mprefer-vector-width=128
     >
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -118,16 +118,44 @@ set(cxx_compile_options_optimization
     # keeps AVX2 and its 128-bit VEX instructions (vpaddq, vpshufb and the rest);
     # only 256-bit vectors go.
     #
-    # Scoped to Debug, where the crash lives and where vector width buys nothing
-    # anyway. Release keeps the full 256-bit -march=native, which is the only
-    # configuration whose measurements depend on it.
+    # Every configuration, not only Debug. #54 scoped this to Debug because that
+    # was where the crashes were, and said the scoping rested on an observation
+    # rather than a guarantee: Release was green because -O2 usually keeps these
+    # values in registers, but register pressure can spill a ymm to a 32-byte
+    # slot at any optimisation level.
     #
-    # That scoping rests on an observation rather than a guarantee. Release was
-    # green throughout because -O2 keeps these values in registers instead of
-    # spilling them - but register pressure can spill a ymm to a 32-byte slot at
-    # any optimisation level. If a Release leg ever faults on a vmovdqa, the
-    # answer is to widen this to every configuration.
-    $<$<AND:$<CXX_COMPILER_ID:GNU>,$<PLATFORM_ID:Windows>,$<CONFIG:Debug>>:
+    # It does. Scanning the built objects with cpp-ci's Windows stack-ABI check
+    # found the instruction in Release, on all three WinLibs rungs, with no
+    # workaround applied:
+    #
+    #   15.3.0    15 aligned 32-byte stack accesses, 0 functions realigned
+    #   16.2.0    12
+    #   17-SVN    14
+    #
+    # for example, in a function no test names and no crash ever reached:
+    #
+    #   fmt::v12::detail::value<context>::format_custom<std::set<unsigned long long, ...>>
+    #     207: vmovdqa %ymm0,0x60(%rsp)
+    #
+    # 0x60(%rsp) is 16-byte aligned but not 32-byte aligned, so it faults on
+    # every entry where rsp happens to land on a 32-byte boundary and not on the
+    # others. Release was never correct; it was lucky, and only about half the
+    # time per entry. Note also that none of the types involved is over-aligned:
+    # std::set, std::bitset and std::flat_set all have alignof 8. GCC invented
+    # the 32-byte requirement on its own.
+    #
+    # Capping the width is the only remedy this target has. -mstackrealign
+    # realigns to the *preferred* stack boundary, and mingw-w64 refuses to let
+    # that boundary exceed 16 bytes - measured on GCC 13, 15.3.0 and the 17
+    # snapshot, all three rejecting "-mpreferred-stack-boundary=5" as "not
+    # between 3 and 4", where Linux x86-64 accepts it. So the frame cannot be
+    # aligned to 32 by any means, and the only fix is to stop generating code
+    # that needs it. Nothing to wait for upstream either: GCC PR target/49001
+    # has been open on this since 2011.
+    #
+    # The cost is 256-bit vectors in Release. That is a real loss for the
+    # benchmarks, and it is not optional.
+    $<$<AND:$<CXX_COMPILER_ID:GNU>,$<PLATFORM_ID:Windows>>:
         -mprefer-vector-width=128
     >
 )


### PR DESCRIPTION
Widens the `-mprefer-vector-width=128` from #54 to every Windows GNU configuration, in `test/` and `benchmark/`.

> **Note on this PR's history.** It began as a do-not-merge validation branch that deliberately *removed* the workaround, to check that cpp-ci's new Windows stack-ABI scan could see the defect. It could — and it found more than expected, which is what this PR now acts on. The earlier comments below are that experiment's record; the branch has been reset to `main` and now carries only the fix.

## Why

#54 scoped the flag to Debug and said plainly that the scoping rested on an observation rather than a guarantee:

> Release was green throughout because -O2 keeps these values in registers instead of spilling them — but register pressure can spill a ymm to a 32-byte slot at any optimisation level. **If a Release leg ever faults on a vmovdqa, the answer is to widen this to every configuration.**

Scanning the built objects settles it without waiting for a fault. The check read bit_set's own **Release** objects — which never had the workaround — and found the instruction on all three rungs:

| Rung | aligned 32-byte stack accesses | functions that realigned |
|---|---|---|
| 15.3.0 | 15 | 0 |
| 16.2.0 | 12 | 0 |
| 17-SVN | 14 | 0 |

For example, in a function no test names and no crash ever reached:

```
fmt::v12::detail::value<context>::format_custom<std::set<unsigned long long, …>>
  207: vmovdqa %ymm0,0x60(%rsp)
```

`0x60(%rsp)` is 16-byte aligned and not 32-byte aligned, so it faults on every entry where `rsp` lands on a 32-byte boundary and not on the others. Release was not correct — it was lucky, at roughly even odds per entry.

Worth recording: **none of the types involved is over-aligned.** `std::set`, `std::bitset` and `std::flat_set` all have `alignof == 8`, and nothing in this library requests 32-byte alignment anywhere. GCC introduced the requirement on its own.

## Why capping the width is the only option

`-mstackrealign` realigns to the *preferred* stack boundary, and mingw-w64 will not let that boundary exceed 16 bytes:

```
GCC 13 / 15.3.0 / 17-SVN   -mpreferred-stack-boundary=5 → error: not between 3 and 4
Linux x86-64               -mpreferred-stack-boundary=5 → accepted
```

The frame cannot be aligned to 32 by any available means, so the only fix is to stop emitting code that needs it. There is no upstream fix to wait for either: [GCC PR target/49001](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=49001) has been open on this since 2011, and [mingw-w64 bug #304](https://sourceforge.net/p/mingw-w64/bugs/304/) was closed pointing back at it.

## Verification

On the mingw-w64 cross with `-march=x86-64-v3`, over `-O0`, `-O1` and `-O2` together:

| | wide-register uses | wide stack accesses |
|---|---|---|
| without the flag | 43 | 12 |
| with the flag | **0** | **0** |

`__AVX2__` stays defined, so 128-bit VEX encodings (`vpaddq`, `vpshufb`, …) remain — only 256-bit vectors go.

The generator expression was checked per configuration against a real target rather than by reading it. The flag reaches the compile line in Debug, Release and RelWithDebInfo on a Windows GNU toolchain, and in none of them on Linux.

## Cost

256-bit vectors in the Windows benchmarks. That is a real loss, and on this target it is not optional.

## Not in scope

`-Wa,-mbig-obj` stays. #47 tested it by withholding it, and two of three rungs then fail to assemble these objects outright (`file too big` on `set/o0`, `set/o2`, `bitset/o0`).