### PR TITLE
Follow xstd's core/ints split: alignment now lives in ints

### DIFF
--- a/.github/workflows/consumption.yml
+++ b/.github/workflows/consumption.yml
@@ -43,4 +43,4 @@ jobs:
       # build tree, so without this the package this library installs is
       # invalid and the consumer fails to configure against it.
       dependency_repos: |
-        https://github.com/rhalbersma/xstd.git 1ce2e2e521bb0c07009922c9631fdffaab94cf9d
+        https://github.com/rhalbersma/xstd.git 42ab0d409fc9118ea0dc8846508ea62e97b90c7e

--- a/.github/workflows/consumption.yml
+++ b/.github/workflows/consumption.yml
@@ -43,4 +43,4 @@ jobs:
       # build tree, so without this the package this library installs is
       # invalid and the consumer fails to configure against it.
       dependency_repos: |
-        https://github.com/rhalbersma/xstd.git ef66c2bd31e44a2bfff64b7acc6fdae06afe6c75
+        https://github.com/rhalbersma/xstd.git 1ce2e2e521bb0c07009922c9631fdffaab94cf9d

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,16 +34,18 @@ if(NOT xstd_FOUND)
         # relocates, rather than discovering it from CI.
         #
         # This bump follows xstd's split into xstd/core and xstd/ints, from
-        # rhalbersma/xstd#223 and #226: <xstd/memory.hpp> is now
-        # <xstd/core/memory.hpp>, and align_up is constrained on the alignable
-        # concept rather than on unsigned_integer. Name a commit on xstd's
-        # main, not a pull request branch head, which merging leaves on no
-        # branch.
+        # rhalbersma/xstd#223, #226 and #227: <xstd/memory.hpp> is now
+        # <xstd/ints/memory.hpp>, alignment having landed in core and then
+        # moved to ints once alignable turned out to be an integer concept.
+        # align_up is constrained on alignable rather than on unsigned_integer,
+        # which does not reach the call sites here: they pass N as the value and
+        # the block width only as the alignment. Name a commit on xstd's main,
+        # not a pull request branch head, which merging leaves on no branch.
         # Move .github/workflows/consumption.yml's dependency_repos with this:
         # the find_package consumer builds against an installed xstd from
         # there, not against this fallback, so a stale pin there fails only
         # that one job, with a rename error this configure never sees.
-        GIT_TAG 1ce2e2e521bb0c07009922c9631fdffaab94cf9d
+        GIT_TAG 42ab0d409fc9118ea0dc8846508ea62e97b90c7e
     )
     FetchContent_MakeAvailable(xstd)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,19 +28,22 @@ if(NOT xstd_FOUND)
         xstd
         GIT_REPOSITORY https://github.com/rhalbersma/xstd.git
         # Pinned, not main. This is the only first-party dependency here and it
-        # moved under us: aligned_size left <xstd/utility.hpp> for
+        # moves under us: aligned_size left <xstd/utility.hpp> for
         # <xstd/memory.hpp>, and every compiling job went red with no commit in
         # this repository. Bump this deliberately, fixing whatever the bump
-        # renames, rather than discovering it from CI.
+        # relocates, rather than discovering it from CI.
         #
-        # This bump renames aligned_size(alignment, size) to align_up(value,
-        # alignment), from rhalbersma/xstd#215. Name a commit on xstd's main,
-        # not a pull request branch head, which merging leaves on no branch.
+        # This bump follows xstd's split into xstd/core and xstd/ints, from
+        # rhalbersma/xstd#223 and #226: <xstd/memory.hpp> is now
+        # <xstd/core/memory.hpp>, and align_up is constrained on the alignable
+        # concept rather than on unsigned_integer. Name a commit on xstd's
+        # main, not a pull request branch head, which merging leaves on no
+        # branch.
         # Move .github/workflows/consumption.yml's dependency_repos with this:
         # the find_package consumer builds against an installed xstd from
         # there, not against this fallback, so a stale pin there fails only
         # that one job, with a rename error this configure never sees.
