### PR TITLE
Repin cpp-ci to v0.8.1

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -26,4 +26,4 @@ jobs:
   # is now most of what a stub can contain. No inputs: the defaults lint
   # .github/workflows with shellcheck on.
   actionlint:
-    uses: rhalbersma/cpp-ci/.github/workflows/actionlint.yml@676e6fb7abc784e54a227998bf3e9c39790e63cf # v0.8.0
+    uses: rhalbersma/cpp-ci/.github/workflows/actionlint.yml@e2886b13f6fcd1eceb231652f816b016de41be1d # v0.8.1

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -26,4 +26,4 @@ jobs:
   # is now most of what a stub can contain. No inputs: the defaults lint
   # .github/workflows with shellcheck on.
   actionlint:
-    uses: rhalbersma/cpp-ci/.github/workflows/actionlint.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1
+    uses: rhalbersma/cpp-ci/.github/workflows/actionlint.yml@676e6fb7abc784e54a227998bf3e9c39790e63cf # v0.8.0

--- a/.github/workflows/appleclang.yml
+++ b/.github/workflows/appleclang.yml
@@ -32,4 +32,4 @@ jobs:
   # the badge URL in the README is the workflow's path, so renaming it would
   # break the badge and every link to a past run.
   apple_clang:
-    uses: rhalbersma/cpp-ci/.github/workflows/apple-clang.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1
+    uses: rhalbersma/cpp-ci/.github/workflows/apple-clang.yml@676e6fb7abc784e54a227998bf3e9c39790e63cf # v0.8.0

--- a/.github/workflows/appleclang.yml
+++ b/.github/workflows/appleclang.yml
@@ -32,4 +32,4 @@ jobs:
   # the badge URL in the README is the workflow's path, so renaming it would
   # break the badge and every link to a past run.
   apple_clang:
-    uses: rhalbersma/cpp-ci/.github/workflows/apple-clang.yml@676e6fb7abc784e54a227998bf3e9c39790e63cf # v0.8.0
+    uses: rhalbersma/cpp-ci/.github/workflows/apple-clang.yml@e2886b13f6fcd1eceb231652f816b016de41be1d # v0.8.1

--- a/.github/workflows/clang-cl.yml
+++ b/.github/workflows/clang-cl.yml
@@ -31,7 +31,7 @@ jobs:
   # leg for that gap is enough; a second adds a runner and no information.
   # 2026-Preview is a gain: the local workflow tested VS 2026 alone.
   clang_cl:
-    uses: rhalbersma/cpp-ci/.github/workflows/visual-studio.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1
+    uses: rhalbersma/cpp-ci/.github/workflows/visual-studio.yml@676e6fb7abc784e54a227998bf3e9c39790e63cf # v0.8.0
     with:
       tiers: qualification,development
       toolset: ClangCL,host=x64

--- a/.github/workflows/clang-cl.yml
+++ b/.github/workflows/clang-cl.yml
@@ -31,7 +31,7 @@ jobs:
   # leg for that gap is enough; a second adds a runner and no information.
   # 2026-Preview is a gain: the local workflow tested VS 2026 alone.
   clang_cl:
-    uses: rhalbersma/cpp-ci/.github/workflows/visual-studio.yml@676e6fb7abc784e54a227998bf3e9c39790e63cf # v0.8.0
+    uses: rhalbersma/cpp-ci/.github/workflows/visual-studio.yml@e2886b13f6fcd1eceb231652f816b016de41be1d # v0.8.1
     with:
       tiers: qualification,development
       toolset: ClangCL,host=x64

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -28,7 +28,7 @@ jobs:
   # Its own tier, deliberately left at stable: a formatter release reformats
   # the code base, which is not something a compiler bump should decide.
   clang_format:
-    uses: rhalbersma/cpp-ci/.github/workflows/clang-format.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1
+    uses: rhalbersma/cpp-ci/.github/workflows/clang-format.yml@676e6fb7abc784e54a227998bf3e9c39790e63cf # v0.8.0
     with:
       # benchmark/ too: the shared default is "include test", but this
       # repository also carries a benchmark tree of hand-written sources.

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -28,7 +28,7 @@ jobs:
   # Its own tier, deliberately left at stable: a formatter release reformats
   # the code base, which is not something a compiler bump should decide.
   clang_format:
-    uses: rhalbersma/cpp-ci/.github/workflows/clang-format.yml@676e6fb7abc784e54a227998bf3e9c39790e63cf # v0.8.0
+    uses: rhalbersma/cpp-ci/.github/workflows/clang-format.yml@e2886b13f6fcd1eceb231652f816b016de41be1d # v0.8.1
     with:
       # benchmark/ too: the shared default is "include test", but this
       # repository also carries a benchmark tree of hand-written sources.

