### PR TITLE
Make the compiler stubs callable, and add the canary

### DIFF
--- a/.github/workflows/apple-clang.yml
+++ b/.github/workflows/apple-clang.yml
@@ -3,13 +3,13 @@
 #    (See accompanying file LICENSE_1_0.txt or copy at
 #          http://www.boost.org/LICENSE_1_0.txt)
 
-name: AppleClang
+name: Apple Clang
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow_ref }}-${{ github.ref }}
   cancel-in-progress: true
 
 on:
@@ -18,6 +18,8 @@ on:
   pull_request:
     branches: [ main ]
   workflow_dispatch:
+  # canary.yml calls this weekly, so the stub stays callable itself.
+  workflow_call:
 
 jobs:
   # Two rungs, Apple publishing no Clang trunk; the file keeps its name because the README badge is the workflow's path.

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,36 @@
+#          Copyright Rein Halbersma 2014-2026.
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+name: Toolchain Canary
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  schedule:
+    - cron: '30 5 * * 1'
+  workflow_dispatch:
+
+jobs:
+  # Run the complete compiler workflows weekly so dynamic development
+  # toolchains and mutable runner images are checked even without a push.
+  gcc:
+    uses: ./.github/workflows/gcc.yml
+  clang:
+    uses: ./.github/workflows/clang.yml
+  clang_libcxx:
+    uses: ./.github/workflows/clang-libc++.yml
+  mingw:
+    uses: ./.github/workflows/mingw.yml
+  apple_clang:
+    uses: ./.github/workflows/apple-clang.yml
+  msvc:
+    uses: ./.github/workflows/msvc.yml
+  clang_cl:
+    uses: ./.github/workflows/clang-cl.yml

--- a/.github/workflows/clang-cl.yml
+++ b/.github/workflows/clang-cl.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow_ref }}-${{ github.ref }}
   cancel-in-progress: true
 
 on:
@@ -18,6 +18,8 @@ on:
   pull_request:
     branches: [ main ]
   workflow_dispatch:
+  # canary.yml calls this weekly, so the stub stays callable itself.
+  workflow_call:
 
 jobs:
   # The msvc.yml ladder with clang-cl in front of the MSVC STL, on its own cache prefix; all three rungs.

--- a/.github/workflows/clang-libc++.yml
+++ b/.github/workflows/clang-libc++.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow_ref }}-${{ github.ref }}
   cancel-in-progress: true
 
 on:
@@ -18,6 +18,8 @@ on:
   pull_request:
     branches: [ main ]
   workflow_dispatch:
+  # canary.yml calls this weekly, so the stub stays callable itself.
+  workflow_call:
 
 jobs:
   # The full ladder; the C++23 range adaptors libc++ lacks are no longer used, so all six legs pass.

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow_ref }}-${{ github.ref }}
   cancel-in-progress: true
 
 on:
@@ -18,6 +18,8 @@ on:
   pull_request:
     branches: [ main ]
   workflow_dispatch:
+  # canary.yml calls this weekly, so the stub stays callable itself.
+  workflow_call:
 
 jobs:
   # No inputs: every rung. The libc++ leg is its own workflow now; what is left here is the libstdc++ side.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,7 +7,6 @@ name: CodeQL
 
 permissions:
   contents: read
-  security-events: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,6 +22,15 @@ on:
   workflow_dispatch:
 
 jobs:
+  # security-events on the job rather than at workflow level. Scorecard's
+  # Token-Permissions check subtracts a full point for a top-level
+  # security-events write and nothing for the same grant on a job, as long as
+  # the workflow still declares a top-level block -- which the contents: read
+  # above does. The called workflow cannot exceed what this job grants, so the
+  # grant has to live somewhere here either way.
   # No inputs: c-cpp with security-extended is the shared workflow's default.
   codeql:
+    permissions:
+      contents: read
+      security-events: write
     uses: rhalbersma/cpp-ci/.github/workflows/codeql.yml@e2886b13f6fcd1eceb231652f816b016de41be1d # v0.8.1

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow_ref }}-${{ github.ref }}
   cancel-in-progress: true
 
 on:
@@ -18,6 +18,8 @@ on:
   pull_request:
     branches: [ main ]
   workflow_dispatch:
+  # canary.yml calls this weekly, so the stub stays callable itself.
+  workflow_call:
 
 jobs:
   # No inputs: every rung, and the rungs move with cpp-ci rather than with a local matrix.

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow_ref }}-${{ github.ref }}
   cancel-in-progress: true
 
 on:
@@ -18,6 +18,8 @@ on:
   pull_request:
     branches: [ main ]
   workflow_dispatch:
+  # canary.yml calls this weekly, so the stub stays callable itself.
+  workflow_call:
 
 jobs:
   # No inputs: every rung. The WinLibs release lookup lives in cpp-ci's install-winlibs action now.

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow_ref }}-${{ github.ref }}
   cancel-in-progress: true
 
 on:
@@ -18,6 +18,8 @@ on:
   pull_request:
     branches: [ main ]
   workflow_dispatch:
+  # canary.yml calls this weekly, so the stub stays callable itself.
+  workflow_call:
 
 jobs:
   # All three rungs; VS 2022's STL has no <flat_set>, which the tests probe for rather than assume.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,11 @@ project(
 
 include(GNUInstallDirs)
 
+# Warnings are errors while this library is being developed, which is what the presets ask for.
+# Declared here rather than under test/, as xstd and tabula do, because benchmark/ carries its
+# own warning set and has to be gated by the same switch.
+option(BIT_SET_WARNINGS_AS_ERRORS "Treat warnings as errors in bit_set tests and benchmarks" ${PROJECT_IS_TOP_LEVEL})
+
 # Prefer an installed xstd so install(EXPORT) can record it as a dependency; a FetchContent build tree cannot be exported.
 find_package(xstd 0.1.0 CONFIG QUIET)
 if(NOT xstd_FOUND)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,108 @@
