### PR TITLE
Re-point the xstd pin at main, which the merged branch's commit is not on

### DIFF
--- a/.github/workflows/consumption.yml
+++ b/.github/workflows/consumption.yml
@@ -43,4 +43,4 @@ jobs:
       # build tree, so without this the package this library installs is
       # invalid and the consumer fails to configure against it.
       dependency_repos: |
-        https://github.com/rhalbersma/xstd.git dad4ef60368187766835408e5a955edbca572296
+        https://github.com/rhalbersma/xstd.git ef66c2bd31e44a2bfff64b7acc6fdae06afe6c75

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,12 +34,13 @@ if(NOT xstd_FOUND)
         # renames, rather than discovering it from CI.
         #
         # This bump renames aligned_size(alignment, size) to align_up(value,
-        # alignment); it points at rhalbersma/xstd#215 until that merges.
+        # alignment), from rhalbersma/xstd#215. Name a commit on xstd's main,
+        # not a pull request branch head, which merging leaves on no branch.
         # Move .github/workflows/consumption.yml's dependency_repos with this:
         # the find_package consumer builds against an installed xstd from
         # there, not against this fallback, so a stale pin there fails only
         # that one job, with a rename error this configure never sees.
-        GIT_TAG dad4ef60368187766835408e5a955edbca572296
+        GIT_TAG ef66c2bd31e44a2bfff64b7acc6fdae06afe6c75
     )
     FetchContent_MakeAvailable(xstd)
 endif()


### PR DESCRIPTION
**This fixes a red `main`.** Follow-up to #62, which merged twenty seconds before this bump was pushed to it.

## What broke

rhalbersma/xstd#215 merged as `ef66c2b`. Both pins here still name `dad4ef6`, a commit on that pull request's branch — and the squash merge left it on no branch of xstd at all. It is not merely stale: it no longer resolves.

`main` went red on the merge commit, in every job that fetches xstd:

```
DEPENDENCY_REPOS: https://github.com/rhalbersma/xstd.git dad4ef6...
fatal: unable to read tree (dad4ef60368187766835408e5a955edbca572296)
```

`consumption / Consume` dies there in *Install the dependency repositories*, before it configures anything; the compiling ladders die the same way inside FetchContent. Nothing is wrong with the tree — the identical source was green as #62's head `b0f5bdc`, back when the branch carrying `dad4ef6` still existed. The pin outlived the branch.

## The change

| file | pin |
| :--- | :--- |
| `CMakeLists.txt` | `GIT_TAG`, for the FetchContent fallback |
| `.github/workflows/consumption.yml` | `dependency_repos`, for the installed xstd |

Both move to `ef66c2b` together, as the comment beside them says they must: the `find_package` consumer builds against an installed xstd from the latter rather than the fallback, so a pin left behind there fails that one job alone, with a rename error this library's own configure never sees. Here they failed together, both being unfetchable rather than wrong.

The comment gains one line for what this cost — name a commit on `main`, not a branch head, which merging leaves on no branch.

## Verification

`consumption / Consume` passed on this branch at 13:34, against an xstd installed from `ef66c2b` — the same gate that is red on `main`.

The local toolchain here is GCC 13 / Clang 18, below this repo's GCC 15+ / Clang 22+ floor, so nothing was built through CMake. Checked against a checkout of `ef66c2b`, with Boost.Hash2 stubbed:

- `xstd/bit/array.hpp` and `xstd/bit_array.hpp` compile clean under Clang — both `align_up` call sites, re-run after the rebase onto `main`.
- The rounding is unchanged at every site: `bit::array<100, uint8_t>::num_bits == 104` over 13 blocks, `<100, uint64_t>` is 128, `<0, …>` and `<64, uint64_t>` stand still; `aligned::bit_array<100, uint8_t>` is still `bit_array<104, …>` and `<100, uint64_t>` still `<128, …>`.
- `xstd/bit_set.hpp`'s call site is identical to `bit_array.hpp`'s, but that header does not compile locally, on `std::from_range_t` — pre-existing and unrelated to this change.