-        GIT_TAG ef66c2bd31e44a2bfff64b7acc6fdae06afe6c75
+        GIT_TAG 1ce2e2e521bb0c07009922c9631fdffaab94cf9d
     )
     FetchContent_MakeAvailable(xstd)
 endif()

--- a/include/xstd/bit/array.hpp
+++ b/include/xstd/bit/array.hpp
@@ -8,7 +8,7 @@
 
 #include <xstd/bit/intrin.hpp>                  // countl_zero, countr_zero, popcount
 #include <xstd/bit/pred.hpp>                    // intersects, is_subset_of, not_equal_to
-#include <xstd/memory.hpp>                      // align_up
+#include <xstd/core/memory.hpp>                 // align_up
 #include <boost/hash2/hash_append_fwd.hpp>      // hash_append, hash_append_tag
 #include <algorithm>                            // all_of, any_of, fill_n, find_if, fold_left, max, shift_left, shift_right
 #include <array>                                // array

--- a/include/xstd/bit/array.hpp
+++ b/include/xstd/bit/array.hpp
@@ -8,7 +8,7 @@
 
 #include <xstd/bit/intrin.hpp>                  // countl_zero, countr_zero, popcount
 #include <xstd/bit/pred.hpp>                    // intersects, is_subset_of, not_equal_to
-#include <xstd/core/memory.hpp>                 // align_up
+#include <xstd/ints/memory.hpp>                 // align_up
 #include <boost/hash2/hash_append_fwd.hpp>      // hash_append, hash_append_tag
 #include <algorithm>                            // all_of, any_of, fill_n, find_if, fold_left, max, shift_left, shift_right
 #include <array>                                // array

--- a/include/xstd/bit_array.hpp
+++ b/include/xstd/bit_array.hpp
@@ -11,7 +11,7 @@
 #include <compare>              // strong_ordering
 #include <initializer_list>     // initializer_list
 
-#include <xstd/memory.hpp>      // align_up
+#include <xstd/core/memory.hpp> // align_up
 #include <concepts>             // unsigned_integral
 #include <cstddef>              // size_t
 #include <limits>               // digits