+{
+  "version": 8,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 28,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "vcpkg",
+      "hidden": true,
+      "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+    },
+    {
+      "name": "dev",
+      "displayName": "Developer debug build",
+      "binaryDir": "${sourceDir}/build/dev",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "BUILD_TESTING": "ON",
+        "BIT_SET_WARNINGS_AS_ERRORS": "ON"
+      }
+    },
+    {
+      "name": "release",
+      "displayName": "Release build",
+      "binaryDir": "${sourceDir}/build/release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "BUILD_TESTING": "ON",
+        "BIT_SET_WARNINGS_AS_ERRORS": "ON"
+      }
+    },
+    {
+      "name": "no-tests",
+      "displayName": "Header-only package build without tests",
+      "binaryDir": "${sourceDir}/build/no-tests",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "BUILD_TESTING": "OFF"
+      }
+    },
+    {
+      "name": "dev-vcpkg",
+      "displayName": "Developer debug build (test and benchmark dependencies via vcpkg, needs VCPKG_ROOT)",
+      "inherits": ["dev", "vcpkg"],
+      "binaryDir": "${sourceDir}/build/dev-vcpkg"
+    },
+    {
+      "name": "release-vcpkg",
+      "displayName": "Release build (test and benchmark dependencies via vcpkg, needs VCPKG_ROOT)",
+      "inherits": ["release", "vcpkg"],
+      "binaryDir": "${sourceDir}/build/release-vcpkg"
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "dev",
+      "configurePreset": "dev"
+    },
+    {
+      "name": "release",
+      "configurePreset": "release"
+    },
+    {
+      "name": "no-tests",
+      "configurePreset": "no-tests"
+    },
+    {
+      "name": "dev-vcpkg",
+      "configurePreset": "dev-vcpkg"
+    },
+    {
+      "name": "release-vcpkg",
+      "configurePreset": "release-vcpkg"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "dev",
+      "configurePreset": "dev",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "release",
+      "configurePreset": "release",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "dev-vcpkg",
+      "configurePreset": "dev-vcpkg",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "release-vcpkg",
+      "configurePreset": "release-vcpkg",
+      "output": {
+        "outputOnFailure": true
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![MinGW](https://github.com/rhalbersma/bit_set/actions/workflows/mingw.yml/badge.svg)](https://github.com/rhalbersma/bit_set/actions/workflows/mingw.yml)
 [![Clang](https://github.com/rhalbersma/bit_set/actions/workflows/clang.yml/badge.svg)](https://github.com/rhalbersma/bit_set/actions/workflows/clang.yml)
 [![Clang-libc++](https://github.com/rhalbersma/bit_set/actions/workflows/clang-libc%2B%2B.yml/badge.svg)](https://github.com/rhalbersma/bit_set/actions/workflows/clang-libc%2B%2B.yml)
-[![AppleClang](https://github.com/rhalbersma/bit_set/actions/workflows/apple-clang.yml/badge.svg)](https://github.com/rhalbersma/bit_set/actions/workflows/apple-clang.yml)
+[![Apple Clang](https://github.com/rhalbersma/bit_set/actions/workflows/apple-clang.yml/badge.svg)](https://github.com/rhalbersma/bit_set/actions/workflows/apple-clang.yml)
 [![Clang-CL](https://github.com/rhalbersma/bit_set/actions/workflows/clang-cl.yml/badge.svg)](https://github.com/rhalbersma/bit_set/actions/workflows/clang-cl.yml)
 [![MSVC](https://github.com/rhalbersma/bit_set/actions/workflows/msvc.yml/badge.svg)](https://github.com/rhalbersma/bit_set/actions/workflows/msvc.yml)
 [![Coverage](https://codecov.io/gh/rhalbersma/bit_set/branch/main/graph/badge.svg)](https://codecov.io/gh/rhalbersma/bit_set)
@@ -433,13 +433,13 @@ This library depends on the C++ Standard Library and [xstd](https://github.com/r
 | Windows | MinGW | libstdc++ | 15 | 16 | — | [![MinGW](https://github.com/rhalbersma/bit_set/actions/workflows/mingw.yml/badge.svg)](https://github.com/rhalbersma/bit_set/actions/workflows/mingw.yml) |
 | Linux | Clang | libstdc++ | 22 (libstdc++ 15) | 23 (libstdc++ 16) | 24-SVN (libstdc++ 17-SVN) | [![Clang](https://github.com/rhalbersma/bit_set/actions/workflows/clang.yml/badge.svg)](https://github.com/rhalbersma/bit_set/actions/workflows/clang.yml) |
 | Linux | Clang | libc++ | 22 | 23 | 24-SVN | [![Clang-libc++](https://github.com/rhalbersma/bit_set/actions/workflows/clang-libc%2B%2B.yml/badge.svg)](https://github.com/rhalbersma/bit_set/actions/workflows/clang-libc%2B%2B.yml) |
-| macOS | AppleClang | libc++ | 17.0.0 (Xcode 16.4) | 21.0.0 (Xcode 26.6) | — | [![AppleClang](https://github.com/rhalbersma/bit_set/actions/workflows/apple-clang.yml/badge.svg)](https://github.com/rhalbersma/bit_set/actions/workflows/apple-clang.yml) |
+| macOS | Apple Clang | libc++ | 17.0.0 (Xcode 16.4) | 21.0.0 (Xcode 26.6) | — | [![Apple Clang](https://github.com/rhalbersma/bit_set/actions/workflows/apple-clang.yml/badge.svg)](https://github.com/rhalbersma/bit_set/actions/workflows/apple-clang.yml) |
 | Windows | Clang-CL | MSVC | 19.1.5 (VS 2022) | 20.1.8 (VS 2026) | 20.1.8 (VS 2026-Preview) | [![Clang-CL](https://github.com/rhalbersma/bit_set/actions/workflows/clang-cl.yml/badge.svg)](https://github.com/rhalbersma/bit_set/actions/workflows/clang-cl.yml) |
 | Windows | MSVC | MSVC | 2022 (17.11+) | 2026 | 2026-Preview | [![MSVC](https://github.com/rhalbersma/bit_set/actions/workflows/msvc.yml/badge.svg)](https://github.com/rhalbersma/bit_set/actions/workflows/msvc.yml) |
 
-`AppleClang` has no `Development` entry because Apple doesn't publish Apple Clang dev snapshots the way LLVM does; that leg tests the latest stable Xcode release from each of the two supported series. `MinGW` has none either: WinLibs publishes no GCC trunk build between stable branches, and the shared workflow drops that rung with a notice rather than failing, so the row names the two that actually run. The `Linux | GCC` row keeps its `17-SVN` — that ladder is unaffected.
+`Apple Clang` has no `Development` entry because Apple doesn't publish Apple Clang dev snapshots the way LLVM does; that leg tests the latest stable Xcode release from each of the two supported series. `MinGW` has none either: WinLibs publishes no GCC trunk build between stable branches, and the shared workflow drops that rung with a notice rather than failing, so the row names the two that actually run. The `Linux | GCC` row keeps its `17-SVN` — that ladder is unaffected.
 
-Every leg above passes. The library no longer uses the C++23 range adaptors libc++ has not implemented (`views::cartesian_product`, `views::adjacent`, `views::pairwise_transform`, `views::stride`), and the tests probe for `<flat_set>` rather than assuming it, so the `Clang | libc++` and `AppleClang` rows and the VS 2022 legs build and run like the rest.
+Every leg above passes. The library no longer uses the C++23 range adaptors libc++ has not implemented (`views::cartesian_product`, `views::adjacent`, `views::pairwise_transform`, `views::stride`), and the tests probe for `<flat_set>` rather than assuming it, so the `Clang | libc++` and `Apple Clang` rows and the VS 2022 legs build and run like the rest.
 
 Note that the benchmarks and unit tests depend on [Boost](https://www.boost.io/), [fmtlib](https://github.com/fmtlib/fmt), [Google Benchmark](https://github.com/google/benchmark) and [range-v3](https://github.com/ericniebler/range-v3). 
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -28,10 +28,6 @@ set(cxx_compile_options_warnings
     $<$<CXX_COMPILER_ID:MSVC>:
         /W4
         /permissive-
-        /WX
-    >
-    $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>:
-        -Werror
     >
     $<$<AND:$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>,$<NOT:$<BOOL:${bit_set_is_clang_cl}>>>:
         -pedantic-errors
@@ -68,6 +64,8 @@ set(cxx_compile_options_warnings
         -Wno-array-bounds                   # triggered by Boost.DynamicBitset for gcc >= 12 in Release mode
         -Wno-stringop-overflow              # triggered by Boost.DynamicBitset for gcc >= 12 in Release mode
     >
+    $<$<AND:$<BOOL:${BIT_SET_WARNINGS_AS_ERRORS}>,$<CXX_COMPILER_ID:MSVC>>:/WX>
+    $<$<AND:$<BOOL:${BIT_SET_WARNINGS_AS_ERRORS}>,$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>>:-Werror>
 )
 
 set(cxx_compile_options_optimization

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,11 +31,7 @@ set(cxx_compile_options_warnings
     $<$<CXX_COMPILER_ID:MSVC>:
         /W4
         /permissive-
-        /WX
         /bigobj
-    >
-    $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>:
-        -Werror
     >
     $<$<AND:$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>,$<NOT:$<BOOL:${bit_set_is_clang_cl}>>>:
         -pedantic-errors
@@ -75,6 +71,8 @@ set(cxx_compile_options_warnings
         -Wno-stringop-overflow              # triggered by Boost.DynamicBitset for gcc >= 12 in Release mode
         -Wno-maybe-uninitialized            # false positive on detail::array's std::array member (WinLibs gcc 15.3.0, Release mode)
     >
+    $<$<AND:$<BOOL:${BIT_SET_WARNINGS_AS_ERRORS}>,$<CXX_COMPILER_ID:MSVC>>:/WX>
+    $<$<AND:$<BOOL:${BIT_SET_WARNINGS_AS_ERRORS}>,$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>>:-Werror>
 )
 
 set(cxx_compile_options_optimization


### PR DESCRIPTION
This repo carries nearly all the remaining gratuitous drift against xstd and tabula. Four items, three of which turn out to be one.

## The canary bundle

There is no `canary.yml` here, and there could not have been one: the seven compiler stubs it would call declare no `workflow_call` trigger, so `uses: ./.github/workflows/gcc.yml` cannot reach them. xstd and tabula run the canary weekly — that is what checks development toolchains and mutable runner images on a repository nobody has pushed to.

Adding the trigger alone would misfire. Inside a called workflow `github.workflow` names the **caller**, so under the group these seven share today all seven would evaluate to `Toolchain Canary` + the ref: one group, `cancel-in-progress`, six of the seven cancelled by the seventh. `github.workflow_ref` separates them — which is precisely why xstd and tabula spell the group that way on these seven workflows and nowhere else. I checked that correlation across all 17 stubs in all three repos; it is exact, not stylistic.

So the three go together:

| | before | after |
| --- | --- | --- |
| `on:` on the seven | no `workflow_call` | `workflow_call:` added |
| concurrency group | `github.workflow` | `github.workflow_ref` |
| `canary.yml` | absent | xstd's file, unchanged |

Closes #71.

## CodeQL permissions

`security-events: write` moves from the workflow level onto the job. The shared workflow declares `contents: read` and cannot exceed what the caller grants, so it has to be somewhere in this stub; at the top level it costs a full point on Scorecard's Token-Permissions check, which reads a workflow-level write as the finding and the same grant on a job as none, provided a top-level block still exists — the `contents: read` above. tabula takes the identical change in rhalbersma/tabula#60.

## Apple Clang

`name: AppleClang` → `name: Apple Clang`, and the five README occurrences with it — the badge label, the compiler table's row label and its badge, and the two backticked references to that row. One of those already read "Apple doesn't publish Apple Clang dev snapshots" in the same sentence as `` `AppleClang` ``, so the file disagreed with itself.

**Correction to an earlier version of this description**, which claimed the rename would change the check name and that a branch protection rule naming `AppleClang / all` would need updating. That was wrong. Check names are built from the **caller's job id**, not the workflow's `name:` — the job id here is `apple_clang`, as in the other two repos, and CI reports `apple_clang / Xcode 26.6 Release` and `apple_clang / all`. Nothing in this PR changes a check name, and `CONTRIBUTING.md`'s `apple_clang / all` row stays correct.

## Warnings-as-errors and the presets

`CMakePresets.json` was the one shared file missing here, and #72 records why it was not a drop-in: xstd's and tabula's presets set `XSTD_`/`TABULA_WARNINGS_AS_ERRORS`, and this repo had no such option — `test/CMakeLists.txt` and `benchmark/CMakeLists.txt` each hardcoded `/WX` and `-Werror`. Copying the file would have set a cache variable nothing reads.

So the option comes first. It sits in the root rather than under `test/`, where the other two put theirs, because `benchmark/` carries its own warning set and needs the same switch. Default is `PROJECT_IS_TOP_LEVEL`, so **a consumer building this as a subproject no longer inherits `-Werror`** — the one behaviour change worth naming.

Closes #72's build-change item.

## Verification

The full ladder ran clean on `1c78467`: 85 checks, no failures — every compiler leg, clang-tidy 22/23/24-SVN, all three sanitizer families, msvc_analyze, CodeQL, Coverage and Consumption. The current head re-runs it from scratch, `main` having been merged in.

An earlier version of this section said this PR would get **no CI**, because every stub triggers on `pull_request: branches: [ main ]` and the PR then targeted `claude/config-drift`. That held only while it was stacked; it has targeted `main` since #73 merged, and the run above is the result.

Locally, before CI had run:

- `actionlint` v1.7.7, the binary the Actionlint job runs — clean on this tree, and on xstd's and tabula's counterpart branches.
- Every `uses: ./.github/workflows/…` target in `canary.yml` resolves to a file that exists here; the seven stubs each gained exactly one `workflow_call:`, and no other stub gained one.
- `cmake --list-presets` accepts all five presets; a configure run puts `BIT_SET_WARNINGS_AS_ERRORS:BOOL=ON` in the cache, so the variable the presets set is one the build reads.
- A standalone project reproducing the generator-expression shape emits `-pedantic-errors -Werror` at `ON` and `-pedantic-errors` at `OFF`, read out of `compile_commands.json`.

## Not in this PR

`coverage.yml` still pins cpp-ci at `3d88e07` rather than a tag — that moves once v0.8.2 is cut, together with dropping `/coverage.txt` and `/coverage.xml` from `.gitignore`, since the same bump is what writes the reports into `build/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KN9Nqf5PjTfd75nCGx46zy