### PR TITLE
Turn on the two checks xstd already runs

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -38,3 +38,10 @@ CheckOptions:
   readability-operators-representation.BinaryOperators: 'not;and;or'
   # No Boost library ships IWYU pragmas, so nothing there is attributable to a header a consumer names.
   misc-include-cleaner.IgnoreHeaders: 'boost/.*'
+  # A lambda already writes its return type after the parameter list, which is
+  # the whole of what this check is for, so for a generic one its suggestion is
+  # the vacuous "-> auto". A lambda whose deduced type is concrete is still
+  # required to name it. clang-tidy 21 began transforming lambdas; 20 silently
+  # accepts the option and does nothing with it, having said nothing about
+  # lambdas in the first place.
+  modernize-use-trailing-return-type.TransformLambdas: all_except_auto

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -24,9 +24,7 @@ Checks: >
   performance-*,
   portability-*,
   readability-*,
-  -misc-include-cleaner,
   -misc-non-private-member-variables-in-classes,
-  -modernize-use-trailing-return-type,
   -readability-avoid-nested-conditional-operator,
   -readability-identifier-length,
   -readability-named-parameter,
@@ -38,3 +36,5 @@ FormatStyle: none
 CheckOptions:
   # Prefer alternative tokens for logical operators.
   readability-operators-representation.BinaryOperators: 'not;and;or'
+  # No Boost library ships IWYU pragmas, so nothing there is attributable to a header a consumer names.
+  misc-include-cleaner.IgnoreHeaders: 'boost/.*'