--- a/.github/workflows/clang-libc++.yml
+++ b/.github/workflows/clang-libc++.yml
@@ -30,4 +30,4 @@ jobs:
   # missed. The old single "23-SVN libc++" leg is what this replaces; running
   # the whole ladder is what makes "which rung fixed it" answerable.
   clang_libcxx:
-    uses: rhalbersma/cpp-ci/.github/workflows/clang-libc++.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1
+    uses: rhalbersma/cpp-ci/.github/workflows/clang-libc++.yml@e2886b13f6fcd1eceb231652f816b016de41be1d # v0.8.1

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   clang_tidy:
-    uses: rhalbersma/cpp-ci/.github/workflows/clang-tidy.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1
+    uses: rhalbersma/cpp-ci/.github/workflows/clang-tidy.yml@676e6fb7abc784e54a227998bf3e9c39790e63cf # v0.8.0
     with:
       # The generated per-header units alone, as run-clang-tidy matches them
       # against the compile database's absolute paths. No sources_regex: the

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   clang_tidy:
-    uses: rhalbersma/cpp-ci/.github/workflows/clang-tidy.yml@676e6fb7abc784e54a227998bf3e9c39790e63cf # v0.8.0
+    uses: rhalbersma/cpp-ci/.github/workflows/clang-tidy.yml@e2886b13f6fcd1eceb231652f816b016de41be1d # v0.8.1
     with:
       # The generated per-header units alone, as run-clang-tidy matches them
       # against the compile database's absolute paths. No sources_regex: the

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -30,4 +30,4 @@ jobs:
   # Clang rung with a matching GCC rung for that libstdc++ rather than
   # pointing every rung at one version of it.
   clang:
-    uses: rhalbersma/cpp-ci/.github/workflows/clang.yml@676e6fb7abc784e54a227998bf3e9c39790e63cf # v0.8.0
+    uses: rhalbersma/cpp-ci/.github/workflows/clang.yml@e2886b13f6fcd1eceb231652f816b016de41be1d # v0.8.1

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -30,4 +30,4 @@ jobs:
   # Clang rung with a matching GCC rung for that libstdc++ rather than
   # pointing every rung at one version of it.
   clang:
-    uses: rhalbersma/cpp-ci/.github/workflows/clang.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1
+    uses: rhalbersma/cpp-ci/.github/workflows/clang.yml@676e6fb7abc784e54a227998bf3e9c39790e63cf # v0.8.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,4 +26,4 @@ jobs:
   # No inputs: c-cpp with security-extended is what the local job ran and
   # what the shared workflow defaults to.
   codeql:
-    uses: rhalbersma/cpp-ci/.github/workflows/codeql.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1
+    uses: rhalbersma/cpp-ci/.github/workflows/codeql.yml@676e6fb7abc784e54a227998bf3e9c39790e63cf # v0.8.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,4 +26,4 @@ jobs:
   # No inputs: c-cpp with security-extended is what the local job ran and
   # what the shared workflow defaults to.
   codeql:
-    uses: rhalbersma/cpp-ci/.github/workflows/codeql.yml@676e6fb7abc784e54a227998bf3e9c39790e63cf # v0.8.0
+    uses: rhalbersma/cpp-ci/.github/workflows/codeql.yml@e2886b13f6fcd1eceb231652f816b016de41be1d # v0.8.1

--- a/.github/workflows/consumption.yml
+++ b/.github/workflows/consumption.yml
@@ -29,7 +29,7 @@ jobs:
   # run of the stub. Both inputs default to off for the callers that need
   # neither.
   consumption:
-    uses: rhalbersma/cpp-ci/.github/workflows/consumption.yml@676e6fb7abc784e54a227998bf3e9c39790e63cf # v0.8.0
+    uses: rhalbersma/cpp-ci/.github/workflows/consumption.yml@e2886b13f6fcd1eceb231652f816b016de41be1d # v0.8.1
     with:
       # CMakeLists.txt does an unconditional
       # find_package(boost_hash2 CONFIG REQUIRED), so even the

--- a/.github/workflows/consumption.yml
+++ b/.github/workflows/consumption.yml
@@ -29,7 +29,7 @@ jobs:
   # run of the stub. Both inputs default to off for the callers that need
   # neither.
   consumption:
-    uses: rhalbersma/cpp-ci/.github/workflows/consumption.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1
+    uses: rhalbersma/cpp-ci/.github/workflows/consumption.yml@676e6fb7abc784e54a227998bf3e9c39790e63cf # v0.8.0
     with:
       # CMakeLists.txt does an unconditional
       # find_package(boost_hash2 CONFIG REQUIRED), so even the

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   coverage:
-    uses: rhalbersma/cpp-ci/.github/workflows/coverage.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1
+    uses: rhalbersma/cpp-ci/.github/workflows/coverage.yml@676e6fb7abc784e54a227998bf3e9c39790e63cf # v0.8.0
     with:
       # benchmark/ as well as the shared default: unlike xstd, this
       # repository ships a benchmark tree, which measures the library rather

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   coverage:
-    uses: rhalbersma/cpp-ci/.github/workflows/coverage.yml@676e6fb7abc784e54a227998bf3e9c39790e63cf # v0.8.0
+    uses: rhalbersma/cpp-ci/.github/workflows/coverage.yml@e2886b13f6fcd1eceb231652f816b016de41be1d # v0.8.1
     with:
       # benchmark/ as well as the shared default: unlike xstd, this
       # repository ships a benchmark tree, which measures the library rather

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -27,4 +27,4 @@ jobs:
   # x64-linux-gcc-trunk overlay triplet that rebuilt the dependencies with
   # the trunk snapshot's own libstdc++.
   gcc:
-    uses: rhalbersma/cpp-ci/.github/workflows/gcc.yml@676e6fb7abc784e54a227998bf3e9c39790e63cf # v0.8.0
+    uses: rhalbersma/cpp-ci/.github/workflows/gcc.yml@e2886b13f6fcd1eceb231652f816b016de41be1d # v0.8.1

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -27,4 +27,4 @@ jobs:
   # x64-linux-gcc-trunk overlay triplet that rebuilt the dependencies with
   # the trunk snapshot's own libstdc++.
   gcc:
-    uses: rhalbersma/cpp-ci/.github/workflows/gcc.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1
+    uses: rhalbersma/cpp-ci/.github/workflows/gcc.yml@676e6fb7abc784e54a227998bf3e9c39790e63cf # v0.8.0

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -26,4 +26,4 @@ jobs:
   # been published between stable branches - now lives in cpp-ci's
   # install-winlibs action.
   mingw:
-    uses: rhalbersma/cpp-ci/.github/workflows/mingw.yml@676e6fb7abc784e54a227998bf3e9c39790e63cf # v0.8.0
+    uses: rhalbersma/cpp-ci/.github/workflows/mingw.yml@e2886b13f6fcd1eceb231652f816b016de41be1d # v0.8.1

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -26,4 +26,4 @@ jobs:
   # been published between stable branches - now lives in cpp-ci's
   # install-winlibs action.
   mingw:
-    uses: rhalbersma/cpp-ci/.github/workflows/mingw.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1
+    uses: rhalbersma/cpp-ci/.github/workflows/mingw.yml@676e6fb7abc784e54a227998bf3e9c39790e63cf # v0.8.0

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -32,4 +32,4 @@ jobs:
   #
   # The toolset input is left at its default, which is the MSVC one.
   msvc:
-    uses: rhalbersma/cpp-ci/.github/workflows/visual-studio.yml@676e6fb7abc784e54a227998bf3e9c39790e63cf # v0.8.0
+    uses: rhalbersma/cpp-ci/.github/workflows/visual-studio.yml@e2886b13f6fcd1eceb231652f816b016de41be1d # v0.8.1

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -32,4 +32,4 @@ jobs:
   #
   # The toolset input is left at its default, which is the MSVC one.
   msvc:
-    uses: rhalbersma/cpp-ci/.github/workflows/visual-studio.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1
+    uses: rhalbersma/cpp-ci/.github/workflows/visual-studio.yml@676e6fb7abc784e54a227998bf3e9c39790e63cf # v0.8.0

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -24,7 +24,7 @@ jobs:
   # Leak detection is on; the local ASan leg this replaced ran with
   # detect_leaks=0.
   sanitizers:
-    uses: rhalbersma/cpp-ci/.github/workflows/sanitizers.yml@676e6fb7abc784e54a227998bf3e9c39790e63cf # v0.8.0
+    uses: rhalbersma/cpp-ci/.github/workflows/sanitizers.yml@e2886b13f6fcd1eceb231652f816b016de41be1d # v0.8.1
     with:
       # No ASan libc++ leg. Not because the sanitizer says anything different
       # there, but because this library does not compile against libc++ at all

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -25,7 +25,7 @@ jobs:
   # libraries, and turns leak detection on - the local ASan leg ran with
   # detect_leaks=0.
   sanitizers:
-    uses: rhalbersma/cpp-ci/.github/workflows/sanitizers.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1
+    uses: rhalbersma/cpp-ci/.github/workflows/sanitizers.yml@676e6fb7abc784e54a227998bf3e9c39790e63cf # v0.8.0
     with:
       # No ASan libc++ leg. Not because the sanitizer says anything different
       # there, but because this library does not compile against libc++ at all

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -20,9 +20,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  # No inputs: every leg on every rung its compiler fills. This replaces two
-  # GCC-only legs with five across both compilers and both standard
-  # libraries, and turns leak detection on - the local ASan leg ran with
+  # Every leg on every rung its compiler fills, less the libc++ one below.
+  # Leak detection is on; the local ASan leg this replaced ran with
   # detect_leaks=0.
   sanitizers:
     uses: rhalbersma/cpp-ci/.github/workflows/sanitizers.yml@676e6fb7abc784e54a227998bf3e9c39790e63cf # v0.8.0

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,4 +32,4 @@ jobs:
       security-events: write
       id-token: write
       actions: read
-    uses: rhalbersma/cpp-ci/.github/workflows/scorecard.yml@847e9ccde5651430e1dbe2cef53c85c1d3df0b90 # v0.6.1
+    uses: rhalbersma/cpp-ci/.github/workflows/scorecard.yml@676e6fb7abc784e54a227998bf3e9c39790e63cf # v0.8.0

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,4 +32,4 @@ jobs:
       security-events: write
       id-token: write
       actions: read
-    uses: rhalbersma/cpp-ci/.github/workflows/scorecard.yml@676e6fb7abc784e54a227998bf3e9c39790e63cf # v0.8.0
+    uses: rhalbersma/cpp-ci/.github/workflows/scorecard.yml@e2886b13f6fcd1eceb231652f816b016de41be1d # v0.8.1


### PR DESCRIPTION
Fifteen pins, `847e9cc` (v0.6.1) → `e2886b1` (v0.8.1). Skipping v0.7.0 and v0.7.1 — both touched `msvc-analyze.yml`, which this repository does not call.

Opened against v0.8.0 and corrected twice — see below for both.

## What arrives

**The MinGW legs pass `-Wa,-muse-unaligned-vector-move`.** #56 added the same flag to `test/` and `benchmark/`. Carrying it in both places is deliberate rather than redundant: the CMake genex covers a local MinGW build and anyone consuming this library outside this CI, the workflow covers the ladder. The flag is idempotent, so the overlap costs nothing.

**The MinGW development rung is gone**, so two check names stop existing:

```
mingw / 17-SVN Debug
mingw / 17-SVN Release
```

`mingw / 15 *`, `mingw / 16 *` and `mingw / all` are unchanged. That rung resolved to `winlibs-16.0.1-snapshot20260222` — a February GCC **16.0.1** snapshot, older than the 16.2.0 the qualification rung runs, which is why #54's findings were misattributed to "the 17 snapshot". rhalbersma/cpp-ci#32 has the detail.

⚠️ **If either `17-SVN` name is a required check in this repository's branch protection, this PR will sit on *"Expected — waiting for status"* forever.** `mingw / all` is the gate that does not move.

## Why this says v0.8.1 and not v0.8.0

v0.8.0 did not drop the rung for anyone. cpp-ci's workflows resolve their ladder through an internally pinned action, and `toolchains.json` lives inside that action; those internal pins were three commits stale, so callers kept reading the old three-rung table. rhalbersma/xstd#214 ran six mingw legs on its v0.8.0 commit, which is how it was found. rhalbersma/cpp-ci#34 repins them, and v0.8.1 is that fix.

The assembler flag was never affected — it lives in `mingw.yml` itself, which a caller reads at its own pin. Only the rung drop was inert.

## And why there is a fourth commit

The repin commits covered **fourteen** files, not fifteen. `clang-libc++.yml` is the only stub whose name contains a `+`, and the regex driving the sweep used a filename class of `[A-Za-z0-9._-]`. It never matched, so that one file sat at v0.6.1 while everything around it moved twice.

Nothing failed, which is what made it invisible: a stale pin still resolves, so `clang_libcxx` simply kept running against v0.6.1's ladder. Same shape as the defect above, one level out — pins individually valid, collectively wrong, green throughout.

All fifteen now name `e2886b1`, verified with a class that admits `+`.

## One change that is not a pin

`ef88bc2` rewrites three lines of comment at the top of `sanitizers.yml`. The header claimed the stub passes no inputs, runs every leg on every rung, and covers both standard libraries — none of which survived `libcxx_tiers: ""` being added below it. Read together the two comments said the ASan libc++ leg both runs and does not, which is the precise question raised by twelve sanitizer legs passing while `clang-libc++.yml` is red.

It rides along rather than getting its own PR because it sits two lines above a line this PR already changes, in a file this PR already touches, and a standalone PR would spend a 39-check CI cycle on two comment lines.

## Pre-existing CI failures

`apple_clang`, `clang_libcxx` and `msvc / 2022` are red on `main` and unrelated to this diff. `apple_clang` is red on `main`'s last six runs, including at `43cd38a`, this PR's base commit, and fails at **Build** with **Configure** succeeding on all four legs.