### PR TITLE
Drop the MinGW development rung from the README matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,14 +430,14 @@ This library depends on the C++ Standard Library and [xstd](https://github.com/r
 | Platform | Compiler | Standard Library | Stable | Qualification | Development | CI |
 | :------- | :------- | :--------------- | :----- | :------------ | :---------- | :- |
 | Linux | GCC | libstdc++ | 15 | 16 | 17-SVN | [![GCC](https://github.com/rhalbersma/bit_set/actions/workflows/gcc.yml/badge.svg)](https://github.com/rhalbersma/bit_set/actions/workflows/gcc.yml) |
-| Windows | MinGW | libstdc++ | 15 | 16 | 17-SVN | [![MinGW](https://github.com/rhalbersma/bit_set/actions/workflows/mingw.yml/badge.svg)](https://github.com/rhalbersma/bit_set/actions/workflows/mingw.yml) |
+| Windows | MinGW | libstdc++ | 15 | 16 | — | [![MinGW](https://github.com/rhalbersma/bit_set/actions/workflows/mingw.yml/badge.svg)](https://github.com/rhalbersma/bit_set/actions/workflows/mingw.yml) |
 | Linux | Clang | libstdc++ | 22 (libstdc++ 15) | 23 (libstdc++ 16) | 24-SVN (libstdc++ 17-SVN) | [![Clang](https://github.com/rhalbersma/bit_set/actions/workflows/clang.yml/badge.svg)](https://github.com/rhalbersma/bit_set/actions/workflows/clang.yml) |
 | Linux | Clang | libc++ | 22 | 23 | 24-SVN | [![Clang-libc++](https://github.com/rhalbersma/bit_set/actions/workflows/clang-libc%2B%2B.yml/badge.svg)](https://github.com/rhalbersma/bit_set/actions/workflows/clang-libc%2B%2B.yml) |
 | macOS | AppleClang | libc++ | 17.0.0 (Xcode 16.4) | 21.0.0 (Xcode 26.6) | — | [![AppleClang](https://github.com/rhalbersma/bit_set/actions/workflows/appleclang.yml/badge.svg)](https://github.com/rhalbersma/bit_set/actions/workflows/appleclang.yml) |
 | Windows | Clang-CL | MSVC | 19.1.5 (VS 2022) | 20.1.8 (VS 2026) | 20.1.8 (VS 2026-Preview) | [![Clang-CL](https://github.com/rhalbersma/bit_set/actions/workflows/clang-cl.yml/badge.svg)](https://github.com/rhalbersma/bit_set/actions/workflows/clang-cl.yml) |
 | Windows | MSVC | MSVC | 2022 (17.11+) | 2026 | 2026-Preview | [![MSVC](https://github.com/rhalbersma/bit_set/actions/workflows/msvc.yml/badge.svg)](https://github.com/rhalbersma/bit_set/actions/workflows/msvc.yml) |
 
-`AppleClang` has no `Development` entry because Apple doesn't publish Apple Clang dev snapshots the way LLVM does; that leg tests the latest stable Xcode release from each of the two supported series.
+`AppleClang` has no `Development` entry because Apple doesn't publish Apple Clang dev snapshots the way LLVM does; that leg tests the latest stable Xcode release from each of the two supported series. `MinGW` has none either: WinLibs publishes no GCC trunk build between stable branches, and the shared workflow drops that rung with a notice rather than failing, so the row names the two that actually run. The `Linux | GCC` row keeps its `17-SVN` — that ladder is unaffected.
 
 Every leg above passes. The library no longer uses the C++23 range adaptors libc++ has not implemented (`views::cartesian_product`, `views::adjacent`, `views::pairwise_transform`, `views::stride`), and the tests probe for `<flat_set>` rather than assuming it, so the `Clang | libc++` and `AppleClang` rows and the VS 2022 legs build and run like the rest.
 


### PR DESCRIPTION
The `Windows | MinGW` row claimed `15 | 16 | 17-SVN`. The workflow runs 15 and 16.

Checked against the jobs the last MinGW ladder actually produced, on `7db5744`:

```
mingw / Resolve the ladder
mingw / 15 Debug      mingw / 15 Release
mingw / 16 Debug      mingw / 16 Release
mingw / all
```

No 17-SVN leg — while the Linux GCC ladder on that same commit did run `gcc / 17-SVN Debug` and `gcc / 17-SVN Release`. So this is specific to MinGW, not a ladder-wide change.

**Why, and why the workflow is not at fault.** WinLibs publishes no GCC trunk build between stable branches, and cpp-ci's `install-winlibs` action drops that rung with a notice rather than failing the job. The ladder is behaving as designed; only the README disagreed with it.

The cell now reads an em dash, as the `macOS | AppleClang` row already does for its own reason, and the note below the table covers both. It also states that the `Linux | GCC` row keeps its `17-SVN`, since one ladder losing a rung says nothing about the other — that distinction is the whole content of this change and is easy to lose.

`CONTRIBUTING.md` needed no edit: its required-checks table already read `mingw / all | MinGW 15 and 16`. Its `Development` sentence names `17-SVN` generically, which stays true of the GCC ladder.

Documentation only — no code, no workflow, no CI behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KN9Nqf5PjTfd75nCGx46zy

---
_Generated by [Claude Code](https://claude.ai/code/session_01KN9Nqf5PjTfd75nCGx46zy)_