--- a/include/opt/set/sieve.hpp
+++ b/include/opt/set/sieve.hpp
@@ -6,10 +6,9 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <concepts> // integral
-#include <cstddef>  // size_t
-#include <ranges>   // to
-                        // begin, end, iota, range_value_t, take_while
+#include <cstddef> // size_t
+#include <ranges>  // to
+                   // begin, end, iota, range_value_t, take_while
 
 namespace xstd {
 

--- a/include/xstd/bits/bit_array.hpp
+++ b/include/xstd/bits/bit_array.hpp
@@ -8,8 +8,7 @@
 
 // Header <array> synopsis                                           [array.syn]
 
-#include <compare>          // strong_ordering
-#include <initializer_list> // initializer_list
+#include <compare> // strong_ordering
 
 #include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer
 #include <xstd/ints/memory.hpp>                    // align_up
@@ -21,7 +20,7 @@ namespace xstd {
 // 23.3.3, class template bit_array
 template<std::size_t N, xstd::unsigned_integer Block> struct bit_array;
 
-template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr bool operator== (const bit_array<N, Block>& x, const bit_array<N, Block>& y) noexcept;
+template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr auto operator== (const bit_array<N, Block>& x, const bit_array<N, Block>& y) noexcept -> bool;
 template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr auto operator<=>(const bit_array<N, Block>& x, const bit_array<N, Block>& y) noexcept -> std::strong_ordering;
 
 // 23.3.4, specialized algorithms
@@ -43,13 +42,11 @@ using bit_array = xstd::bit_array<xstd::align_up(N, static_cast<std::size_t>(std
 #include <compare>                    // strong_ordering
 #include <cstddef>                    // ptrdiff_t, size_t
 #include <format>                     // format
-#include <initializer_list>           // initializer_list
 #include <iterator>                   // make_reverse_iterator, reverse_iterator,
 #include <limits>                     // digits
 #include <source_location>            // source_location
 #include <stdexcept>                  // out_of_range
 #include <type_traits>                // conditional_t
-#include <utility>                    // pair
 // NOLINTEND(readability-duplicate-include)
 
 // Class template array [array], Overview [array.overview]
@@ -62,12 +59,12 @@ struct bit_array
         detail::bits::array<N, Block> m_bits;
 
         // ADL rather than a specialization, because this type is ours to add hidden friends to.
-        [[nodiscard]] friend constexpr std::size_t block_count(const bit_array&) noexcept { return detail::bits::array<N, Block>::num_blocks; }
-        [[nodiscard]] friend constexpr Block block_at(const bit_array& c, std::size_t i) noexcept { return c.m_bits.block(i); }
+        [[nodiscard]] friend constexpr auto block_count(const bit_array&) noexcept -> std::size_t { return detail::bits::array<N, Block>::num_blocks; }
+        [[nodiscard]] friend constexpr auto block_at(const bit_array& c, std::size_t i) noexcept -> Block { return c.m_bits.block(i); }
 
-        [[nodiscard]] friend constexpr std::size_t find_first(const bit_array&)                  noexcept { return 0UZ;         }
-        [[nodiscard]] friend constexpr std::size_t find_last (const bit_array&)                  noexcept { return N;           }
-        [[nodiscard]] friend constexpr std::size_t find_at   (const bit_array& c, std::size_t n) noexcept { return c.m_bits[n]; }
+        [[nodiscard]] friend constexpr auto find_first(const bit_array&)                  noexcept -> std::size_t { return 0UZ;         }
+        [[nodiscard]] friend constexpr auto find_last (const bit_array&)                  noexcept -> std::size_t { return N;           }
+        [[nodiscard]] friend constexpr auto find_at   (const bit_array& c, std::size_t n) noexcept -> std::size_t { return c.m_bits[n]; }
         friend constexpr void assign_at(bit_array& c, std::size_t n, bool value) noexcept { if (value) { c.m_bits.set(n); } else { c.m_bits.reset(n); } }
 
         // types
@@ -112,9 +109,9 @@ struct bit_array
         [[nodiscard]] constexpr auto crend()   const noexcept { return rend();   }
 
         // capacity
-        [[nodiscard]] constexpr bool         empty() const noexcept { return N == 0; }
-        [[nodiscard]] constexpr size_type     size() const noexcept { return N;      }
-        [[nodiscard]] constexpr size_type max_size() const noexcept { return N;      }
+        [[nodiscard]] constexpr auto    empty() const noexcept -> bool      { return N == 0; }
+        [[nodiscard]] constexpr auto     size() const noexcept -> size_type { return N;      }
+        [[nodiscard]] constexpr auto max_size() const noexcept -> size_type { return N;      }
 
         // element access; an explicit trailing return type, because plain auto cannot deduce from a braced-init-list return.
         template<class Self>
@@ -150,7 +147,7 @@ private:
         }        
 };
 
-template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr bool operator== (const bit_array<N, Block>& x, const bit_array<N, Block>& y) noexcept { return x.m_bits == y.m_bits; }
+template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr auto operator== (const bit_array<N, Block>& x, const bit_array<N, Block>& y) noexcept -> bool { return x.m_bits == y.m_bits; }
 
 // bit_array orders as a sequence of bool over every index, which is what std::array<bool, N>'s <=> would compute.
 template<std::size_t N, xstd::unsigned_integer Block>

--- a/include/xstd/bits/bit_finite_set.hpp
+++ b/include/xstd/bits/bit_finite_set.hpp
@@ -23,13 +23,13 @@ namespace xstd {
 template<std::size_t N, xstd::unsigned_integer Block = std::size_t> 
 class bit_finite_set;
 
-template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr bool operator== (const bit_finite_set<N, Block>& x, const bit_finite_set<N, Block>& y) noexcept;
+template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr auto operator== (const bit_finite_set<N, Block>& x, const bit_finite_set<N, Block>& y) noexcept -> bool;
 template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr auto operator<=>(const bit_finite_set<N, Block>& x, const bit_finite_set<N, Block>& y) noexcept -> std::strong_ordering;
 template<std::size_t N, xstd::unsigned_integer Block>               constexpr void swap       (      bit_finite_set<N, Block>& x,       bit_finite_set<N, Block>& y) noexcept(noexcept(x.swap(y)));
 
 // 23.4.6.3, erasure for set
 template<std::size_t N, xstd::unsigned_integer Block, class Predicate>
-constexpr bit_finite_set<N, Block>::size_type erase_if(bit_finite_set<N, Block>& c, Predicate pred);
+constexpr auto erase_if(bit_finite_set<N, Block>& c, Predicate pred) -> bit_finite_set<N, Block>::size_type;
 
 namespace aligned {
 
@@ -51,12 +51,11 @@ using bit_finite_set = xstd::bit_finite_set<xstd::align_up(N, static_cast<std::s
 #include <functional>                  // less
 #include <initializer_list>            // initializer_list
 #include <iterator>                    // make_reverse_iterator, reverse_iterator,
-                                        // input_iterator, sentinel_for
-#include <limits> // digits
-#include <ranges> // begin, empty, end, from_range_t, next, rbegin, rend
-                                        // input_range
-#include <type_traits> // conditional_t
-#include <utility>     // forward, move, pair
+                                       // input_iterator, sentinel_for
+#include <limits>                      // digits
+#include <ranges>                      // begin, empty, end, from_range_t, next, rbegin, rend
+                                       // input_range
+#include <utility>                     // forward, move, pair
 // NOLINTEND(readability-duplicate-include)
 
 // Class template set [set], Overview [set.overview]
@@ -69,13 +68,13 @@ class bit_finite_set
         detail::bits::array<N, Block> m_bits{};
 
         // ADL rather than a specialization, because this type is ours to add hidden friends to.
-        [[nodiscard]] friend constexpr std::size_t block_count(const bit_finite_set&) noexcept { return detail::bits::array<N, Block>::num_blocks; }
-        [[nodiscard]] friend constexpr Block block_at(const bit_finite_set& c, std::size_t i) noexcept { return c.m_bits.block(i); }
+        [[nodiscard]] friend constexpr auto block_count(const bit_finite_set&) noexcept -> std::size_t { return detail::bits::array<N, Block>::num_blocks; }
+        [[nodiscard]] friend constexpr auto block_at(const bit_finite_set& c, std::size_t i) noexcept -> Block { return c.m_bits.block(i); }
 
-        [[nodiscard]] friend constexpr std::size_t find_first(const bit_finite_set& c)                noexcept { return c.m_bits.find_first(); }
-        [[nodiscard]] friend constexpr std::size_t find_last (const bit_finite_set& c)                noexcept { return c.m_bits.find_last();  }
-        [[nodiscard]] friend constexpr std::size_t find_next (const bit_finite_set& c, std::size_t n) noexcept { return c.m_bits.find_next(n); }
-        [[nodiscard]] friend constexpr std::size_t find_prev (const bit_finite_set& c, std::size_t n) noexcept { return c.m_bits.find_prev(n); }
+        [[nodiscard]] friend constexpr auto find_first(const bit_finite_set& c)                noexcept -> std::size_t { return c.m_bits.find_first(); }
+        [[nodiscard]] friend constexpr auto find_last (const bit_finite_set& c)                noexcept -> std::size_t { return c.m_bits.find_last();  }
+        [[nodiscard]] friend constexpr auto find_next (const bit_finite_set& c, std::size_t n) noexcept -> std::size_t { return c.m_bits.find_next(n); }
+        [[nodiscard]] friend constexpr auto find_prev (const bit_finite_set& c, std::size_t n) noexcept -> std::size_t { return c.m_bits.find_prev(n); }
 
         template<class Provider, class Hash, class Flavor>
         friend constexpr void tag_invoke(boost::hash2::hash_append_tag const&, Provider const&, Hash& h, Flavor const& f, bit_finite_set const* v) noexcept
@@ -123,14 +122,15 @@ public:
                 insert(il.begin(), il.end());
         }
 
-        constexpr bit_finite_set& operator=(std::initializer_list<value_type> il) noexcept
+        constexpr auto operator=(std::initializer_list<value_type> il) noexcept
+                -> bit_finite_set&
         {
                 m_bits.reset();
                 insert(il.begin(), il.end());
                 return *this;
         }
 
-        friend constexpr bool operator==  <>(const bit_finite_set&, const bit_finite_set&) noexcept;
+        friend constexpr auto operator==  <>(const bit_finite_set&, const bit_finite_set&) noexcept -> bool;
         friend constexpr auto operator<=> <>(const bit_finite_set&, const bit_finite_set&) noexcept -> std::strong_ordering;
 
         // iterators
@@ -145,26 +145,28 @@ public:
         [[nodiscard]] constexpr auto crend()   const noexcept { return rend();   }
 
         // capacity
-        [[nodiscard]] constexpr bool empty() const noexcept { return m_bits.none(); }
-        [[nodiscard]] constexpr bool full()  const noexcept { return m_bits.all();  }
+        [[nodiscard]] constexpr auto empty() const noexcept -> bool { return m_bits.none(); }
+        [[nodiscard]] constexpr auto full()  const noexcept -> bool { return m_bits.all();  }
 
-        [[nodiscard]]        constexpr size_type     size() const noexcept { return m_bits.count();           }
-        [[nodiscard]] static constexpr size_type max_size()       noexcept { return decltype(m_bits)::size(); }
+        [[nodiscard]]        constexpr auto     size() const noexcept -> size_type { return m_bits.count();           }
+        [[nodiscard]] static constexpr auto max_size()       noexcept -> size_type { return decltype(m_bits)::size(); }
 
         // element access
-        [[nodiscard]] constexpr reference front() const noexcept { return { *this, m_bits.find_front() }; }
-        [[nodiscard]] constexpr reference back()  const noexcept { return { *this, m_bits.find_back()  }; }
+        [[nodiscard]] constexpr auto front() const noexcept -> reference { return { *this, m_bits.find_front() }; }
+        [[nodiscard]] constexpr auto back()  const noexcept -> reference { return { *this, m_bits.find_back()  }; }
 
         // 23.4.6.4, modifiers
         template<class... Args>
-        constexpr std::pair<iterator, bool> emplace(Args&&... args) noexcept
+        constexpr auto emplace(Args&&... args) noexcept
+                -> std::pair<iterator, bool>
                 requires (sizeof...(args) == 1)
         {
                 return do_insert(value_type(std::forward<Args>(args)...));
         }
 
         template<class... Args>
-        constexpr iterator emplace_hint(const_iterator position, Args&&... args) noexcept
+        constexpr auto emplace_hint(const_iterator position, Args&&... args) noexcept
+                -> iterator
                 requires (sizeof...(args) == 1)
         {
                 return do_insert(position, value_type(std::forward<Args>(args)...));
@@ -201,19 +203,22 @@ public:
                 m_bits.set();
         }
 
-        constexpr iterator erase(const_iterator position) noexcept
+        constexpr auto erase(const_iterator position) noexcept
+                -> iterator
         {
                 assert(position != end());
                 m_bits.reset(*position++);
                 return position;
         }
 
-        constexpr size_type erase(const key_type& x) noexcept
+        constexpr auto erase(const key_type& x) noexcept
+                -> size_type
         {
                 return m_bits.erase(x);
         }
 
-        constexpr iterator erase(const_iterator first, const_iterator last) noexcept
+        constexpr auto erase(const_iterator first, const_iterator last) noexcept
+                -> iterator
         {
                 while (first != last) {
                         m_bits.reset(*first++);
@@ -241,20 +246,20 @@ public:
                 m_bits.flip();
         }
 
-        constexpr bit_finite_set& operator&=(const bit_finite_set& other) noexcept { this->m_bits &= other.m_bits; return *this; }
-        constexpr bit_finite_set& operator|=(const bit_finite_set& other) noexcept { this->m_bits |= other.m_bits; return *this; }
-        constexpr bit_finite_set& operator^=(const bit_finite_set& other) noexcept { this->m_bits ^= other.m_bits; return *this; }
-        constexpr bit_finite_set& operator-=(const bit_finite_set& other) noexcept { this->m_bits -= other.m_bits; return *this; }
+        constexpr auto operator&=(const bit_finite_set& other) noexcept -> bit_finite_set& { this->m_bits &= other.m_bits; return *this; }
+        constexpr auto operator|=(const bit_finite_set& other) noexcept -> bit_finite_set& { this->m_bits |= other.m_bits; return *this; }
+        constexpr auto operator^=(const bit_finite_set& other) noexcept -> bit_finite_set& { this->m_bits ^= other.m_bits; return *this; }
+        constexpr auto operator-=(const bit_finite_set& other) noexcept -> bit_finite_set& { this->m_bits -= other.m_bits; return *this; }
 
-        constexpr bit_finite_set& operator<<=(std::size_t n) noexcept { m_bits <<= n; return *this; }
-        constexpr bit_finite_set& operator>>=(std::size_t n) noexcept { m_bits >>= n; return *this; }
+        constexpr auto operator<<=(std::size_t n) noexcept -> bit_finite_set& { m_bits <<= n; return *this; }
+        constexpr auto operator>>=(std::size_t n) noexcept -> bit_finite_set& { m_bits >>= n; return *this; }
 
         // observers
-        [[nodiscard]] constexpr   key_compare   key_comp() const noexcept { return {}; }
-        [[nodiscard]] constexpr value_compare value_comp() const noexcept { return {}; }
+        [[nodiscard]] constexpr auto   key_comp() const noexcept -> key_compare   { return {}; }
+        [[nodiscard]] constexpr auto value_comp() const noexcept -> value_compare { return {}; }
 
         // set operations
-        [[nodiscard]] constexpr bool contains(const key_type& x) const noexcept              { return m_bits[x]; }
+        [[nodiscard]] constexpr auto contains(const key_type& x) const noexcept -> bool      { return m_bits[x]; }
         [[nodiscard]] constexpr auto count   (const key_type& x) const noexcept -> size_type { return m_bits[x]; }
 
         [[nodiscard]] constexpr auto find(this auto&& self, const key_type& x) noexcept -> iterator
@@ -268,16 +273,16 @@ public:
         [[nodiscard]] constexpr auto upper_bound(this auto&& self, const key_type& x) noexcept -> iterator                      { return { &self, find_next(self, x) };                              }
         [[nodiscard]] constexpr auto equal_range(this auto&& self, const key_type& x) noexcept -> std::pair<iterator, iterator> { return { self.lower_bound(x), self.upper_bound(x) };               }
 
-        [[nodiscard]] constexpr bool is_subset_of       (const bit_finite_set& other) const noexcept { return this->m_bits.is_subset_of       (other.m_bits); }
-        [[nodiscard]] constexpr bool is_proper_subset_of(const bit_finite_set& other) const noexcept { return this->m_bits.is_proper_subset_of(other.m_bits); }
-        [[nodiscard]] constexpr bool intersects         (const bit_finite_set& other) const noexcept { return this->m_bits.intersects         (other.m_bits); }
+        [[nodiscard]] constexpr auto is_subset_of       (const bit_finite_set& other) const noexcept -> bool { return this->m_bits.is_subset_of       (other.m_bits); }
+        [[nodiscard]] constexpr auto is_proper_subset_of(const bit_finite_set& other) const noexcept -> bool { return this->m_bits.is_proper_subset_of(other.m_bits); }
+        [[nodiscard]] constexpr auto intersects         (const bit_finite_set& other) const noexcept -> bool { return this->m_bits.intersects         (other.m_bits); }
 
 private:
         constexpr auto do_insert(                value_type x) noexcept -> std::pair<iterator, bool> {                return { { this, x }, m_bits.insert(x) }; }
         constexpr auto do_insert(const_iterator, value_type x) noexcept ->           iterator        { m_bits.set(x); return   { this, x };                     }
 };
 
-template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr bool operator== (const bit_finite_set<N, Block>& x, const bit_finite_set<N, Block>& y) noexcept { return x.m_bits == y.m_bits; }
+template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr auto operator== (const bit_finite_set<N, Block>& x, const bit_finite_set<N, Block>& y) noexcept -> bool { return x.m_bits == y.m_bits; }
 
 // bit_finite_set orders as std::set<int> does: lexicographically over its ascending sequence of set-bit indices.
 template<std::size_t N, xstd::unsigned_integer Block>
@@ -290,7 +295,8 @@ template<std::size_t N, xstd::unsigned_integer Block>               constexpr vo
 
 // 23.4.6.3 Erasure                                                [set.erasure]
 template<std::size_t N, xstd::unsigned_integer Block, class Predicate>
-constexpr bit_finite_set<N, Block>::size_type erase_if(bit_finite_set<N, Block>& c, Predicate pred)
+constexpr auto erase_if(bit_finite_set<N, Block>& c, Predicate pred)
+        -> bit_finite_set<N, Block>::size_type
 {
         auto original_size = c.size();
         for (auto i = c.begin(), last = c.end(); i != last;) {
@@ -304,15 +310,15 @@ constexpr bit_finite_set<N, Block>::size_type erase_if(bit_finite_set<N, Block>&
 }
 
 // bitwise operators
-template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr bit_finite_set<N, Block> operator~(const bit_finite_set<N, Block>& lhs) noexcept { auto nrv = lhs; nrv.complement(); return nrv; }
+template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr auto operator~(const bit_finite_set<N, Block>& lhs) noexcept -> bit_finite_set<N, Block> { auto nrv = lhs; nrv.complement(); return nrv; }
 
-template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr bit_finite_set<N, Block> operator&(const bit_finite_set<N, Block>& lhs, const bit_finite_set<N, Block>& rhs) noexcept { auto nrv = lhs; nrv &= rhs; return nrv; }
-template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr bit_finite_set<N, Block> operator|(const bit_finite_set<N, Block>& lhs, const bit_finite_set<N, Block>& rhs) noexcept { auto nrv = lhs; nrv |= rhs; return nrv; }
-template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr bit_finite_set<N, Block> operator^(const bit_finite_set<N, Block>& lhs, const bit_finite_set<N, Block>& rhs) noexcept { auto nrv = lhs; nrv ^= rhs; return nrv; }
-template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr bit_finite_set<N, Block> operator-(const bit_finite_set<N, Block>& lhs, const bit_finite_set<N, Block>& rhs) noexcept { auto nrv = lhs; nrv -= rhs; return nrv; }
+template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr auto operator&(const bit_finite_set<N, Block>& lhs, const bit_finite_set<N, Block>& rhs) noexcept -> bit_finite_set<N, Block> { auto nrv = lhs; nrv &= rhs; return nrv; }
+template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr auto operator|(const bit_finite_set<N, Block>& lhs, const bit_finite_set<N, Block>& rhs) noexcept -> bit_finite_set<N, Block> { auto nrv = lhs; nrv |= rhs; return nrv; }
+template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr auto operator^(const bit_finite_set<N, Block>& lhs, const bit_finite_set<N, Block>& rhs) noexcept -> bit_finite_set<N, Block> { auto nrv = lhs; nrv ^= rhs; return nrv; }
+template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr auto operator-(const bit_finite_set<N, Block>& lhs, const bit_finite_set<N, Block>& rhs) noexcept -> bit_finite_set<N, Block> { auto nrv = lhs; nrv -= rhs; return nrv; }
 
-template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr bit_finite_set<N, Block> operator<<(const bit_finite_set<N, Block>& lhs, std::size_t n) noexcept { auto nrv = lhs; nrv <<= n; return nrv; }
-template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr bit_finite_set<N, Block> operator>>(const bit_finite_set<N, Block>& lhs, std::size_t n) noexcept { auto nrv = lhs; nrv >>= n; return nrv; }
+template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr auto operator<<(const bit_finite_set<N, Block>& lhs, std::size_t n) noexcept -> bit_finite_set<N, Block> { auto nrv = lhs; nrv <<= n; return nrv; }
+template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr auto operator>>(const bit_finite_set<N, Block>& lhs, std::size_t n) noexcept -> bit_finite_set<N, Block> { auto nrv = lhs; nrv >>= n; return nrv; }
 
 }       // namespace xstd
 

--- a/include/xstd/bits/bitset.hpp
+++ b/include/xstd/bits/bitset.hpp
@@ -18,13 +18,13 @@ namespace xstd {
 
 template<std::size_t N, xstd::unsigned_integer Block = std::size_t> class bitset;
 
-template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr bitset<N, Block> operator&(const bitset<N, Block>&, const bitset<N, Block>&) noexcept;
-template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr bitset<N, Block> operator|(const bitset<N, Block>&, const bitset<N, Block>&) noexcept;
-template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr bitset<N, Block> operator^(const bitset<N, Block>&, const bitset<N, Block>&) noexcept;
-template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr bitset<N, Block> operator-(const bitset<N, Block>&, const bitset<N, Block>&) noexcept;
+template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr auto operator&(const bitset<N, Block>&, const bitset<N, Block>&) noexcept -> bitset<N, Block>;
+template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr auto operator|(const bitset<N, Block>&, const bitset<N, Block>&) noexcept -> bitset<N, Block>;
+template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr auto operator^(const bitset<N, Block>&, const bitset<N, Block>&) noexcept -> bitset<N, Block>;
+template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr auto operator-(const bitset<N, Block>&, const bitset<N, Block>&) noexcept -> bitset<N, Block>;
 
-template<class charT, class traits, std::size_t N, xstd::unsigned_integer Block> std::basic_istream<charT, traits>& operator>>(std::basic_istream<charT, traits>& is,       bitset<N, Block>& x);
-template<class charT, class traits, std::size_t N, xstd::unsigned_integer Block> std::basic_ostream<charT, traits>& operator<<(std::basic_ostream<charT, traits>& os, const bitset<N, Block>& x);
+template<class charT, class traits, std::size_t N, xstd::unsigned_integer Block> auto operator>>(std::basic_istream<charT, traits>& is,       bitset<N, Block>& x) -> std::basic_istream<charT, traits>&;
+template<class charT, class traits, std::size_t N, xstd::unsigned_integer Block> auto operator<<(std::basic_ostream<charT, traits>& os, const bitset<N, Block>& x) -> std::basic_ostream<charT, traits>&;
 
 }       // namespace xstd
 
@@ -32,10 +32,12 @@ template<class charT, class traits, std::size_t N, xstd::unsigned_integer Block>
 #include <boost/hash2/hash_append.hpp>     // hash_append
 #include <xstd/bits/detail/array.hpp>      // array
 #include <xstd/bits/ranges/array_view.hpp> // array_find
+#include <xstd/bits/ranges/bit_extent.hpp> // bit_extent
 #include <xstd/bits/ranges/set_view.hpp>   // set_find, set_compare
 #include <algorithm>                       // find_if, min
 #include <cassert>                         // assert
 #include <compare>                         // strong_ordering
+#include <concepts>                        // unsigned_integral
 #include <format>                          // format
 #include <functional>                      // hash
 #include <ios>                             // ios_base
@@ -57,8 +59,8 @@ class bitset
         detail::bits::array<N, Block> m_bits{};
 
         // ADL rather than a specialization, because this type is ours to add hidden friends to.
-        [[nodiscard]] friend constexpr std::size_t block_count(const bitset&) noexcept { return detail::bits::array<N, Block>::num_blocks; }
-        [[nodiscard]] friend constexpr Block block_at(const bitset& c, std::size_t i) noexcept { return c.m_bits.block(i); }
+        [[nodiscard]] friend constexpr auto block_count(const bitset&) noexcept -> std::size_t { return detail::bits::array<N, Block>::num_blocks; }
+        [[nodiscard]] friend constexpr auto block_at(const bitset& c, std::size_t i) noexcept -> Block { return c.m_bits.block(i); }
 
         template<class Provider, class Hash, class Flavor>
         friend constexpr void tag_invoke(boost::hash2::hash_append_tag const&, Provider const&, Hash& h, Flavor const& f, bitset const* v) noexcept
@@ -74,18 +76,18 @@ public:
         public:
                 constexpr reference(const reference& x) noexcept = default;
                 constexpr ~reference() = default;
-                constexpr reference& operator=(bool x) noexcept;
-                constexpr reference& operator=(const reference& x) noexcept = default;
+                constexpr auto operator=(bool x) noexcept -> reference&;
+                constexpr auto operator=(const reference& x) noexcept -> reference& = default;
                 // A proxy reference assigns through a const proxy, the shape the standard gives vector<bool>::reference.
-                constexpr const reference& operator=(bool x) const noexcept;  // NOLINT(misc-unconventional-assign-operator)
+                constexpr auto operator=(bool x) const noexcept -> const reference&;  // NOLINT(misc-unconventional-assign-operator)
                 constexpr explicit(false) operator bool() const noexcept;  // NOLINT(misc-explicit-constructor)
-                constexpr bool operator~() const noexcept;
+                constexpr auto operator~() const noexcept -> bool;
 
                 friend constexpr void swap(reference x, reference y) noexcept { bool t = x; x = y; y = t; }
                 friend constexpr void swap(reference x,     bool& y) noexcept { bool t = x; x = y; y = t; }
                 friend constexpr void swap(    bool& x, reference y) noexcept { bool t = x; x = y; y = t; }
 
-                constexpr reference& flip() noexcept;
+                constexpr auto flip() noexcept -> reference&;
         };
 
         // Constructors                                            [bitset.cons]
@@ -144,12 +146,13 @@ public:
         {}
 
         // Members                                              [bitset.members]
-        constexpr bitset& operator&=(const bitset& rhs) noexcept { m_bits &= rhs.m_bits; return *this; }
-        constexpr bitset& operator|=(const bitset& rhs) noexcept { m_bits |= rhs.m_bits; return *this; }
-        constexpr bitset& operator^=(const bitset& rhs) noexcept { m_bits ^= rhs.m_bits; return *this; }
-        constexpr bitset& operator-=(const bitset& rhs) noexcept { m_bits -= rhs.m_bits; return *this; }
+        constexpr auto operator&=(const bitset& rhs) noexcept -> bitset& { m_bits &= rhs.m_bits; return *this; }
+        constexpr auto operator|=(const bitset& rhs) noexcept -> bitset& { m_bits |= rhs.m_bits; return *this; }
+        constexpr auto operator^=(const bitset& rhs) noexcept -> bitset& { m_bits ^= rhs.m_bits; return *this; }
+        constexpr auto operator-=(const bitset& rhs) noexcept -> bitset& { m_bits -= rhs.m_bits; return *this; }
 
-        constexpr bitset& operator<<=(std::size_t pos) noexcept
+        constexpr auto operator<<=(std::size_t pos) noexcept
+                -> bitset&
         {
                 if (pos < N) {
                         m_bits <<= pos;
@@ -159,7 +162,8 @@ public:
                 return *this;
         }
 
-        constexpr bitset& operator>>=(std::size_t pos) noexcept
+        constexpr auto operator>>=(std::size_t pos) noexcept
+                -> bitset&
         {
                 if (pos < N) {
                         m_bits >>= pos;
@@ -169,16 +173,17 @@ public:
                 return *this;
         }
 
-        [[nodiscard]] constexpr bitset operator<<(std::size_t pos) const noexcept { auto nrv = *this; nrv <<= pos; return nrv; }
-        [[nodiscard]] constexpr bitset operator>>(std::size_t pos) const noexcept { auto nrv = *this; nrv >>= pos; return nrv; }
+        [[nodiscard]] constexpr auto operator<<(std::size_t pos) const noexcept -> bitset { auto nrv = *this; nrv <<= pos; return nrv; }
+        [[nodiscard]] constexpr auto operator>>(std::size_t pos) const noexcept -> bitset { auto nrv = *this; nrv >>= pos; return nrv; }
 
-        [[nodiscard]] constexpr bitset operator~() const noexcept { auto nrv = *this; nrv.flip(); return nrv; }
+        [[nodiscard]] constexpr auto operator~() const noexcept -> bitset { auto nrv = *this; nrv.flip(); return nrv; }
 
-        constexpr bitset& set  () noexcept { m_bits.set  (); return *this; }
-        constexpr bitset& reset() noexcept { m_bits.reset(); return *this; }
-        constexpr bitset& flip () noexcept { m_bits.flip (); return *this; }
+        constexpr auto set  () noexcept -> bitset& { m_bits.set  (); return *this; }
+        constexpr auto reset() noexcept -> bitset& { m_bits.reset(); return *this; }
+        constexpr auto flip () noexcept -> bitset& { m_bits.flip (); return *this; }
 
-        constexpr bitset& set(std::size_t pos, bool val = true)
+        constexpr auto set(std::size_t pos, bool val = true)
+                -> bitset&
         {
                 if (pos < N) {
                         if (val) {
@@ -191,7 +196,8 @@ public:
                 throw out_of_range(pos);
         }
 
-        constexpr bitset& reset(std::size_t pos)
+        constexpr auto reset(std::size_t pos)
+                -> bitset&
         {
                 if (pos < N) {
                         m_bits.reset(pos);
@@ -200,7 +206,8 @@ public:
                 throw out_of_range(pos);
         }
 
-        constexpr bitset& flip(std::size_t pos)
+        constexpr auto flip(std::size_t pos)
+                -> bitset&
         {
                 if (pos < N) {
                         m_bits.flip(pos);
@@ -209,22 +216,24 @@ public:
                 throw out_of_range(pos);
         }
 
-        [[nodiscard]] constexpr bool operator[](std::size_t pos) const noexcept
+        [[nodiscard]] constexpr auto operator[](std::size_t pos) const noexcept
+                -> bool
         {
                 return m_bits[pos];
         }
 
-        [[nodiscard]] constexpr reference operator[](std::size_t pos) = delete; // TODO
+        [[nodiscard]] constexpr auto operator[](std::size_t pos) -> reference = delete; // TODO
 
-        [[nodiscard]] constexpr unsigned long      to_ulong()  const = delete;  // TODO
-        [[nodiscard]] constexpr unsigned long long to_ullong() const = delete;  // TODO
+        [[nodiscard]] constexpr auto to_ulong()  const -> unsigned long      = delete;  // TODO
+        [[nodiscard]] constexpr auto to_ullong() const -> unsigned long long = delete;  // TODO
 
         template<
                 class charT = char,
                 class traits = std::char_traits<charT>,
                 class Allocator = std::allocator<charT>
         >
-        [[nodiscard]] constexpr std::basic_string<charT, traits, Allocator> to_string(charT zero = charT('0'), charT one = charT('1')) const
+        [[nodiscard]] constexpr auto to_string(charT zero = charT('0'), charT one = charT('1')) const
+                -> std::basic_string<charT, traits, Allocator>
         {
                 auto str = std::basic_string<charT, traits, Allocator>(N, zero);
                 for (auto i : std::views::iota(0UZ, N)) {
@@ -236,12 +245,13 @@ public:
         }
 
         // observers
-        [[nodiscard]] constexpr std::size_t count() const noexcept { return m_bits.count(); }
-        [[nodiscard]] constexpr std::size_t size()  const noexcept { return m_bits.size();  }
+        [[nodiscard]] constexpr auto count() const noexcept -> std::size_t { return m_bits.count(); }
+        [[nodiscard]] constexpr auto size()  const noexcept -> std::size_t { return m_bits.size();  }
 
-        [[nodiscard]] constexpr bool operator==(const bitset& rhs) const noexcept = default;
+        [[nodiscard]] constexpr auto operator==(const bitset& rhs) const noexcept -> bool = default;
 
-        [[nodiscard]] constexpr bool test(std::size_t pos) const
+        [[nodiscard]] constexpr auto test(std::size_t pos) const
+                -> bool
         {
                 if (pos < N) {
                         return m_bits[pos];
@@ -249,13 +259,13 @@ public:
                 throw out_of_range(pos);
         }
 
-        [[nodiscard]] constexpr bool all()  const noexcept { return m_bits.all();  }
-        [[nodiscard]] constexpr bool any()  const noexcept { return m_bits.any();  }
-        [[nodiscard]] constexpr bool none() const noexcept { return m_bits.none(); }
+        [[nodiscard]] constexpr auto all()  const noexcept -> bool { return m_bits.all();  }
+        [[nodiscard]] constexpr auto any()  const noexcept -> bool { return m_bits.any();  }
+        [[nodiscard]] constexpr auto none() const noexcept -> bool { return m_bits.none(); }
 
-        [[nodiscard]] constexpr bool is_subset_of       (const bitset& rhs) const noexcept { return m_bits.is_subset_of       (rhs.m_bits); }
-        [[nodiscard]] constexpr bool is_proper_subset_of(const bitset& rhs) const noexcept { return m_bits.is_proper_subset_of(rhs.m_bits); }
-        [[nodiscard]] constexpr bool intersects         (const bitset& rhs) const noexcept { return m_bits.intersects         (rhs.m_bits); }
+        [[nodiscard]] constexpr auto is_subset_of       (const bitset& rhs) const noexcept -> bool { return m_bits.is_subset_of       (rhs.m_bits); }
+        [[nodiscard]] constexpr auto is_proper_subset_of(const bitset& rhs) const noexcept -> bool { return m_bits.is_proper_subset_of(rhs.m_bits); }
+        [[nodiscard]] constexpr auto intersects         (const bitset& rhs) const noexcept -> bool { return m_bits.intersects         (rhs.m_bits); }
 
 private:
         template<class charT>
@@ -295,7 +305,8 @@ inline constexpr std::size_t bit_extent<xstd::bitset<N, Block>> = N;
 template<std::size_t N, xstd::unsigned_integer Block>
 struct set_find<xstd::bitset<N, Block>>
 {
-        [[nodiscard]] static constexpr std::size_t first(xstd::bitset<N, Block> const& c) noexcept
+        [[nodiscard]] static constexpr auto first(xstd::bitset<N, Block> const& c) noexcept
+                -> std::size_t
         {
                 if constexpr (N == 0) {
                         return N;
@@ -306,19 +317,22 @@ struct set_find<xstd::bitset<N, Block>>
                 }
         }
 
-        [[nodiscard]] static constexpr std::size_t last(xstd::bitset<N, Block> const&) noexcept
+        [[nodiscard]] static constexpr auto last(xstd::bitset<N, Block> const&) noexcept
+                -> std::size_t
         {
                 return N;
         }
 
-        [[nodiscard]] static constexpr std::size_t next(xstd::bitset<N, Block> const& c, std::size_t n) noexcept
+        [[nodiscard]] static constexpr auto next(xstd::bitset<N, Block> const& c, std::size_t n) noexcept
+                -> std::size_t
         {
                 return *std::ranges::find_if(std::views::iota(n + 1, N), [&](auto i) {
                         return c[i];
                 });
         }
 
-        [[nodiscard]] static std::size_t prev(xstd::bitset<N, Block> const& c, std::size_t n) noexcept
+        [[nodiscard]] static auto prev(xstd::bitset<N, Block> const& c, std::size_t n) noexcept
+                -> std::size_t
         {
                 assert(c.any());
                 return *std::ranges::find_if(std::views::iota(0UZ, n) | std::views::reverse, [&](auto i) {
@@ -331,16 +345,17 @@ struct set_find<xstd::bitset<N, Block>>
 template<std::size_t N, xstd::unsigned_integer Block>
 struct array_find<xstd::bitset<N, Block>>
 {
-        [[nodiscard]] static constexpr std::size_t first(xstd::bitset<N, Block> const&) noexcept { return 0UZ; }
-        [[nodiscard]] static constexpr std::size_t last (xstd::bitset<N, Block> const&) noexcept { return N;   }
-        [[nodiscard]] static constexpr bool         at  (xstd::bitset<N, Block> const& c, std::size_t n) noexcept { return c[n]; }
+        [[nodiscard]] static constexpr auto first(xstd::bitset<N, Block> const&) noexcept -> std::size_t { return 0UZ; }
+        [[nodiscard]] static constexpr auto last (xstd::bitset<N, Block> const&) noexcept -> std::size_t { return N;   }
+        [[nodiscard]] static constexpr auto at   (xstd::bitset<N, Block> const& c, std::size_t n) noexcept -> bool { return c[n]; }
 };
 
 // No <=> of its own, so opt in to the iteration-based ordering explicitly, as std::bitset and dynamic_bitset do.
 template<std::size_t N, xstd::unsigned_integer Block>
 struct set_compare<xstd::bitset<N, Block>>
 {
-        [[nodiscard]] static constexpr std::strong_ordering lexicographical_three_way(xstd::bitset<N, Block> const& x, xstd::bitset<N, Block> const& y) noexcept
+        [[nodiscard]] static constexpr auto lexicographical_three_way(xstd::bitset<N, Block> const& x, xstd::bitset<N, Block> const& y) noexcept
+                -> std::strong_ordering
         {
                 return set_three_way(set_view(x), set_view(y));
         }
@@ -356,7 +371,8 @@ namespace std {
 template<size_t N, unsigned_integral Block>
 struct hash<xstd::bitset<N, Block>>
 {
-        [[nodiscard]] constexpr std::size_t operator()(xstd::bitset<N, Block> const& v) const noexcept
+        [[nodiscard]] constexpr auto operator()(xstd::bitset<N, Block> const& v) const noexcept
+                -> std::size_t
         {
                 boost::hash2::fnv1a_64 h;
                 boost::hash2::hash_append(h, {}, v);
@@ -371,13 +387,14 @@ struct hash<xstd::bitset<N, Block>>
 namespace xstd {
 
 // bitset operators                                           [bitset.operators]
-template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr bitset<N, Block> operator&(const bitset<N, Block>& lhs, const bitset<N, Block>& rhs) noexcept { auto nrv = lhs; nrv &= rhs; return nrv; }
-template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr bitset<N, Block> operator|(const bitset<N, Block>& lhs, const bitset<N, Block>& rhs) noexcept { auto nrv = lhs; nrv |= rhs; return nrv; }
-template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr bitset<N, Block> operator^(const bitset<N, Block>& lhs, const bitset<N, Block>& rhs) noexcept { auto nrv = lhs; nrv ^= rhs; return nrv; }
-template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr bitset<N, Block> operator-(const bitset<N, Block>& lhs, const bitset<N, Block>& rhs) noexcept { auto nrv = lhs; nrv -= rhs; return nrv; }
+template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr auto operator&(const bitset<N, Block>& lhs, const bitset<N, Block>& rhs) noexcept -> bitset<N, Block> { auto nrv = lhs; nrv &= rhs; return nrv; }
+template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr auto operator|(const bitset<N, Block>& lhs, const bitset<N, Block>& rhs) noexcept -> bitset<N, Block> { auto nrv = lhs; nrv |= rhs; return nrv; }
+template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr auto operator^(const bitset<N, Block>& lhs, const bitset<N, Block>& rhs) noexcept -> bitset<N, Block> { auto nrv = lhs; nrv ^= rhs; return nrv; }
+template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr auto operator-(const bitset<N, Block>& lhs, const bitset<N, Block>& rhs) noexcept -> bitset<N, Block> { auto nrv = lhs; nrv -= rhs; return nrv; }
 
 template<class charT, class traits, std::size_t N, xstd::unsigned_integer Block>
-std::basic_istream<charT, traits>& operator>>(std::basic_istream<charT, traits>& is, bitset<N, Block>& x)
+auto operator>>(std::basic_istream<charT, traits>& is, bitset<N, Block>& x)
+        -> std::basic_istream<charT, traits>&
 {
         auto str = std::basic_string<charT, traits>(N, is.widen('0'));
         auto state = std::ios_base::goodbit;
@@ -406,7 +423,8 @@ std::basic_istream<charT, traits>& operator>>(std::basic_istream<charT, traits>&
 }
 
 template<class charT, class traits, std::size_t N, xstd::unsigned_integer Block>
-std::basic_ostream<charT, traits>& operator<<(std::basic_ostream<charT, traits>& os, const bitset<N, Block>& x)
+auto operator<<(std::basic_ostream<charT, traits>& os, const bitset<N, Block>& x)
+        -> std::basic_ostream<charT, traits>&
 {
         return os << x.template to_string<charT, traits, std::allocator<charT>>(
                 std::use_facet<std::ctype<charT>>(os.getloc()).widen('0'),

--- a/include/xstd/bits/detail/array.hpp
+++ b/include/xstd/bits/detail/array.hpp
@@ -17,11 +17,12 @@
 #include <cassert>                                 // assert
 #include <cstddef>                                 // ptrdiff_t, size_t
 #include <functional>                              // plus
+#include <iterator>                                // distance, prev, random_access_iterator, sized_sentinel_for
 #include <limits>                                  // digits
-#include <ranges>                                  // distance, prev (views::drop_last when P22014R2 is accepted)
-                                                // drop, iota, reverse, take, transform, zip
-#include <type_traits> // conditional_t, is_const_v, is_nothrow_swappable_v, remove_reference_t
-#include <utility>     // pair
+#include <ranges>                                  // drop, iota, reverse, take, transform, zip
+                                                   // (views::drop_last when P22014R2 is accepted)
+#include <type_traits>                             // conditional_t, is_const_v, is_nothrow_swappable_v, remove_reference_t
+#include <utility>                                 // pair
 
 namespace xstd::detail::bits {
 
@@ -35,12 +36,14 @@ struct array
         std::array<Block, num_blocks> m_bits;
 
         // The block, for xstd::ranges::block_access; padding above N stays zero, which is what makes whole-block comparison mean anything.
-        [[nodiscard]] constexpr Block block(std::size_t i) const noexcept
+        [[nodiscard]] constexpr auto block(std::size_t i) const noexcept
+                -> Block
         {
                 return m_bits[i];
         }
 
-        [[nodiscard]] friend constexpr bool operator==(array const& x [[maybe_unused]], array const& y [[maybe_unused]]) noexcept
+        [[nodiscard]] friend constexpr auto operator==(array const& x [[maybe_unused]], array const& y [[maybe_unused]]) noexcept
+                -> bool
         {
                 if constexpr (N == 0) {
                         return true;
@@ -57,7 +60,8 @@ struct array
                 boost::hash2::hash_append(h, f, v->m_bits);
         }
 
-        [[nodiscard]] constexpr std::size_t find_front() const noexcept
+        [[nodiscard]] constexpr auto find_front() const noexcept
+                -> std::size_t
         {
                 assert(any());
                 if constexpr (num_blocks == 1) {
@@ -71,7 +75,8 @@ struct array
                 }
         }
 
-        [[nodiscard]] constexpr std::size_t find_back() const noexcept
+        [[nodiscard]] constexpr auto find_back() const noexcept
+                -> std::size_t
         {
                 assert(any());
                 if constexpr (num_blocks == 1) {
@@ -85,7 +90,8 @@ struct array
                 }
         }
 
-        [[nodiscard]] constexpr std::size_t find_first() const noexcept
+        [[nodiscard]] constexpr auto find_first() const noexcept
+                -> std::size_t
         {
                 if constexpr (N > 0 and num_blocks == 1) {
                         if (m_bits[0] != zero) {
@@ -106,12 +112,14 @@ struct array
                 return N;
         }
 
-        [[nodiscard]] constexpr std::size_t find_last() const noexcept
+        [[nodiscard]] constexpr auto find_last() const noexcept
+                -> std::size_t
         {
                 return N;
         }
 
-        [[nodiscard]] constexpr std::size_t find_next(std::size_t n) const noexcept
+        [[nodiscard]] constexpr auto find_next(std::size_t n) const noexcept
+                -> std::size_t
         {
                 ++n;
                 if (n == N) {
@@ -138,7 +146,8 @@ struct array
                 return N;
         }
 
-        [[nodiscard]] constexpr std::size_t find_prev(std::size_t n) const noexcept
+        [[nodiscard]] constexpr auto find_prev(std::size_t n) const noexcept
+                -> std::size_t
         {
                 assert(any());
                 --n;
@@ -308,7 +317,8 @@ struct array
                 assert((*this)[n]);
         }
 
-        [[nodiscard]] constexpr bool insert(std::size_t n) noexcept
+        [[nodiscard]] constexpr auto insert(std::size_t n) noexcept
+                -> bool
         {
                 assert(is_valid(n));
                 auto&& [ block, mask ] = block_mask(n);
@@ -326,7 +336,8 @@ struct array
                 assert(not (*this)[n]);
         }
 
-        [[nodiscard]] constexpr bool erase(std::size_t n) noexcept
+        [[nodiscard]] constexpr auto erase(std::size_t n) noexcept
+                -> bool
         {
                 assert(is_valid(n));
                 auto&& [ block, mask ] = block_mask(n);
@@ -343,14 +354,16 @@ struct array
                 block ^= mask;
         }
 
-        [[nodiscard]] constexpr bool operator[](std::size_t n) const noexcept
+        [[nodiscard]] constexpr auto operator[](std::size_t n) const noexcept
+                -> bool
         {
                 assert(is_valid(n));
                 auto&& [ block, mask ] = block_mask(n);
                 return detail::bits::intersects(block, mask);
         }
 
-        [[nodiscard]] constexpr std::size_t count() const noexcept
+        [[nodiscard]] constexpr auto count() const noexcept
+                -> std::size_t
         {
                 if constexpr (N == 0) {
                         return 0UZ;
@@ -366,12 +379,14 @@ struct array
                 }
         }
 
-        [[nodiscard]] static constexpr std::size_t size() noexcept
+        [[nodiscard]] static constexpr auto size() noexcept
+                -> std::size_t
         {
                 return N;
         }
 
-        [[nodiscard]] constexpr bool all() const noexcept
+        [[nodiscard]] constexpr auto all() const noexcept
+                -> bool
         {
                 if constexpr (has_unused_bits) {
                         if constexpr (num_blocks == 1) {
@@ -396,12 +411,14 @@ struct array
                 }
         }
 
-        [[nodiscard]] constexpr bool any() const noexcept
+        [[nodiscard]] constexpr auto any() const noexcept
+                -> bool
         {
                 return not none();
         }
 
-        [[nodiscard]] constexpr bool none() const noexcept
+        [[nodiscard]] constexpr auto none() const noexcept
+                -> bool
         {
                 if constexpr (N == 0) {
                         return true;
@@ -414,7 +431,8 @@ struct array
                 }
         }
 
-        [[nodiscard]] constexpr bool is_subset_of(array const& other [[maybe_unused]]) const noexcept
+        [[nodiscard]] constexpr auto is_subset_of(array const& other [[maybe_unused]]) const noexcept
+                -> bool
         {
                 if constexpr (N == 0) {
                         return true;
@@ -433,7 +451,8 @@ struct array
                 }
         }
 
-        [[nodiscard]] constexpr bool is_proper_subset_of(array const& other [[maybe_unused]]) const noexcept
+        [[nodiscard]] constexpr auto is_proper_subset_of(array const& other [[maybe_unused]]) const noexcept
+                -> bool
         {
                 if constexpr (N == 0) {
                         return false;
@@ -471,7 +490,8 @@ struct array
                 }
         }
 
-        [[nodiscard]] constexpr bool intersects(array const& other [[maybe_unused]]) const noexcept
+        [[nodiscard]] constexpr auto intersects(array const& other [[maybe_unused]]) const noexcept
+                -> bool
         {
                 if constexpr (N == 0) {
                         return false;
@@ -508,7 +528,8 @@ private:
         static constexpr auto used_bits       = static_cast<Block>(ones >> num_unused_bits);
         static constexpr auto unused_bits     = static_cast<Block>(~used_bits);
 
-        [[nodiscard]] static constexpr bool is_valid(std::size_t n [[maybe_unused]]) noexcept
+        [[nodiscard]] static constexpr auto is_valid(std::size_t n [[maybe_unused]]) noexcept
+                -> bool
         {
                 if constexpr (N == 0) {
                         // Unreachable: only an assert calls is_valid, and a bit_array<0> has no member that reaches one. Not removable either - MSVC's /W4 rejects a bare n < N as always false (C4296).

--- a/include/xstd/bits/detail/intrin.hpp
+++ b/include/xstd/bits/detail/intrin.hpp
@@ -13,17 +13,20 @@
 // The seam: constrained on xstd::unsigned_integer but forwarding to <bit>, so an xstd::popcount lands as a change of body, not interface.
 namespace xstd::detail::bits {
 
-[[nodiscard]] constexpr std::size_t countl_zero(xstd::unsigned_integer auto block) noexcept
+[[nodiscard]] constexpr auto countl_zero(xstd::unsigned_integer auto block) noexcept
+        -> std::size_t
 {
         return static_cast<std::size_t>(std::countl_zero(block));
 } 
 
-[[nodiscard]] constexpr std::size_t countr_zero(xstd::unsigned_integer auto block) noexcept
+[[nodiscard]] constexpr auto countr_zero(xstd::unsigned_integer auto block) noexcept
+        -> std::size_t
 {
         return static_cast<std::size_t>(std::countr_zero(block));
 }   
 
-[[nodiscard]] constexpr std::size_t popcount(xstd::unsigned_integer auto block) noexcept
+[[nodiscard]] constexpr auto popcount(xstd::unsigned_integer auto block) noexcept
+        -> std::size_t
 {
         return static_cast<std::size_t>(std::popcount(block));
 }

--- a/include/xstd/bits/detail/pred.hpp
+++ b/include/xstd/bits/detail/pred.hpp
@@ -11,19 +11,22 @@
 namespace xstd::detail::bits {
 
 template<xstd::unsigned_integer Block>
-[[nodiscard]] constexpr bool intersects(Block lhs, Block rhs) noexcept
+[[nodiscard]] constexpr auto intersects(Block lhs, Block rhs) noexcept
+        -> bool
 {
         return lhs & rhs;
 }   
 
 template<xstd::unsigned_integer Block>
-[[nodiscard]] constexpr bool is_subset_of(Block lhs, Block rhs) noexcept
+[[nodiscard]] constexpr auto is_subset_of(Block lhs, Block rhs) noexcept
+        -> bool
 {
         return not (lhs & static_cast<Block>(~rhs));
 }  
 
 template<xstd::unsigned_integer Block>
-[[nodiscard]] constexpr bool not_equal_to(Block lhs, Block rhs) noexcept
+[[nodiscard]] constexpr auto not_equal_to(Block lhs, Block rhs) noexcept
+        -> bool
 {
         return lhs != rhs;
 }

--- a/include/xstd/bits/ext/boost/dynamic_bitset.hpp
+++ b/include/xstd/bits/ext/boost/dynamic_bitset.hpp
@@ -23,22 +23,26 @@ namespace xstd::ranges {
 template<xstd::unsigned_integer Block, class Allocator>
 struct set_find<boost::dynamic_bitset<Block, Allocator>>
 {
-        [[nodiscard]] static constexpr std::size_t first(boost::dynamic_bitset<Block, Allocator> const& c) noexcept
+        [[nodiscard]] static constexpr auto first(boost::dynamic_bitset<Block, Allocator> const& c) noexcept
+                -> std::size_t
         {
                 return c.find_first();
         }
 
-        [[nodiscard]] static constexpr std::size_t last(boost::dynamic_bitset<Block, Allocator> const& c) noexcept
+        [[nodiscard]] static constexpr auto last(boost::dynamic_bitset<Block, Allocator> const& c) noexcept
+                -> std::size_t
         {
                 return c.npos;
         }
 
-        [[nodiscard]] static constexpr std::size_t next(boost::dynamic_bitset<Block, Allocator> const& c, std::size_t n) noexcept
+        [[nodiscard]] static constexpr auto next(boost::dynamic_bitset<Block, Allocator> const& c, std::size_t n) noexcept
+                -> std::size_t
         {
                 return c.find_next(n);
         }
 
-        [[nodiscard]] static constexpr std::size_t prev(boost::dynamic_bitset<Block, Allocator> const& c, std::size_t n) noexcept
+        [[nodiscard]] static constexpr auto prev(boost::dynamic_bitset<Block, Allocator> const& c, std::size_t n) noexcept
+                -> std::size_t
         {
                 assert(c.any());
                 return *std::ranges::find_if(std::views::iota(0UZ, std::ranges::min(n, c.size())) | std::views::reverse, [&](auto i) {
@@ -51,7 +55,8 @@ struct set_find<boost::dynamic_bitset<Block, Allocator>>
 template<xstd::unsigned_integer Block, class Allocator>
 struct set_compare<boost::dynamic_bitset<Block, Allocator>>
 {
-        [[nodiscard]] static constexpr std::strong_ordering lexicographical_three_way(boost::dynamic_bitset<Block, Allocator> const& x, boost::dynamic_bitset<Block, Allocator> const& y) noexcept
+        [[nodiscard]] static constexpr auto lexicographical_three_way(boost::dynamic_bitset<Block, Allocator> const& x, boost::dynamic_bitset<Block, Allocator> const& y) noexcept
+                -> std::strong_ordering
         {
                 return set_three_way(set_view(x), set_view(y));
         }
@@ -65,9 +70,9 @@ namespace xstd::ranges {
 template<xstd::unsigned_integer Block, class Allocator>
 struct array_find<boost::dynamic_bitset<Block, Allocator>>
 {
-        [[nodiscard]] static constexpr std::size_t first(boost::dynamic_bitset<Block, Allocator> const&) noexcept { return 0UZ; }
-        [[nodiscard]] static constexpr std::size_t last (boost::dynamic_bitset<Block, Allocator> const& c) noexcept { return c.size(); }
-        [[nodiscard]] static constexpr bool         at  (boost::dynamic_bitset<Block, Allocator> const& c, std::size_t n) noexcept { return c[n]; }
+        [[nodiscard]] static constexpr auto first(boost::dynamic_bitset<Block, Allocator> const&) noexcept -> std::size_t { return 0UZ; }
+        [[nodiscard]] static constexpr auto last (boost::dynamic_bitset<Block, Allocator> const& c) noexcept -> std::size_t { return c.size(); }
+        [[nodiscard]] static constexpr auto at   (boost::dynamic_bitset<Block, Allocator> const& c, std::size_t n) noexcept -> bool { return c[n]; }
 };
 
 

--- a/include/xstd/bits/ext/std/bitset.hpp
+++ b/include/xstd/bits/ext/std/bitset.hpp
@@ -6,18 +6,20 @@
 #ifndef XSTD_BITS_EXT_STD_BITSET_HPP
 #define XSTD_BITS_EXT_STD_BITSET_HPP
 
-#include <xstd/bits/ranges/array_view.hpp>   // find, view
-#include <xstd/bits/ranges/block_access.hpp> // block_access
-#include <xstd/bits/ranges/set_view.hpp>     // find, view
-#include <algorithm>                         // find_if
-#include <bitset>                            // bitset
-#include <cassert>                           // assert
-#include <compare>                           // strong_ordering
-#include <cstddef>                           // size_t
-#include <limits>                            // numeric_limits
-#include <ranges>                            // find_if
-#include <utility>                           // declval
-                                        // iota
+#include <xstd/bits/ranges/array_view.hpp>         // find, view
+#include <xstd/bits/ranges/bit_extent.hpp>         // bit_extent
+#include <xstd/bits/ranges/block_access.hpp>       // block_access
+#include <xstd/bits/ranges/set_view.hpp>           // find, view
+#include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer
+#include <algorithm>                               // find_if
+#include <bitset>                                  // bitset
+#include <cassert>                                 // assert
+#include <compare>                                 // strong_ordering
+#include <cstddef>                                 // size_t
+#include <limits>                                  // numeric_limits
+#include <ranges>                                  // find_if
+#include <utility>                                 // declval
+                                                   // iota
 
 // std::bitset's only associated namespace is std, where [namespace.std] forbids adding ADL hooks, so specialize set_find instead.
 namespace xstd::ranges {
@@ -29,7 +31,8 @@ inline constexpr std::size_t bit_extent<std::bitset<N>> = N;
 template<std::size_t N>
 struct set_find<std::bitset<N>>
 {
-        [[nodiscard]] static constexpr std::size_t first(const std::bitset<N>& c) noexcept
+        [[nodiscard]] static constexpr auto first(const std::bitset<N>& c) noexcept
+                -> std::size_t
         {
                 if constexpr (N == 0) {
                         return N;
@@ -42,12 +45,14 @@ struct set_find<std::bitset<N>>
                 }
         }
 
-        [[nodiscard]] static constexpr std::size_t last(const std::bitset<N>&) noexcept
+        [[nodiscard]] static constexpr auto last(const std::bitset<N>&) noexcept
+                -> std::size_t
         {
                 return N;
         }
 
-        [[nodiscard]] static constexpr std::size_t next(const std::bitset<N>& c, std::size_t n) noexcept
+        [[nodiscard]] static constexpr auto next(const std::bitset<N>& c, std::size_t n) noexcept
+                -> std::size_t
         {
                 if constexpr (requires { c._Find_next(n); }) {
                         return c._Find_next(n);
@@ -58,7 +63,8 @@ struct set_find<std::bitset<N>>
                 }
         }
 
-        [[nodiscard]] static std::size_t prev(const std::bitset<N>& c, std::size_t n) noexcept
+        [[nodiscard]] static auto prev(const std::bitset<N>& c, std::size_t n) noexcept
+                -> std::size_t
         {
                 assert(c.any());
                 return *std::ranges::find_if(std::views::iota(0UZ, n) | std::views::reverse, [&](auto i) {
@@ -71,7 +77,8 @@ struct set_find<std::bitset<N>>
 template<std::size_t N>
 struct set_compare<std::bitset<N>>
 {
-        [[nodiscard]] static constexpr std::strong_ordering lexicographical_three_way(std::bitset<N> const& x, std::bitset<N> const& y) noexcept
+        [[nodiscard]] static constexpr auto lexicographical_three_way(std::bitset<N> const& x, std::bitset<N> const& y) noexcept
+                -> std::strong_ordering
         {
                 return set_three_way(set_view(x), set_view(y));
         }
@@ -91,12 +98,14 @@ struct block_access<std::bitset<N>>
 
         static constexpr auto digits = static_cast<std::size_t>(std::numeric_limits<block_type>::digits);
 
-        [[nodiscard]] static constexpr std::size_t num_blocks(std::bitset<N> const&) noexcept
+        [[nodiscard]] static constexpr auto num_blocks(std::bitset<N> const&) noexcept
+                -> std::size_t
         {
                 return N == 0UZ ? 1UZ : (N + digits - 1UZ) / digits;
         }
 
-        [[nodiscard]] static constexpr block_type block(std::bitset<N> const& c, std::size_t i) noexcept
+        [[nodiscard]] static constexpr auto block(std::bitset<N> const& c, std::size_t i) noexcept
+                -> block_type
         {
                 return c._Getword(i);
         }
@@ -105,9 +114,9 @@ struct block_access<std::bitset<N>>
 template<std::size_t N>
 struct array_find<std::bitset<N>>
 {
-        [[nodiscard]] static constexpr std::size_t first(const std::bitset<N>&) noexcept { return 0UZ; }
-        [[nodiscard]] static constexpr std::size_t last (const std::bitset<N>&) noexcept { return N;   }
-        [[nodiscard]] static constexpr bool         at  (const std::bitset<N>& c, std::size_t n) noexcept { return c[n]; }
+        [[nodiscard]] static constexpr auto first(const std::bitset<N>&) noexcept -> std::size_t { return 0UZ; }
+        [[nodiscard]] static constexpr auto last (const std::bitset<N>&) noexcept -> std::size_t { return N;   }
+        [[nodiscard]] static constexpr auto at   (const std::bitset<N>& c, std::size_t n) noexcept -> bool { return c[n]; }
 };
 
 
@@ -119,13 +128,15 @@ namespace std {
 // NOLINTBEGIN(bugprone-std-namespace-modification)
 
 template<std::size_t N>
-bitset<N>& operator-=(bitset<N>& lhs, const bitset<N>& rhs) noexcept
+auto operator-=(bitset<N>& lhs, const bitset<N>& rhs) noexcept
+        -> bitset<N>&
 {
         return lhs &= ~rhs;
 }
 
 template<std::size_t N>
-bitset<N> operator-(const bitset<N>& lhs, const bitset<N>& rhs) noexcept
+auto operator-(const bitset<N>& lhs, const bitset<N>& rhs) noexcept
+        -> bitset<N>
 {
         auto nrv = lhs; nrv -= rhs; return nrv;
 }

--- a/include/xstd/bits/ext/xstd/bitset.hpp
+++ b/include/xstd/bits/ext/xstd/bitset.hpp
@@ -9,6 +9,7 @@
 #include <xstd/bits/bitset.hpp>                    // bitset
 #include <xstd/bits/ranges/set_view.hpp>           // begin, end
 #include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer
+#include <cstddef>                                 // size_t
 #include <iterator>                                // make_reverse_iterator
 #include <ranges>                                  // begin, end, rbegin, rend
 

--- a/include/xstd/bits/ranges/array_view.hpp
+++ b/include/xstd/bits/ranges/array_view.hpp
@@ -6,6 +6,7 @@
 #ifndef XSTD_BITS_RANGES_ARRAY_VIEW_HPP
 #define XSTD_BITS_RANGES_ARRAY_VIEW_HPP
 
+#include <xstd/bits/detail/intrin.hpp>       // countr_zero
 #include <xstd/bits/ranges/bit_extent.hpp>   // bit_extent, static_bit_extent
 #include <xstd/bits/ranges/block_access.hpp> // block_access, block_range, first_difference
 #include <algorithm>                         // equal, lexicographical_compare_three_way
@@ -27,19 +28,22 @@ namespace xstd::ranges {
 template<class Bits>
 struct array_find
 {
-        [[nodiscard]] static constexpr std::size_t first(Bits const& c) noexcept
+        [[nodiscard]] static constexpr auto first(Bits const& c) noexcept
+                -> std::size_t
                 requires requires { { find_first(c) } -> std::convertible_to<std::size_t>; }
         {
                 return find_first(c);
         }
 
-        [[nodiscard]] static constexpr std::size_t last(Bits const& c) noexcept
+        [[nodiscard]] static constexpr auto last(Bits const& c) noexcept
+                -> std::size_t
                 requires requires { { find_last(c) } -> std::convertible_to<std::size_t>; }
         {
                 return find_last(c);
         }
 
-        [[nodiscard]] static constexpr bool at(Bits const& c, std::size_t n) noexcept
+        [[nodiscard]] static constexpr auto at(Bits const& c, std::size_t n) noexcept
+                -> bool
                 requires requires { { find_at(c, n) } -> std::convertible_to<bool>; }
         {
                 return find_at(c, n);
@@ -50,7 +54,8 @@ struct array_find
 template<class Bits>
 struct array_ops
 {
-        [[nodiscard]] static constexpr std::size_t size(Bits const& c) noexcept
+        [[nodiscard]] static constexpr auto size(Bits const& c) noexcept
+                -> std::size_t
         {
                 if constexpr (static_bit_extent<Bits>) {
                         return bit_extent<Bits>;
@@ -86,7 +91,8 @@ struct array_ops
 
 // The sequence ordering, defined once: the bools in position order, compared lexicographically through value_type.
 template<std::ranges::input_range X, std::ranges::input_range Y>
-[[nodiscard]] constexpr std::strong_ordering array_three_way(X const& x, Y const& y) noexcept
+[[nodiscard]] constexpr auto array_three_way(X const& x, Y const& y) noexcept
+        -> std::strong_ordering
 {
         return std::lexicographical_compare_three_way(
                 std::ranges::begin(x), std::ranges::end(x),
@@ -97,7 +103,8 @@ template<std::ranges::input_range X, std::ranges::input_range Y>
 
 // The same ordering a word at a time; at the lowest differing bit the sequence LACKING it is smaller, with no prefix clause.
 template<block_range Bits>
-[[nodiscard]] constexpr std::strong_ordering array_three_way(Bits const& x, Bits const& y) noexcept
+[[nodiscard]] constexpr auto array_three_way(Bits const& x, Bits const& y) noexcept
+        -> std::strong_ordering
 {
         using access = block_access<Bits>;
         using block_type = decltype(access::block(x, 0UZ));
@@ -130,10 +137,10 @@ template<class, bool> class array_iterator;
 template<class, bool> class array_reference;
 
 // Forward-declared so array_iterator's dependent friend template-ids have a template to name; Clang requires it, GCC does not.
-template<array_range Bits> [[nodiscard]] constexpr array_iterator<Bits, false> array_begin(      Bits& c) noexcept;
-template<array_range Bits> [[nodiscard]] constexpr array_iterator<Bits, true > array_begin(Bits const& c) noexcept;
-template<array_range Bits> [[nodiscard]] constexpr array_iterator<Bits, false> array_end  (      Bits& c) noexcept;
-template<array_range Bits> [[nodiscard]] constexpr array_iterator<Bits, true > array_end  (Bits const& c) noexcept;
+template<array_range Bits> [[nodiscard]] constexpr auto array_begin(      Bits& c) noexcept -> array_iterator<Bits, false>;
+template<array_range Bits> [[nodiscard]] constexpr auto array_begin(Bits const& c) noexcept -> array_iterator<Bits, true >;
+template<array_range Bits> [[nodiscard]] constexpr auto array_end  (      Bits& c) noexcept -> array_iterator<Bits, false>;
+template<array_range Bits> [[nodiscard]] constexpr auto array_end  (Bits const& c) noexcept -> array_iterator<Bits, true >;
 
 template<class Bits, bool IsConst>
 class array_iterator
@@ -167,7 +174,8 @@ public:
 
         [[nodiscard]] constexpr array_iterator() noexcept = default;
 
-        [[nodiscard]] friend constexpr bool operator==(array_iterator lhs, array_iterator rhs) noexcept
+        [[nodiscard]] friend constexpr auto operator==(array_iterator lhs, array_iterator rhs) noexcept
+                -> bool
         {
                 assert(lhs.m_ptr == rhs.m_ptr);
                 return lhs.m_idx == rhs.m_idx;
@@ -180,41 +188,44 @@ public:
                 return lhs.m_idx <=> rhs.m_idx;
         }
 
-        [[nodiscard]] constexpr reference operator*() const noexcept
+        [[nodiscard]] constexpr auto operator*() const noexcept
+                -> reference
         {
                 assert(m_ptr != nullptr);
                 return { *m_ptr, m_idx };
         }
 
-        constexpr array_iterator& operator++() noexcept { ++m_idx; return *this; }
-        constexpr array_iterator& operator--() noexcept { --m_idx; return *this; }
+        constexpr auto operator++() noexcept -> array_iterator& { ++m_idx; return *this; }
+        constexpr auto operator--() noexcept -> array_iterator& { --m_idx; return *this; }
 
-        constexpr array_iterator operator++(int) noexcept { auto nrv = *this; ++*this; return nrv; }
-        constexpr array_iterator operator--(int) noexcept { auto nrv = *this; --*this; return nrv; }
+        constexpr auto operator++(int) noexcept -> array_iterator { auto nrv = *this; ++*this; return nrv; }
+        constexpr auto operator--(int) noexcept -> array_iterator { auto nrv = *this; --*this; return nrv; }
 
-        constexpr array_iterator& operator+=(difference_type n) noexcept { m_idx = static_cast<std::size_t>(static_cast<difference_type>(m_idx) + n); return *this; }
-        constexpr array_iterator& operator-=(difference_type n) noexcept { m_idx = static_cast<std::size_t>(static_cast<difference_type>(m_idx) - n); return *this; }
+        constexpr auto operator+=(difference_type n) noexcept -> array_iterator& { m_idx = static_cast<std::size_t>(static_cast<difference_type>(m_idx) + n); return *this; }
+        constexpr auto operator-=(difference_type n) noexcept -> array_iterator& { m_idx = static_cast<std::size_t>(static_cast<difference_type>(m_idx) - n); return *this; }
 
-        [[nodiscard]] friend constexpr difference_type operator-(array_iterator lhs, array_iterator rhs) noexcept
+        [[nodiscard]] friend constexpr auto operator-(array_iterator lhs, array_iterator rhs) noexcept
+                -> difference_type
         {
                 return static_cast<difference_type>(lhs.m_idx) - static_cast<difference_type>(rhs.m_idx);
         }
 
-        [[nodiscard]] constexpr reference operator[](difference_type n) const noexcept
+        [[nodiscard]] constexpr auto operator[](difference_type n) const noexcept
+                -> reference
         {
                 assert(m_ptr != nullptr);
                 return { *m_ptr, static_cast<std::size_t>(static_cast<difference_type>(m_idx) + n) };
         }
 };
 
-template<array_range Bits, bool IsConst> [[nodiscard]] constexpr array_iterator<Bits, IsConst> operator+(array_iterator<Bits, IsConst> lhs, std::ptrdiff_t n) noexcept { auto nrv = lhs; nrv += n; return nrv; }
-template<array_range Bits, bool IsConst> [[nodiscard]] constexpr array_iterator<Bits, IsConst> operator+(std::ptrdiff_t n, array_iterator<Bits, IsConst> rhs) noexcept { auto nrv = rhs; nrv += n; return nrv; }
-template<array_range Bits, bool IsConst> [[nodiscard]] constexpr array_iterator<Bits, IsConst> operator-(array_iterator<Bits, IsConst> lhs, std::ptrdiff_t n) noexcept { auto nrv = lhs; nrv -= n; return nrv; }
+template<array_range Bits, bool IsConst> [[nodiscard]] constexpr auto operator+(array_iterator<Bits, IsConst> lhs, std::ptrdiff_t n) noexcept -> array_iterator<Bits, IsConst> { auto nrv = lhs; nrv += n; return nrv; }
+template<array_range Bits, bool IsConst> [[nodiscard]] constexpr auto operator+(std::ptrdiff_t n, array_iterator<Bits, IsConst> rhs) noexcept -> array_iterator<Bits, IsConst> { auto nrv = rhs; nrv += n; return nrv; }
+template<array_range Bits, bool IsConst> [[nodiscard]] constexpr auto operator-(array_iterator<Bits, IsConst> lhs, std::ptrdiff_t n) noexcept -> array_iterator<Bits, IsConst> { auto nrv = lhs; nrv -= n; return nrv; }
 
-template<array_range Bits> [[nodiscard]] constexpr array_iterator<Bits, false> array_begin(      Bits& c) noexcept { return { &c, array_find<Bits>::first(c) }; }
-template<array_range Bits> [[nodiscard]] constexpr array_iterator<Bits, true > array_begin(Bits const& c) noexcept { return { &c, array_find<Bits>::first(c) }; }
-template<array_range Bits> [[nodiscard]] constexpr array_iterator<Bits, false> array_end  (      Bits& c) noexcept { return { &c, array_find<Bits>::last (c) }; }
-template<array_range Bits> [[nodiscard]] constexpr array_iterator<Bits, true > array_end  (Bits const& c) noexcept { return { &c, array_find<Bits>::last (c) }; }
+template<array_range Bits> [[nodiscard]] constexpr auto array_begin(      Bits& c) noexcept -> array_iterator<Bits, false> { return { &c, array_find<Bits>::first(c) }; }
+template<array_range Bits> [[nodiscard]] constexpr auto array_begin(Bits const& c) noexcept -> array_iterator<Bits, true > { return { &c, array_find<Bits>::first(c) }; }
+template<array_range Bits> [[nodiscard]] constexpr auto array_end  (      Bits& c) noexcept -> array_iterator<Bits, false> { return { &c, array_find<Bits>::last (c) }; }
+template<array_range Bits> [[nodiscard]] constexpr auto array_end  (Bits const& c) noexcept -> array_iterator<Bits, true > { return { &c, array_find<Bits>::last (c) }; }
 
 // A proxy bool assigning back into the bits, with std::vector<bool>::reference the precedent, const-qualified assignment included.
 template<class Bits, bool IsConst>
@@ -238,7 +249,8 @@ public:
         using value_type = bool;
         using iterator   = array_iterator<Bits, IsConst>;
 
-        [[nodiscard]] constexpr iterator operator&() const noexcept
+        [[nodiscard]] constexpr auto operator&() const noexcept
+                -> iterator
         {
                 return { &m_ref, m_idx };
         }
@@ -256,20 +268,23 @@ public:
         }
 
         // const-qualified and returning a const reference, the proxy shape P2321R2 gave std::vector<bool>::reference.
-        constexpr array_reference const& operator=(bool value) const noexcept  // NOLINT(misc-unconventional-assign-operator)
+        constexpr auto operator=(bool value) const noexcept  // NOLINT(misc-unconventional-assign-operator)
+                -> array_reference const&
                 requires (not IsConst) and requires(Bits& c) { array_ops<Bits>::assign(c, 0UZ, true); }
         {
                 array_ops<Bits>::assign(m_ref, m_idx, value);
                 return *this;
         }
 
-        constexpr array_reference const& operator=(array_reference const& other) const noexcept  // NOLINT(misc-unconventional-assign-operator)
+        constexpr auto operator=(array_reference const& other) const noexcept  // NOLINT(misc-unconventional-assign-operator)
+                -> array_reference const&
                 requires (not IsConst) and requires(Bits& c) { array_ops<Bits>::assign(c, 0UZ, true); }
         {
                 return *this = static_cast<bool>(other);
         }
 
-        constexpr array_reference const& flip() const noexcept
+        constexpr auto flip() const noexcept
+                -> array_reference const&
                 requires (not IsConst) and requires(Bits& c) { array_ops<Bits>::assign(c, 0UZ, true); }
         {
                 return *this = not static_cast<bool>(*this);
@@ -295,7 +310,8 @@ class array_view : public std::ranges::view_base
         Bits_cv* m_ptr;
 
         // A view is as block-accessible as the thing it views; constrained, so one over an opaque type keeps the element-wise path.
-        [[nodiscard]] friend constexpr std::size_t block_count(array_view v) noexcept
+        [[nodiscard]] friend constexpr auto block_count(array_view v) noexcept
+                -> std::size_t
                 requires block_range<bits_type>
         {
                 return block_access<bits_type>::num_blocks(*v.m_ptr);
@@ -323,19 +339,20 @@ public:
 
         [[nodiscard]] constexpr explicit array_view(Bits_cv& c) noexcept : m_ptr(&c) {}
 
-        [[nodiscard]] constexpr iterator begin() const noexcept { return array_begin(*m_ptr); }
-        [[nodiscard]] constexpr iterator end()   const noexcept { return array_end  (*m_ptr); }
+        [[nodiscard]] constexpr auto begin() const noexcept -> iterator { return array_begin(*m_ptr); }
+        [[nodiscard]] constexpr auto end()   const noexcept -> iterator { return array_end  (*m_ptr); }
 
-        [[nodiscard]] constexpr reverse_iterator rbegin() const noexcept { return std::make_reverse_iterator(end());   }
-        [[nodiscard]] constexpr reverse_iterator rend()   const noexcept { return std::make_reverse_iterator(begin()); }
+        [[nodiscard]] constexpr auto rbegin() const noexcept -> reverse_iterator { return std::make_reverse_iterator(end());   }
+        [[nodiscard]] constexpr auto rend()   const noexcept -> reverse_iterator { return std::make_reverse_iterator(begin()); }
 
-        [[nodiscard]] constexpr const_iterator         cbegin()  const noexcept { return array_begin(std::as_const(*m_ptr)); }
-        [[nodiscard]] constexpr const_iterator         cend()    const noexcept { return array_end  (std::as_const(*m_ptr)); }
-        [[nodiscard]] constexpr const_reverse_iterator crbegin() const noexcept { return std::make_reverse_iterator(cend());   }
-        [[nodiscard]] constexpr const_reverse_iterator crend()   const noexcept { return std::make_reverse_iterator(cbegin()); }
+        [[nodiscard]] constexpr auto cbegin()  const noexcept -> const_iterator         { return array_begin(std::as_const(*m_ptr)); }
+        [[nodiscard]] constexpr auto cend()    const noexcept -> const_iterator         { return array_end  (std::as_const(*m_ptr)); }
+        [[nodiscard]] constexpr auto crbegin() const noexcept -> const_reverse_iterator { return std::make_reverse_iterator(cend());   }
+        [[nodiscard]] constexpr auto crend()   const noexcept -> const_reverse_iterator { return std::make_reverse_iterator(cbegin()); }
 
         // A constant expression wherever the Bits knows its own width, which is why Extent is a parameter at all.
-        [[nodiscard]] constexpr size_type size() const noexcept
+        [[nodiscard]] constexpr auto size() const noexcept
+                -> size_type
         {
                 if constexpr (extent != std::dynamic_extent) {
                         return extent;
@@ -344,15 +361,17 @@ public:
                 }
         }
 
-        [[nodiscard]] constexpr bool empty() const noexcept { return size() == 0UZ; }
+        [[nodiscard]] constexpr auto empty() const noexcept -> bool { return size() == 0UZ; }
 
-        [[nodiscard]] constexpr reference operator[](size_type n) const noexcept
+        [[nodiscard]] constexpr auto operator[](size_type n) const noexcept
+                -> reference
         {
                 assert(n < size());
                 return *(begin() + static_cast<difference_type>(n));
         }
 
-        [[nodiscard]] constexpr reference at(size_type n) const
+        [[nodiscard]] constexpr auto at(size_type n) const
+                -> reference
         {
                 if (n >= size()) {
                         throw std::out_of_range("xstd::array_view::at");
@@ -360,8 +379,8 @@ public:
                 return (*this)[n];
         }
 
-        [[nodiscard]] constexpr reference front() const noexcept { return (*this)[0UZ]; }
-        [[nodiscard]] constexpr reference back()  const noexcept { return (*this)[size() - 1UZ]; }
+        [[nodiscard]] constexpr auto front() const noexcept -> reference { return (*this)[0UZ]; }
+        [[nodiscard]] constexpr auto back()  const noexcept -> reference { return (*this)[size() - 1UZ]; }
 
         constexpr void fill(bool value) const noexcept
                 requires (not is_const)
@@ -369,7 +388,8 @@ public:
                 ops::fill(*m_ptr, value);
         }
 
-        [[nodiscard]] friend constexpr bool operator==(array_view lhs, array_view rhs) noexcept
+        [[nodiscard]] friend constexpr auto operator==(array_view lhs, array_view rhs) noexcept
+                -> bool
         {
                 if constexpr (requires { *lhs.m_ptr == *rhs.m_ptr; }) {
                         return *lhs.m_ptr == *rhs.m_ptr;
@@ -379,7 +399,8 @@ public:
         }
 
         // Sequence order, index 0 first, always computed from the sequence: nothing to trust, and no set_compare analogue.
-        [[nodiscard]] friend constexpr std::strong_ordering operator<=>(array_view lhs, array_view rhs) noexcept
+        [[nodiscard]] friend constexpr auto operator<=>(array_view lhs, array_view rhs) noexcept
+                -> std::strong_ordering
         {
                 return array_three_way(lhs, rhs);
         }

--- a/include/xstd/bits/ranges/block_access.hpp
+++ b/include/xstd/bits/ranges/block_access.hpp
@@ -6,7 +6,6 @@
 #ifndef XSTD_BITS_RANGES_BLOCK_ACCESS_HPP
 #define XSTD_BITS_RANGES_BLOCK_ACCESS_HPP
 
-#include <xstd/bits/detail/intrin.hpp>             // countr_zero
 #include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer
 #include <cassert>                                 // assert
 #include <concepts>                                // convertible_to
@@ -21,7 +20,8 @@ namespace xstd::ranges {
 template<class Bits>
 struct block_access
 {
-        [[nodiscard]] static constexpr std::size_t num_blocks(Bits const& c) noexcept
+        [[nodiscard]] static constexpr auto num_blocks(Bits const& c) noexcept
+                -> std::size_t
                 requires requires { { block_count(c) } -> std::convertible_to<std::size_t>; }
         {
                 return block_count(c);
@@ -64,7 +64,8 @@ template<block_range Bits>
 
 // Whether x holds any position strictly above the given one, which is the whole of what separates the two orderings.
 template<block_range Bits>
-[[nodiscard]] constexpr bool any_above(Bits const& x, std::size_t index, std::size_t offset) noexcept
+[[nodiscard]] constexpr auto any_above(Bits const& x, std::size_t index, std::size_t offset) noexcept
+        -> bool
 {
         using access = block_access<Bits>;
         using block_type = decltype(access::block(x, 0UZ));

--- a/include/xstd/bits/ranges/set_view.hpp
+++ b/include/xstd/bits/ranges/set_view.hpp
@@ -6,6 +6,7 @@
 #ifndef XSTD_BITS_RANGES_SET_VIEW_HPP
 #define XSTD_BITS_RANGES_SET_VIEW_HPP
 
+#include <xstd/bits/detail/intrin.hpp>       // countr_zero
 #include <xstd/bits/ranges/bit_extent.hpp>   // bit_extent, static_bit_extent
 #include <xstd/bits/ranges/block_access.hpp> // block_access, block_range, first_difference, any_above
 #include <algorithm>                         // includes
@@ -27,25 +28,29 @@ namespace xstd::ranges {
 template<class Bits>
 struct set_find
 {
-        [[nodiscard]] static constexpr std::size_t first(Bits const& c) noexcept
+        [[nodiscard]] static constexpr auto first(Bits const& c) noexcept
+                -> std::size_t
                 requires requires { { find_first(c) } -> std::convertible_to<std::size_t>; }
         {
                 return find_first(c);
         }
 
-        [[nodiscard]] static constexpr std::size_t last(Bits const& c) noexcept
+        [[nodiscard]] static constexpr auto last(Bits const& c) noexcept
+                -> std::size_t
                 requires requires { { find_last(c) } -> std::convertible_to<std::size_t>; }
         {
                 return find_last(c);
         }
 
-        [[nodiscard]] static constexpr std::size_t next(Bits const& c, std::size_t n) noexcept
+        [[nodiscard]] static constexpr auto next(Bits const& c, std::size_t n) noexcept
+                -> std::size_t
                 requires requires { { find_next(c, n) } -> std::convertible_to<std::size_t>; }
         {
                 return find_next(c, n);
         }
 
-        [[nodiscard]] static constexpr std::size_t prev(Bits const& c, std::size_t n) noexcept
+        [[nodiscard]] static constexpr auto prev(Bits const& c, std::size_t n) noexcept
+                -> std::size_t
                 requires requires { { find_prev(c, n) } -> std::convertible_to<std::size_t>; }
         {
                 return find_prev(c, n);
@@ -64,7 +69,8 @@ template<class Bits>
 struct set_ops
 {
         // A bitset's count() is a set's size().
-        [[nodiscard]] static constexpr std::size_t size(Bits const& c) noexcept
+        [[nodiscard]] static constexpr auto size(Bits const& c) noexcept
+                -> std::size_t
         {
                 if constexpr (bitset_vocabulary<Bits>) {
                         return c.count();
@@ -74,7 +80,8 @@ struct set_ops
         }
 
         // and a bitset's size() is a set's max_size(), constant where the type declares its width.
-        [[nodiscard]] static constexpr std::size_t max_size(Bits const& c) noexcept
+        [[nodiscard]] static constexpr auto max_size(Bits const& c) noexcept
+                -> std::size_t
         {
                 if constexpr (static_bit_extent<Bits>) {
                         return bit_extent<Bits>;
@@ -85,7 +92,8 @@ struct set_ops
                 }
         }
 
-        [[nodiscard]] static constexpr bool contains(Bits const& c, std::size_t n) noexcept
+        [[nodiscard]] static constexpr auto contains(Bits const& c, std::size_t n) noexcept
+                -> bool
         {
                 if constexpr (bitset_vocabulary<Bits>) {
                         return c.test(n);
@@ -125,7 +133,8 @@ struct set_ops
 
 // The set ordering, defined once: the keys in increasing order, lexicographically, over ranges so a block path can replace it.
 template<std::ranges::input_range X, std::ranges::input_range Y>
-[[nodiscard]] constexpr std::strong_ordering set_three_way(X const& x, Y const& y) noexcept
+[[nodiscard]] constexpr auto set_three_way(X const& x, Y const& y) noexcept
+        -> std::strong_ordering
 {
         return std::lexicographical_compare_three_way(
                 std::ranges::begin(x), std::ranges::end(x),
@@ -135,7 +144,8 @@ template<std::ranges::input_range X, std::ranges::input_range Y>
 
 // The same ordering a word at a time; the set HAVING the lowest differing bit is smaller, unless the other is a prefix.
 template<block_range Bits>
-[[nodiscard]] constexpr std::strong_ordering set_three_way(Bits const& x, Bits const& y) noexcept
+[[nodiscard]] constexpr auto set_three_way(Bits const& x, Bits const& y) noexcept
+        -> std::strong_ordering
 {
         using access = block_access<Bits>;
         using block_type = decltype(access::block(x, 0UZ));
@@ -176,8 +186,8 @@ template<class> class set_reference;
 template<set_range> struct set_compare;
 
 // Forward-declared so set_iterator's dependent friend template-ids have a template to name; Clang requires it, GCC does not.
-template<set_range Bits> [[nodiscard]] constexpr set_iterator<Bits> set_begin(Bits const& c) noexcept;
-template<set_range Bits> [[nodiscard]] constexpr set_iterator<Bits> set_end  (Bits const& c) noexcept;
+template<set_range Bits> [[nodiscard]] constexpr auto set_begin(Bits const& c) noexcept -> set_iterator<Bits>;
+template<set_range Bits> [[nodiscard]] constexpr auto set_end  (Bits const& c) noexcept -> set_iterator<Bits>;
 
 template<class Bits>
 class set_iterator
@@ -209,20 +219,23 @@ public:
 
         [[nodiscard]] constexpr set_iterator() noexcept = default;
 
-        [[nodiscard]] friend constexpr bool operator==(set_iterator lhs, set_iterator rhs) noexcept
+        [[nodiscard]] friend constexpr auto operator==(set_iterator lhs, set_iterator rhs) noexcept
+                -> bool
         {
                 assert(lhs.m_ptr == rhs.m_ptr);
                 return lhs.m_idx == rhs.m_idx;
         }
 
-        [[nodiscard]] constexpr reference operator*() const noexcept
+        [[nodiscard]] constexpr auto operator*() const noexcept
+                -> reference
         {
                 assert(m_ptr != nullptr);
                 return { *m_ptr, m_idx };
         }
 
         // The assert is on its own line: the coverage job drops assert branches by matching the start of the line.
-        constexpr set_iterator& operator++() noexcept
+        constexpr auto operator++() noexcept
+                -> set_iterator&
                 requires requires (Bits const& c, std::size_t n) { set_find<Bits>::next(c, n); }
         {
                 assert(m_ptr != nullptr);
@@ -230,7 +243,8 @@ public:
                 return *this;
         }
 
-        constexpr set_iterator& operator--() noexcept
+        constexpr auto operator--() noexcept
+                -> set_iterator&
                 requires requires (Bits const& c, std::size_t n) { set_find<Bits>::prev(c, n); }
         {
                 assert(m_ptr != nullptr);
@@ -238,12 +252,12 @@ public:
                 return *this;
         }
 
-        constexpr set_iterator operator++(int) noexcept { auto nrv = *this; ++*this; return nrv; }
-        constexpr set_iterator operator--(int) noexcept { auto nrv = *this; --*this; return nrv; }
+        constexpr auto operator++(int) noexcept -> set_iterator { auto nrv = *this; ++*this; return nrv; }
+        constexpr auto operator--(int) noexcept -> set_iterator { auto nrv = *this; --*this; return nrv; }
 };
 
-template<set_range Bits> [[nodiscard]] constexpr set_iterator<Bits> set_begin(Bits const& c) noexcept { return { &c, set_find<Bits>::first(c) }; }
-template<set_range Bits> [[nodiscard]] constexpr set_iterator<Bits> set_end  (Bits const& c) noexcept { return { &c, set_find<Bits>::last (c) }; }
+template<set_range Bits> [[nodiscard]] constexpr auto set_begin(Bits const& c) noexcept -> set_iterator<Bits> { return { &c, set_find<Bits>::first(c) }; }
+template<set_range Bits> [[nodiscard]] constexpr auto set_end  (Bits const& c) noexcept -> set_iterator<Bits> { return { &c, set_find<Bits>::last (c) }; }
 
 template<class Bits>
 class set_reference
@@ -264,7 +278,8 @@ public:
         using value_type = std::size_t;
         using iterator   = set_iterator<Bits>;
 
-        [[nodiscard]] constexpr iterator operator&() const noexcept
+        [[nodiscard]] constexpr auto operator&() const noexcept
+                -> iterator
         {
                 return { &m_ref, m_idx };
         }
@@ -293,7 +308,8 @@ template<class Bits>
 template<set_range Bits>
 struct set_compare
 {
-        [[nodiscard]] static constexpr std::strong_ordering lexicographical_three_way(Bits const& x, Bits const& y) noexcept
+        [[nodiscard]] static constexpr auto lexicographical_three_way(Bits const& x, Bits const& y) noexcept
+                -> std::strong_ordering
         {
                 return x <=> y;
         }
@@ -309,7 +325,8 @@ class set_view : public std::ranges::view_base
         Bits* m_ptr;
 
         // A view is as block-accessible as the thing it views; constrained, so one over an opaque type keeps the element-wise path.
-        [[nodiscard]] friend constexpr std::size_t block_count(set_view v) noexcept
+        [[nodiscard]] friend constexpr auto block_count(set_view v) noexcept
+                -> std::size_t
                 requires block_range<bits_type>
         {
                 return block_access<bits_type>::num_blocks(*v.m_ptr);
@@ -338,27 +355,28 @@ public:
         [[nodiscard]] constexpr explicit set_view(Bits& c) noexcept : m_ptr(&c) {}
 
         // begin() and cbegin() coincide, this proxy iteration being read-only; mutation goes through insert and erase.
-        [[nodiscard]] constexpr const_iterator begin() const noexcept { return set_begin(*m_ptr); }
-        [[nodiscard]] constexpr const_iterator end()   const noexcept { return set_end  (*m_ptr); }
+        [[nodiscard]] constexpr auto begin() const noexcept -> const_iterator { return set_begin(*m_ptr); }
+        [[nodiscard]] constexpr auto end()   const noexcept -> const_iterator { return set_end  (*m_ptr); }
 
-        [[nodiscard]] constexpr const_reverse_iterator rbegin() const noexcept { return std::make_reverse_iterator(end());   }
-        [[nodiscard]] constexpr const_reverse_iterator rend()   const noexcept { return std::make_reverse_iterator(begin()); }
+        [[nodiscard]] constexpr auto rbegin() const noexcept -> const_reverse_iterator { return std::make_reverse_iterator(end());   }
+        [[nodiscard]] constexpr auto rend()   const noexcept -> const_reverse_iterator { return std::make_reverse_iterator(begin()); }
 
-        [[nodiscard]] constexpr const_iterator         cbegin()  const noexcept { return begin();  }
-        [[nodiscard]] constexpr const_iterator         cend()    const noexcept { return end();    }
-        [[nodiscard]] constexpr const_reverse_iterator crbegin() const noexcept { return rbegin(); }
-        [[nodiscard]] constexpr const_reverse_iterator crend()   const noexcept { return rend();   }
+        [[nodiscard]] constexpr auto cbegin()  const noexcept -> const_iterator         { return begin();  }
+        [[nodiscard]] constexpr auto cend()    const noexcept -> const_iterator         { return end();    }
+        [[nodiscard]] constexpr auto crbegin() const noexcept -> const_reverse_iterator { return rbegin(); }
+        [[nodiscard]] constexpr auto crend()   const noexcept -> const_reverse_iterator { return rend();   }
 
         // A bitset's none() is a set's empty(), and its count() a set's size().
-        [[nodiscard]] constexpr bool empty() const noexcept { return size() == 0UZ; }
+        [[nodiscard]] constexpr auto empty() const noexcept -> bool { return size() == 0UZ; }
 
-        [[nodiscard]] constexpr size_type size() const noexcept { return ops::size(*m_ptr); }
+        [[nodiscard]] constexpr auto size() const noexcept -> size_type { return ops::size(*m_ptr); }
 
         // Constant where the Bits knows its own width, per bit_extent.
-        [[nodiscard]] constexpr size_type max_size() const noexcept { return ops::max_size(*m_ptr); }
+        [[nodiscard]] constexpr auto max_size() const noexcept -> size_type { return ops::max_size(*m_ptr); }
 
         // Modifiers, present only where Bits is not const, returning what [set] says they return.
-        constexpr std::pair<const_iterator, bool> insert(key_type x) const noexcept
+        constexpr auto insert(key_type x) const noexcept
+                -> std::pair<const_iterator, bool>
                 requires (not std::is_const_v<Bits>)
         {
                 auto const inserted = not contains(x);
@@ -366,7 +384,8 @@ public:
                 return { const_iterator{ m_ptr, x }, inserted };
         }
 
-        constexpr const_iterator insert(const_iterator, key_type x) const noexcept
+        constexpr auto insert(const_iterator, key_type x) const noexcept
+                -> const_iterator
                 requires (not std::is_const_v<Bits>)
         {
                 ops::insert(*m_ptr, x);
@@ -389,7 +408,8 @@ public:
         }
 
         // Not [[nodiscard]], for the reason std::set::erase is not: the count is there for callers who want it.
-        constexpr size_type erase(key_type x) const noexcept  // NOLINT(modernize-use-nodiscard)
+        constexpr auto erase(key_type x) const noexcept  // NOLINT(modernize-use-nodiscard)
+                -> size_type
                 requires (not std::is_const_v<Bits>)
         {
                 auto const erased = contains(x);
@@ -397,7 +417,8 @@ public:
                 return erased;
         }
 
-        constexpr const_iterator erase(const_iterator pos) const noexcept
+        constexpr auto erase(const_iterator pos) const noexcept
+                -> const_iterator
                 requires (not std::is_const_v<Bits>)
         {
                 auto nrv = pos;
@@ -413,33 +434,38 @@ public:
         }
 
         // Lookup, all of it falling out of set_find's four operations, with no further hook.
-        [[nodiscard]] constexpr bool contains(key_type x) const noexcept { return ops::contains(*m_ptr, x); }
+        [[nodiscard]] constexpr auto contains(key_type x) const noexcept -> bool { return ops::contains(*m_ptr, x); }
 
-        [[nodiscard]] constexpr size_type count(key_type x) const noexcept { return contains(x); }
+        [[nodiscard]] constexpr auto count(key_type x) const noexcept -> size_type { return contains(x); }
 
-        [[nodiscard]] constexpr const_iterator find(key_type x) const noexcept
+        [[nodiscard]] constexpr auto find(key_type x) const noexcept
+                -> const_iterator
         {
                 return contains(x) ? const_iterator{ m_ptr, x } : end();
         }
 
         // The first element not less than x, asked about directly because stepping from x - 1 would underflow at zero.
-        [[nodiscard]] constexpr const_iterator lower_bound(key_type x) const noexcept
+        [[nodiscard]] constexpr auto lower_bound(key_type x) const noexcept
+                -> const_iterator
         {
                 return contains(x) ? const_iterator{ m_ptr, x } : upper_bound(x);
         }
 
-        [[nodiscard]] constexpr const_iterator upper_bound(key_type x) const noexcept
+        [[nodiscard]] constexpr auto upper_bound(key_type x) const noexcept
+                -> const_iterator
         {
                 return const_iterator{ m_ptr, set_find<bits_type>::next(*m_ptr, x) };
         }
 
-        [[nodiscard]] constexpr std::pair<const_iterator, const_iterator> equal_range(key_type x) const noexcept
+        [[nodiscard]] constexpr auto equal_range(key_type x) const noexcept
+                -> std::pair<const_iterator, const_iterator>
         {
                 return { lower_bound(x), upper_bound(x) };
         }
 
         // Prefer Bits' own == when it has one; equality is unambiguous either way, so this is purely an optimization.
-        [[nodiscard]] friend constexpr bool operator==(set_view lhs, set_view rhs) noexcept
+        [[nodiscard]] friend constexpr auto operator==(set_view lhs, set_view rhs) noexcept
+                -> bool
         {
                 if constexpr (requires { *lhs.m_ptr == *rhs.m_ptr; }) {
                         return *lhs.m_ptr == *rhs.m_ptr;
@@ -449,13 +475,15 @@ public:
         }
 
         // Always through set_compare, so specializing that trait changes how any set_view over the Bits orders too.
-        [[nodiscard]] friend constexpr std::strong_ordering operator<=>(set_view lhs, set_view rhs) noexcept
+        [[nodiscard]] friend constexpr auto operator<=>(set_view lhs, set_view rhs) noexcept
+                -> std::strong_ordering
         {
                 return set_compare<bits_type>::lexicographical_three_way(*lhs.m_ptr, *rhs.m_ptr);
         }
 
         // Not [set] and under review; three paths, cheapest first: the member, then the bitwise operators, then the element-wise scan.
-        [[nodiscard]] constexpr bool is_subset_of(set_view other) const noexcept
+        [[nodiscard]] constexpr auto is_subset_of(set_view other) const noexcept
+                -> bool
         {
                 if constexpr (requires { m_ptr->is_subset_of(*other.m_ptr); }) {
                         return m_ptr->is_subset_of(*other.m_ptr);
@@ -466,7 +494,8 @@ public:
                 }
         }
 
-        [[nodiscard]] constexpr bool is_proper_subset_of(set_view other) const noexcept
+        [[nodiscard]] constexpr auto is_proper_subset_of(set_view other) const noexcept
+                -> bool
         {
                 if constexpr (requires { m_ptr->is_proper_subset_of(*other.m_ptr); }) {
                         return m_ptr->is_proper_subset_of(*other.m_ptr);
@@ -475,7 +504,8 @@ public:
                 }
         }
 
-        [[nodiscard]] constexpr bool intersects(set_view other) const noexcept
+        [[nodiscard]] constexpr auto intersects(set_view other) const noexcept
+                -> bool
         {
                 if constexpr (requires { m_ptr->intersects(*other.m_ptr); }) {
                         return m_ptr->intersects(*other.m_ptr);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -108,9 +108,13 @@ foreach(h ${public_headers})
     string(REPLACE "/" "." header_test_id ${h})
     string(REGEX REPLACE "[.]hpp$" "" header_test_id ${header_test_id})
     set(header_test_source ${CMAKE_CURRENT_BINARY_DIR}/header_self_sufficiency/${header_test_id}.cpp)
+    # An IWYU pragma because clang-tidy runs misc-include-cleaner over these
+    # generated sources too, and the one include is by construction unused; a
+    # trailing return type because modernize-use-trailing-return-type flags
+    # "int main()".
     file(
         WRITE ${header_test_source}
-        "#include <${h}>\nint main() {}\n"
+        "#include <${h}> // IWYU pragma: keep\nauto main() -> int {}\n"
     )
 
     add_executable(header.${header_test_id} ${header_test_source})


### PR DESCRIPTION
**Stacked on #73**, which touches the same `.clang-tidy`. Base retargets to `main` automatically when #73 merges; review this PR's own commit, not the two together.

`modernize-use-trailing-return-type` and `misc-include-cleaner` were both switched off in `.clang-tidy`. The header tree was largely conforming already — every trailing return type in it was on its own indented line, and the aggregates already carried IWYU pragmas — but by habit rather than by check, and 254 declarations and 15 includes had drifted. This closes the last two `.clang-tidy` differences with xstd.

## Trailing return types

Applied with the check's own fixer, then reformatted. The split follows xstd, and follows what this tree already did everywhere it had a trailing return type:

- **own line, indented one level**, when the body follows on the next line;
- **inline**, for a one-line body, a pure declaration, `= default` and `= delete`.

Three `NOLINT` markers moved back onto the declaration line: the fixer left them stranded on the new `->` line, where they no longer covered the diagnostic. `misc-unconventional-assign-operator` ×2 in `array_view.hpp` and `modernize-use-nodiscard` in `set_view.hpp` all went red until they moved back.

Alignment inside a declaration was re-struck wherever collapsing a named return type to `auto` left the old padding pointing at nothing — 13 lines across 8 files. No reflow beyond that; the wider formatting question is #70.

## Include hygiene

Removed as unused, each confirmed by grepping the file for the symbol its own comment names:

| header | include |
| --- | --- |
| `bit_array.hpp` | `<initializer_list>` (both blocks), `<utility>` |
| `bit_finite_set.hpp` | `<type_traits>` |
| `opt/set/sieve.hpp` | `<concepts>` |

Added where a used symbol had no header naming it:

| header | include | for |
| --- | --- | --- |
| `bitset.hpp` | `ranges/bit_extent.hpp`, `<concepts>` | `bit_extent`, `std::unsigned_integral` |
| `detail/array.hpp` | `<iterator>` | `ranges::distance`, `ranges::prev`, `random_access_iterator`, `sized_sentinel_for` |
| `ext/std/bitset.hpp` | `ranges/bit_extent.hpp`, `unsigned_integer.hpp` | `bit_extent`, `xstd::unsigned_integer` |
| `ext/xstd/bitset.hpp` | `<cstddef>` | `std::size_t` |

`detail/intrin.hpp` moved rather than went. `block_access.hpp` does not use `countr_zero`, but `array_view.hpp` and `set_view.hpp` do, and were reaching it through `block_access.hpp` — dropping it there alone fails to compile. It is now named by the two headers that use it.

`misc-include-cleaner.IgnoreHeaders: 'boost/.*'` matches xstd's, for the reason xstd gives: no Boost library ships IWYU pragmas, so nothing under `boost/` is attributable to the header a consumer names. Unlike tabula, this repo's linted headers do include Boost.

Realigning an include block's comment column is a consequence of adding or removing a line in it, so a few blocks that had gone ragged come out aligned.

## Generated units

The self-sufficiency units gain the two accommodations xstd's already carry: `// IWYU pragma: keep` on the include, which is unused by construction, and `auto main() -> int`.

## Verification

Run locally with **clang-tidy 20** — not 18, which is a rung below CI's ladder and has a stdlib-mapping gap that wants `<bits/ranges_algo.h>` for `std::ranges::fold_left` — over both passes CI runs: the generated self-sufficiency units, and every header under `include/` as a primary input, which is what puts `opt/` in scope. Clean on both under the full `.clang-tidy` with the two checks live, and every unit still compiles.

Boost and the C++23 library pieces came from local stubs and libstdc++ 14, so the CI ladder is the real check — hence draft.

Test sources include `<initializer_list>`, `<utility>`, `<type_traits>` and `<bit>` themselves, so nothing was relying on the removed includes transitively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KN9Nqf5PjTfd75nCGx46zy

---
_Generated by [Claude Code](https://claude.ai/code/session_01KN9Nqf5PjTfd75nCGx46zy)_