@@ -41,7 +41,7 @@ using bit_array = xstd::bit_array<xstd::align_up(N, static_cast<std::size_t>(std
 // NOLINTBEGIN(readability-duplicate-include): deliberate, see above
 #include <xstd/bit/array.hpp>   // array
 #include <xstd/proxy.hpp>       // begin, end, iterator, reference
-#include <xstd/memory.hpp>      // align_up
+#include <xstd/core/memory.hpp> // align_up
 #include <algorithm>            // lexicographical_compare_three_way
 #include <cassert>              // assert
 #include <compare>              // strong_ordering

--- a/include/xstd/bit_array.hpp
+++ b/include/xstd/bit_array.hpp
@@ -11,7 +11,7 @@
 #include <compare>              // strong_ordering
 #include <initializer_list>     // initializer_list
 
-#include <xstd/core/memory.hpp> // align_up
+#include <xstd/ints/memory.hpp> // align_up
 #include <concepts>             // unsigned_integral
 #include <cstddef>              // size_t
 #include <limits>               // digits
@@ -41,7 +41,7 @@ using bit_array = xstd::bit_array<xstd::align_up(N, static_cast<std::size_t>(std
 // NOLINTBEGIN(readability-duplicate-include): deliberate, see above
 #include <xstd/bit/array.hpp>   // array
 #include <xstd/proxy.hpp>       // begin, end, iterator, reference
-#include <xstd/core/memory.hpp> // align_up
+#include <xstd/ints/memory.hpp> // align_up
 #include <algorithm>            // lexicographical_compare_three_way
 #include <cassert>              // assert
 #include <compare>              // strong_ordering

--- a/include/xstd/bit_set.hpp
+++ b/include/xstd/bit_set.hpp
@@ -11,7 +11,7 @@
 #include <compare>              // strong_ordering
 #include <initializer_list>     // initializer_list
 
-#include <xstd/core/memory.hpp> // align_up
+#include <xstd/ints/memory.hpp> // align_up
 #include <concepts>             // unsigned_integral
 #include <cstddef>              // size_t
 #include <limits>               // digits

--- a/include/xstd/bit_set.hpp
+++ b/include/xstd/bit_set.hpp
@@ -11,7 +11,7 @@
 #include <compare>              // strong_ordering
 #include <initializer_list>     // initializer_list
 
-#include <xstd/memory.hpp>      // align_up
+#include <xstd/core/memory.hpp> // align_up
 #include <concepts>             // unsigned_integral
 #include <cstddef>              // size_t
 #include <limits>               // digits


### PR DESCRIPTION
## What moved

xstd split into `xstd/core` and `xstd/ints` ([rhalbersma/xstd#223](https://github.com/rhalbersma/xstd/pull/223)); `align_up`/`align_down` were freed from ints onto an `alignable` concept ([#226](https://github.com/rhalbersma/xstd/pull/226)); then that concept turned out to be `integer_class`'s opening clauses and nothing more, so it moved to ints and took alignment with it ([#227](https://github.com/rhalbersma/xstd/pull/227)).

| | before | after |
| :--- | :--- | :--- |
| header | `<xstd/memory.hpp>` | `<xstd/ints/memory.hpp>` |
| `align_up`'s constraint | `unsigned_integer` | `alignable` |

The old path is **gone** at the new pin, so the include change isn't cosmetic — it's what makes the bump compile. Both move in one commit for that reason.

`<xstd/core/memory.hpp>` was the target for exactly one pin and never reached a merge here, which is why this lands as a single bump rather than two.

## Why the constraint change doesn't reach here

All three call sites pass `N` as the value and the block width only as the alignment:

```cpp
static constexpr auto num_bits = align_up(N, bits_per_block);
using bit_set = xstd::bit_set<xstd::align_up(N, static_cast<std::size_t>(std::numeric_limits<Block>::digits)), Block>;
using bit_array = xstd::bit_array<xstd::align_up(N, static_cast<std::size_t>(std::numeric_limits<Block>::digits)), Block>;
```

So the constrained parameter is `std::size_t` throughout, never `Block`. `alignable<std::size_t>` holds, and nothing about which `Block` types this library accepts is at stake.

## The pin

`CMakeLists.txt` and `.github/workflows/consumption.yml`'s `dependency_repos` both move to `42ab0d4`, as the comment beside the pin asks — the `find_package` consumer builds against an installed xstd from there rather than the FetchContent fallback, so a stale pin in one and not the other fails exactly one job. The comment is rewritten for what this bump relocates.

## What was deliberately left alone

`bit_array.hpp` includes the header twice, at lines 14 and 44. That is on purpose — the synopsis and the implementation each list what that section needs, mirroring the standard's own layout, which is what the `NOLINTBEGIN(readability-duplicate-include)` above it is for. Both occurrences were repointed; neither was collapsed.

Each block's comment column is preserved, so no surrounding line moves.

## Verification

Against xstd checked out at the new pin `42ab0d4` (where `include/xstd/core/memory.hpp` no longer exists), with clang 18:

- `xstd/bit/array.hpp` and `xstd/bit_array.hpp` compile clean.
- The call sites were **instantiated**, not merely parsed: `bit::array<100, Block>::num_bits` forced for `unsigned char`, `unsigned short`, `unsigned`, `unsigned long`, `unsigned long long`, `uint8_t` and `uint64_t`, giving 104/112/128/128/128/104/128, plus the template-argument spelling from `bit_set.hpp` reproduced verbatim. All hold as constant expressions.
- `xstd/bit_set.hpp` resolves the new include and gets as far as `std::from_range_t`, which libstdc++ 13 doesn't ship — a toolchain limit in the sandbox, not a consequence of this change.

g++ 13 can't build this repository at all — `bit/array.hpp` uses an explicit object parameter, which needs GCC 14 — so it wasn't a usable second opinion here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY9H5sRH5fXEPv2cyTgNFH)_