### PR TITLE
Point MSVC's analyser at this library

### DIFF
--- a/.github/workflows/msvc-analyze.yml
+++ b/.github/workflows/msvc-analyze.yml
@@ -1,0 +1,36 @@
+#          Copyright Rein Halbersma 2014-2026.
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+name: MSVC-Analyze
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  # MSVC's /analyze, in the role clang-tidy.yml fills for Clang. New here: the
+  # analyser has never been pointed at this library.
+  #
+  # The two VS 18 rungs only. /analyze is a compiler flag rather than a
+  # separate binary, so its legs compile the whole tree -- which means the 2022
+  # leg would fail on <flat_set>, exactly as msvc.yml's does, and report
+  # nothing about the code. msvc.yml keeps that leg for reference because
+  # showing where the floor is has value there; a permanently red analysis leg
+  # has none, so this ladder starts at the floor instead. Same shape as
+  # clang-cl.yml here.
+  msvc_analyze:
+    uses: rhalbersma/cpp-ci/.github/workflows/msvc-analyze.yml@e2886b13f6fcd1eceb231652f816b016de41be1d # v0.8.1
+    with:
+      tiers: qualification,development


### PR DESCRIPTION
One new stub, `.github/workflows/msvc-analyze.yml`. Two new check names.

`/analyze` has never run over this code. It is the counterpart to `clang-tidy.yml` on the other compiler, and cpp-ci has shipped the workflow since v0.5.0 — this repository simply never called it. With rhalbersma/tabula#52, all three consumers call the same set of cpp-ci workflows, which is worth having on its own: rhalbersma/cpp-ci#26 is a design about how a caller declares what it supports, and three repositories differing only in *what they support* are a better place to reason about it than three that also differ in *what they run*.

Rebuilt on #57, so the diff here is the one new file. All sixteen cpp-ci pins in this repository name `e2886b1`.

## Two rungs, not three

```yaml
with:
  tiers: qualification,development
```

`/analyze` is a compiler flag rather than a separate binary reading a compile database, so each leg **compiles the whole tree**. A 2022 leg would stop at `<flat_set>` in `benchmark/src/set/sieve.cpp` — exactly where `msvc.yml`'s does — having said nothing at all about the code.

`msvc.yml` keeps that leg deliberately, and the README explains why: *"for reference only, to show exactly where it fails."* Showing where the floor is has value. An analysis leg that never reaches the analysis has none, so this ladder starts at the floor instead. `clang-cl.yml` here is scoped the same way, for the same reason.

New check names:

```
msvc_analyze / msvc-analyze 2026
msvc_analyze / msvc-analyze 2026-Preview
msvc_analyze / all
```

`msvc_analyze / all` is the gate to require, if any — it aggregates whatever the ladder emits, so a rung added later is covered without touching branch protection.

## Both legs passed

The first run is in and the whole workflow came back **`success`**. I expected findings and said so — a fresh analyser generation over an untouched tree under `/WX`, with cpp-ci's v0.6.0 and v0.7.0 notes as precedent for clang-tidy 23/24 and `msvc-analyze 2022`. That precedent did not hold here: MSVC's analyser reported nothing it would fail on, across VS 2026 and 2026-Preview.

So this adds working analysis coverage at no cost beyond runner time.

Worth contrasting with rhalbersma/tabula#52, the same change scoped the same way on a tree that does **not** compile under VS 18: both its legs fail, `/analyze` produces zero findings, and its 12 KB report artifact is compile errors. Same workflow, opposite value — decided entirely by whether the tree compiles on the rung, which is a property of the code rather than of the CI. That contrast is better evidence for #26 than either PR alone.

## Pre-existing CI failures

This branch carries `main`'s existing reds, and those are **not** this PR's:

| check | cause |
| :-- | :-- |
| `apple_clang` (4 legs + gate) | red on `main` for many runs; fails at Build with Configure succeeding |
| `clang_libcxx` (6 legs + gate) | missing C++23 range adaptors in libc++ |
| `msvc / 2022` (both) | no `<flat_set>`; the deliberate reference leg |

The only checks this PR is answerable for are the two `msvc_analyze` legs and their gate — all three green.