### PR TITLE
Lint the test sources, and fix what instantiating the templates reveals

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -23,8 +23,10 @@ jobs:
   clang_tidy:
     uses: rhalbersma/cpp-ci/.github/workflows/clang-tidy.yml@e2886b13f6fcd1eceb231652f816b016de41be1d # v0.8.1
     with:
-      # The generated per-header units alone: the Boost.Test macros drown the signal in noise.
+      # The generated per-header units and the test sources, as run-clang-tidy
+      # matches them against the compile database's absolute paths.
       self_sufficiency_regex: ${{ github.workspace }}/build/test/header_self_sufficiency/.*
+      sources_regex: ${{ github.workspace }}/test/src/.*
       # The per-header pass compiles standalone, so xstd (FetchContent) and Boost (vcpkg) must be named; an absent candidate costs nothing.
       adapted_dirs: >-
         build/_deps/xstd-src/include

--- a/include/opt/bitset/sieve.hpp
+++ b/include/opt/bitset/sieve.hpp
@@ -7,7 +7,7 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/dynamic_bitset_fwd.hpp>            // dynamic_bitset
-#include <xstd/bits/ranges/set_view.hpp>           // view
+#include <xstd/bits/ranges/set_view.hpp>           // set_view
 #include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer
 #include <cstddef>                                 // size_t
 #include <ranges>                                  // take_while

--- a/include/xstd/bits/bit_finite_set.hpp
+++ b/include/xstd/bits/bit_finite_set.hpp
@@ -8,8 +8,8 @@
 
 // Header <set> synopsis                                   [associative.set.syn]
 
-#include <compare>          // strong_ordering
-#include <initializer_list> // initializer_list
+#include <compare>                                 // strong_ordering
+#include <initializer_list>                        // initializer_list
 
 #include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer
 #include <xstd/ints/memory.hpp>                    // align_up
@@ -40,22 +40,21 @@ using bit_finite_set = xstd::bit_finite_set<xstd::align_up(N, static_cast<std::s
 }       // namespace xstd
 
 // NOLINTBEGIN(readability-duplicate-include): synopsis and implementation each list what that section needs.
-#include <boost/hash2/fnv1a.hpp>       // fnv1a_64
-#include <boost/hash2/hash_append.hpp> // hash_append
-#include <xstd/bits/detail/array.hpp>  // array
-#include <xstd/bits/ranges.hpp>        // const_iterator, const_reference
-#include <cassert>                     // assert
-#include <compare>                     // strong_ordering
-#include <concepts>                    // constructible_from
-#include <cstddef>                     // ptrdiff_t, size_t
-#include <functional>                  // less
-#include <initializer_list>            // initializer_list
-#include <iterator>                    // make_reverse_iterator, reverse_iterator,
+#include <boost/hash2/hash_append.hpp>             // hash_append
+#include <xstd/bits/detail/array.hpp>              // array
+#include <xstd/bits/ranges.hpp>                    // const_iterator, const_reference
+#include <cassert>                                 // assert
+#include <compare>                                 // strong_ordering
+#include <concepts>                                // constructible_from
+#include <cstddef>                                 // ptrdiff_t, size_t
+#include <functional>                              // less
+#include <initializer_list>                        // initializer_list
+#include <iterator>                                // make_reverse_iterator, reverse_iterator,
                                        // input_iterator, sentinel_for
-#include <limits>                      // digits
-#include <ranges>                      // begin, empty, end, from_range_t, next, rbegin, rend
+#include <limits>                                  // digits
+#include <ranges>                                  // begin, empty, end, from_range_t, rbegin, rend
                                        // input_range
-#include <utility>                     // forward, move, pair
+#include <utility>                                 // forward, move, pair
 // NOLINTEND(readability-duplicate-include)
 
 // Class template set [set], Overview [set.overview]

--- a/include/xstd/bits/bitset.hpp
+++ b/include/xstd/bits/bitset.hpp
@@ -8,8 +8,8 @@
 
 // Bitsets [bitset], Header <bitset> synopsis [bitset.syn]
 
-#include <iosfwd> // basic_istream, basic_ostream
-#include <string> // basic_string, char_traits
+#include <iosfwd>                                  // basic_istream, basic_ostream
+#include <string>                                  // basic_string, char_traits
 
 #include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer
 #include <cstddef>                                 // size_t
@@ -28,25 +28,25 @@ template<class charT, class traits, std::size_t N, xstd::unsigned_integer Block>
 
 }       // namespace xstd
 
-#include <boost/hash2/fnv1a.hpp>           // fnv1a_64
-#include <boost/hash2/hash_append.hpp>     // hash_append
-#include <xstd/bits/detail/array.hpp>      // array
-#include <xstd/bits/ranges/array_view.hpp> // array_find
-#include <xstd/bits/ranges/bit_extent.hpp> // bit_extent
-#include <xstd/bits/ranges/set_view.hpp>   // set_find, set_compare
-#include <algorithm>                       // find_if, min
-#include <cassert>                         // assert
-#include <compare>                         // strong_ordering
-#include <concepts>                        // unsigned_integral
-#include <format>                          // format
-#include <functional>                      // hash
-#include <ios>                             // ios_base
-#include <locale>                          // ctype, use_facet
-#include <memory>                          // allocator
-#include <ranges>                          // find_if, iota, reverse
-#include <source_location>                 // source_location
-#include <stdexcept>                       // invalid_argument, out_of_range, overflow_error
-#include <string_view>                     // basic_string_view
+#include <boost/hash2/fnv1a.hpp>                   // fnv1a_64
+#include <boost/hash2/hash_append.hpp>             // hash_append
+#include <xstd/bits/detail/array.hpp>              // array
+#include <xstd/bits/ranges/array_view.hpp>         // array_find
+#include <xstd/bits/ranges/bit_extent.hpp>         // bit_extent
+#include <xstd/bits/ranges/set_view.hpp>           // set_find, set_compare
+#include <algorithm>                               // find_if, min
+#include <cassert>                                 // assert
+#include <compare>                                 // strong_ordering
+#include <concepts>                                // unsigned_integral
+#include <format>                                  // format
+#include <functional>                              // hash
+#include <ios>                                     // ios_base
+#include <locale>                                  // ctype, use_facet
+#include <memory>                                  // allocator
+#include <ranges>                                  // find_if, iota, reverse
+#include <source_location>                         // source_location
+#include <stdexcept>                               // invalid_argument, out_of_range
+#include <string_view>                             // basic_string_view
 #include <utility>                                 // as_const
 
 // Class template bitset [template.bitset], General [template.bitset.general]

--- a/include/xstd/bits/bitset.hpp
+++ b/include/xstd/bits/bitset.hpp
@@ -175,7 +175,7 @@ public:
                 }
                 auto const rlen = std::ranges::min(n, str.size() - pos);
                 auto const M = std::ranges::min(N, rlen);
-                for (auto i : std::views::iota(0UZ, M)) {
+                for (auto const i : std::views::iota(0UZ, M)) {
                         auto const ch = str[pos + M - 1 - i];
                         if (traits::eq(ch, zero)) {
                                 continue;
@@ -293,8 +293,10 @@ public:
         [[nodiscard]] constexpr auto to_string(charT zero = charT('0'), charT one = charT('1')) const
                 -> std::basic_string<charT, traits, Allocator>
         {
-                auto str = std::basic_string<charT, traits, Allocator>(N, zero);
-                for (auto i : std::views::iota(0UZ, N)) {
+                // bugprone-string-constructor sees the N == 0 instantiation, where this is empty --
+                // which is what bitset<0>::to_string() returns.
+                auto str = std::basic_string<charT, traits, Allocator>(N, zero);  // NOLINT(bugprone-string-constructor)
+                for (auto const i : std::views::iota(0UZ, N)) {
                         if (m_bits[N - 1 - i]) {
                                 str[i] = one;
                         }
@@ -454,8 +456,11 @@ template<class charT, class traits, std::size_t N, xstd::unsigned_integer Block>
 auto operator>>(std::basic_istream<charT, traits>& is, bitset<N, Block>& x)
         -> std::basic_istream<charT, traits>&
 {
-        auto str = std::basic_string<charT, traits>(N, is.widen('0'));
-        auto state = std::ios_base::goodbit;
+        auto str = std::basic_string<charT, traits>(N, is.widen('0'));  // NOLINT(bugprone-string-constructor)
+        // state is assigned below, inside an if constexpr (N > 0) that the N == 0 instantiation
+        // discards; misc-const-correctness sees only that one and asks for a const that would
+        // stop every other instantiation from compiling.
+        auto state = std::ios_base::goodbit;  // NOLINT(misc-const-correctness)
         charT ch;
         auto i = 0UZ;
         // One peek per character: peeking twice sets eofbit then failbit, failing a short but valid extraction ([bitset.operators]/6).

--- a/include/xstd/bits/bitset.hpp
+++ b/include/xstd/bits/bitset.hpp
@@ -47,6 +47,7 @@ template<class charT, class traits, std::size_t N, xstd::unsigned_integer Block>
 #include <source_location>                 // source_location
 #include <stdexcept>                       // invalid_argument, out_of_range, overflow_error
 #include <string_view>                     // basic_string_view
+#include <utility>                                 // as_const
 
 // Class template bitset [template.bitset], General [template.bitset.general]
 
@@ -71,23 +72,76 @@ class bitset
 public:
         using block_type = Block;
 
+        // array_view's proxy, ported to the member [bitset.refs] asks for: the bits and a position,
+        // handed out by operator[] and reaching them only when read or written. Every such reach
+        // goes through detail::bits::array, whose set, reset, flip and operator[] are noexcept and
+        // asserted, so the proxy never takes the checked set(pos, val) beside it that throws.
         class reference
         {
+                // A pointer, not the reference array_view's proxy holds, so that the copy
+                // constructor below can stay defaulted as [bitset.refs] declares it.
+                bitset* m_ptr{};
+                std::size_t m_idx{};
+
+                friend bitset;
+
+                [[nodiscard]] constexpr reference(bitset& c, std::size_t idx) noexcept
+                :
+                        m_ptr(&c),
+                        m_idx(idx)
+                {}
+
         public:
                 constexpr reference(const reference& x) noexcept = default;
                 constexpr ~reference() = default;
-                constexpr auto operator=(bool x) noexcept -> reference&;
-                constexpr auto operator=(const reference& x) noexcept -> reference& = default;
+
+                constexpr auto operator=(bool x) noexcept -> reference&
+                {
+                        std::as_const(*this) = x;
+                        return *this;
+                }
+
+                // Assigns the bit and not the proxy: b[i] = b[j] is what [bitset.refs] gives this
+                // signature, and the swap below reads b[i] = b[j] too, so rebinding would leave
+                // both positions holding whatever the second one did.
+                //
+                // bugprone-unhandled-self-assignment wants the &other == this guard a class owning
+                // storage needs. This one owns none: b[i] = b[i] reads the bit and writes it back.
+                constexpr auto operator=(const reference& x) noexcept -> reference&  // NOLINT(bugprone-unhandled-self-assignment)
+                {
+                        return *this = static_cast<bool>(x);
+                }
+
                 // A proxy reference assigns through a const proxy, the shape the standard gives vector<bool>::reference.
-                constexpr auto operator=(bool x) const noexcept -> const reference&;  // NOLINT(misc-unconventional-assign-operator)
-                constexpr explicit(false) operator bool() const noexcept;  // NOLINT(misc-explicit-constructor)
-                constexpr auto operator~() const noexcept -> bool;
+                constexpr auto operator=(bool x) const noexcept -> const reference&  // NOLINT(misc-unconventional-assign-operator)
+                {
+                        if (x) {
+                                m_ptr->m_bits.set(m_idx);
+                        } else {
+                                m_ptr->m_bits.reset(m_idx);
+                        }
+                        return *this;
+                }
 
-                friend constexpr void swap(reference x, reference y) noexcept { bool t = x; x = y; y = t; }
-                friend constexpr void swap(reference x,     bool& y) noexcept { bool t = x; x = y; y = t; }
-                friend constexpr void swap(    bool& x, reference y) noexcept { bool t = x; x = y; y = t; }
+                [[nodiscard]] constexpr explicit(false) operator bool() const noexcept  // NOLINT(misc-explicit-constructor)
+                {
+                        return m_ptr->m_bits[m_idx];
+                }
 
-                constexpr auto flip() noexcept -> reference&;
+                [[nodiscard]] constexpr auto operator~() const noexcept -> bool
+                {
+                        return not m_ptr->m_bits[m_idx];
+                }
+
+                friend constexpr void swap(reference x, reference y) noexcept { bool const t = x; x = y; y = t; }
+                friend constexpr void swap(reference x,     bool& y) noexcept { bool const t = x; x = y; y = t; }
+                friend constexpr void swap(    bool& x, reference y) noexcept { bool const t = x; x = y; y = t; }
+
+                constexpr auto flip() noexcept -> reference&
+                {
+                        m_ptr->m_bits.flip(m_idx);
+                        return *this;
+                }
         };
 
         // Constructors                                            [bitset.cons]
@@ -222,7 +276,11 @@ public:
                 return m_bits[pos];
         }
 
-        [[nodiscard]] constexpr auto operator[](std::size_t pos) -> reference = delete; // TODO
+        [[nodiscard]] constexpr auto operator[](std::size_t pos) noexcept
+                -> reference
+        {
+                return { *this, pos };
+        }
 
         [[nodiscard]] constexpr auto to_ulong()  const -> unsigned long      = delete;  // TODO
         [[nodiscard]] constexpr auto to_ullong() const -> unsigned long long = delete;  // TODO

--- a/include/xstd/bits/detail/array.hpp
+++ b/include/xstd/bits/detail/array.hpp
@@ -569,8 +569,22 @@ private:
                 }
         }
 
+        // Iterators are taken by value, as std::ranges::distance itself takes them.
+        //
+        // performance-unnecessary-value-param flags both parameters, and only for the
+        // reverse_iterator instantiations. libstdc++ hand-writes that class's copy
+        // constructor -- a pre-"= default" idiom; the copy assignment beside it is
+        // defaulted -- so it is not trivially copyable, where libc++'s is and the check
+        // stays silent. The verdict is a property of the standard library rather than of
+        // this signature.
+        //
+        // Nor is the cost it names paid here. Not trivially copyable means non-trivial
+        // for the purposes of calls under the Itanium ABI, so an out-of-line callee takes
+        // a pointer to a caller-built temporary where a trivially copyable type of the
+        // same eight bytes arrives in a register. This is a static constexpr one-liner:
+        // at -O2 it inlines and both iterators fold away to a pointer subtraction.
         template<std::random_access_iterator I, std::sized_sentinel_for<I> S>
-        [[nodiscard]] static constexpr auto distance(I first, S last) noexcept
+        [[nodiscard]] static constexpr auto distance(I first, S last) noexcept  // NOLINT(performance-unnecessary-value-param)
         {
                 return static_cast<std::size_t>(std::ranges::distance(first, last));
         }

--- a/include/xstd/bits/detail/array.hpp
+++ b/include/xstd/bits/detail/array.hpp
@@ -139,7 +139,12 @@ struct array
                                 n += bits_per_block - offset;
                         }
                         auto const rg = m_bits | std::views::drop(index);
-                        if (auto const next = std::ranges::find_if(rg, [](auto block) { return block != zero; }); next != rg.end()) {
+                        // next is an iterator. That std::array's is a pointer is
+                        // implementation-defined -- [array.overview] requires only that it model
+                        // contiguous_iterator -- so readability-qualified-auto's auto const *const
+                        // would encode a detail this code never relies on: next is dereferenced and
+                        // passed to distance, both pure iterator operations.
+                        if (auto const next = std::ranges::find_if(rg, [](auto block) { return block != zero; }); next != rg.end()) {  // NOLINT(readability-qualified-auto)
                                 return n + detail::bits::countr_zero(*next) + (bits_per_block * distance(rg.begin(), next));
                         }
                 }

--- a/include/xstd/bits/detail/array.hpp
+++ b/include/xstd/bits/detail/array.hpp
@@ -182,7 +182,7 @@ struct array
                         this->m_bits[0] &= other.m_bits[0];
                         this->m_bits[1] &= other.m_bits[1];
                 } else if constexpr (num_blocks >= 3) {
-                        for (auto i : std::views::iota(0UZ, num_blocks)) {
+                        for (auto const i : std::views::iota(0UZ, num_blocks)) {
                                 this->m_bits[i] &= other.m_bits[i];
                         }
                 }
@@ -196,7 +196,7 @@ struct array
                         this->m_bits[0] |= other.m_bits[0];
                         this->m_bits[1] |= other.m_bits[1];
                 } else if constexpr (num_blocks >= 3) {
-                        for (auto i : std::views::iota(0UZ, num_blocks)) {
+                        for (auto const i : std::views::iota(0UZ, num_blocks)) {
                                 this->m_bits[i] |= other.m_bits[i];
                         }
                 }
@@ -210,7 +210,7 @@ struct array
                         this->m_bits[0] ^= other.m_bits[0];
                         this->m_bits[1] ^= other.m_bits[1];
                 } else if constexpr (num_blocks >= 3) {
-                        for (auto i : std::views::iota(0UZ, num_blocks)) {
+                        for (auto const i : std::views::iota(0UZ, num_blocks)) {
                                 this->m_bits[i] ^= other.m_bits[i];
                         }
                 }
@@ -224,7 +224,7 @@ struct array
                         this->m_bits[0] &= static_cast<Block>(~other.m_bits[0]);
                         this->m_bits[1] &= static_cast<Block>(~other.m_bits[1]);
                 } else if constexpr (num_blocks >= 3) {
-                        for (auto i : std::views::iota(0UZ, num_blocks)) {
+                        for (auto const i : std::views::iota(0UZ, num_blocks)) {
                                 this->m_bits[i] &= static_cast<Block>(~other.m_bits[i]);
                         }
                 }
@@ -300,7 +300,7 @@ struct array
                         m_bits[0] = static_cast<Block>(~m_bits[0]);
                         m_bits[1] = static_cast<Block>(~m_bits[1]);
                 } else if constexpr (num_blocks >= 3) {
-                        for (auto i : std::views::iota(0UZ, num_blocks)) {
+                        for (auto const i : std::views::iota(0UZ, num_blocks)) {
                                 m_bits[i] = static_cast<Block>(~m_bits[i]);
                         }
                 }

--- a/include/xstd/bits/ext/boost/dynamic_bitset.hpp
+++ b/include/xstd/bits/ext/boost/dynamic_bitset.hpp
@@ -9,8 +9,8 @@
 // IWYU pragma: always_keep
 
 #include <boost/dynamic_bitset.hpp>                // IWYU pragma: export; dynamic_bitset
-#include <xstd/bits/ranges/array_view.hpp>         // find, view
-#include <xstd/bits/ranges/set_view.hpp>           // find, view
+#include <xstd/bits/ranges/array_view.hpp>         // array_find
+#include <xstd/bits/ranges/set_view.hpp>           // set_find, set_view
 #include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer
 #include <algorithm>                               // find_if, min
 #include <cassert>                                 // assert

--- a/include/xstd/bits/ext/boost/dynamic_bitset.hpp
+++ b/include/xstd/bits/ext/boost/dynamic_bitset.hpp
@@ -6,7 +6,9 @@
 #ifndef XSTD_BITS_EXT_BOOST_DYNAMIC_BITSET_HPP
 #define XSTD_BITS_EXT_BOOST_DYNAMIC_BITSET_HPP
 
-#include <boost/dynamic_bitset.hpp>                // dynamic_bitset
+// IWYU pragma: always_keep
+
+#include <boost/dynamic_bitset.hpp>                // IWYU pragma: export; dynamic_bitset
 #include <xstd/bits/ranges/array_view.hpp>         // find, view
 #include <xstd/bits/ranges/set_view.hpp>           // find, view
 #include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer

--- a/include/xstd/bits/ext/std/bitset.hpp
+++ b/include/xstd/bits/ext/std/bitset.hpp
@@ -6,13 +6,15 @@
 #ifndef XSTD_BITS_EXT_STD_BITSET_HPP
 #define XSTD_BITS_EXT_STD_BITSET_HPP
 
+// IWYU pragma: always_keep
+
 #include <xstd/bits/ranges/array_view.hpp>         // find, view
 #include <xstd/bits/ranges/bit_extent.hpp>         // bit_extent
 #include <xstd/bits/ranges/block_access.hpp>       // block_access
 #include <xstd/bits/ranges/set_view.hpp>           // find, view
 #include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer
 #include <algorithm>                               // find_if
-#include <bitset>                                  // bitset
+#include <bitset>                                  // IWYU pragma: export; bitset
 #include <cassert>                                 // assert
 #include <compare>                                 // strong_ordering
 #include <cstddef>                                 // size_t

--- a/include/xstd/bits/ext/std/bitset.hpp
+++ b/include/xstd/bits/ext/std/bitset.hpp
@@ -8,10 +8,10 @@
 
 // IWYU pragma: always_keep
 
-#include <xstd/bits/ranges/array_view.hpp>         // find, view
+#include <xstd/bits/ranges/array_view.hpp>         // array_find, array_view
 #include <xstd/bits/ranges/bit_extent.hpp>         // bit_extent
 #include <xstd/bits/ranges/block_access.hpp>       // block_access
-#include <xstd/bits/ranges/set_view.hpp>           // find, view
+#include <xstd/bits/ranges/set_view.hpp>           // set_find, set_view
 #include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer
 #include <algorithm>                               // find_if
 #include <bitset>                                  // IWYU pragma: export; bitset

--- a/include/xstd/bits/ext/xstd/bitset.hpp
+++ b/include/xstd/bits/ext/xstd/bitset.hpp
@@ -6,7 +6,9 @@
 #ifndef XSTD_BITS_EXT_XSTD_BITSET_HPP
 #define XSTD_BITS_EXT_XSTD_BITSET_HPP
 
-#include <xstd/bits/bitset.hpp>                    // bitset
+// IWYU pragma: always_keep
+
+#include <xstd/bits/bitset.hpp>                    // IWYU pragma: export; bitset
 #include <xstd/bits/ranges/set_view.hpp>           // begin, end
 #include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer
 #include <cstddef>                                 // size_t

--- a/include/xstd/bits/ranges/array_view.hpp
+++ b/include/xstd/bits/ranges/array_view.hpp
@@ -68,6 +68,8 @@ struct array_ops
         static constexpr void assign(Bits& c, std::size_t n, bool value) noexcept
                 requires requires { c.set(n, value); }
         {
+                // The assert is on its own line: the coverage job drops assert branches by matching the start of the line.
+                assert(n < size(c));
                 c.set(n, value);
         }
 

--- a/include/xstd/bits/ranges/array_view.hpp
+++ b/include/xstd/bits/ranges/array_view.hpp
@@ -97,7 +97,7 @@ template<std::ranges::input_range X, std::ranges::input_range Y>
         return std::lexicographical_compare_three_way(
                 std::ranges::begin(x), std::ranges::end(x),
                 std::ranges::begin(y), std::ranges::end(y),
-                [](bool a, bool b) static noexcept { return static_cast<int>(a) <=> static_cast<int>(b); }
+                [](bool a, bool b) static noexcept -> std::strong_ordering { return static_cast<int>(a) <=> static_cast<int>(b); }
         );
 }
 

--- a/include/xstd/bits/ranges/array_view.hpp
+++ b/include/xstd/bits/ranges/array_view.hpp
@@ -64,13 +64,23 @@ struct array_ops
                 }
         }
 
-        // No operator[] fallback: a type whose operator[] returns our own proxy would recurse until the stack is gone.
+        // The operator[] fallback this class refuses is the one below, for a type without
+        // set(n, value): were its operator[] to return our own proxy, that proxy's assignment
+        // would land back here and recurse until the stack is gone. Where set(n, value) does
+        // exist the type is a concrete bitset, and its subscript is the unchecked way in --
+        // which is the one to take, the position being a precondition asserted just below,
+        // where std::bitset::set and xstd::bitset::set check it again and throw out of this
+        // noexcept.
         static constexpr void assign(Bits& c, std::size_t n, bool value) noexcept
                 requires requires { c.set(n, value); }
         {
                 // The assert is on its own line: the coverage job drops assert branches by matching the start of the line.
                 assert(n < size(c));
-                c.set(n, value);
+                if constexpr (requires { c[n] = value; }) {
+                        c[n] = value;
+                } else {
+                        c.set(n, value);
+                }
         }
 
         static constexpr void assign(Bits& c, std::size_t n, bool value) noexcept

--- a/include/xstd/bits/ranges/array_view.hpp
+++ b/include/xstd/bits/ranges/array_view.hpp
@@ -283,7 +283,7 @@ public:
                 return *this = static_cast<bool>(other);
         }
 
-        constexpr auto flip() const noexcept
+        constexpr auto flip() const noexcept  // NOLINT(modernize-use-nodiscard)
                 -> array_reference const&
                 requires (not IsConst) and requires(Bits& c) { array_ops<Bits>::assign(c, 0UZ, true); }
         {

--- a/include/xstd/bits/ranges/set_view.hpp
+++ b/include/xstd/bits/ranges/set_view.hpp
@@ -92,22 +92,20 @@ struct set_ops
                 }
         }
 
-        // Two models meet here. A static extent is a fixed-capacity set that cannot grow, so -- as with
-        // std::array -- a position outside it is a precondition violation and not a question worth an
-        // answer. A dynamic extent can still grow, so it is a std::set: any key may be asked about, and one
-        // past the current size is simply absent, which is what lets set_view::find(x) return end().
+        // Asking is total, whatever the extent: a position past the width is a key the set does not
+        // hold, which is an answer and not a precondition violation. That is what [set] gives
+        // contains and find -- s.find(k) returns end() for any k it does not hold, never refuses the
+        // question -- and it is the difference between the set reading and the sequence reading,
+        // where array_view's operator[] indexes and out of range is out of bounds.
         //
-        // Either way the position is in range by the time the bitset is read, so the read goes through
+        // The position is in range by the time the bitset is read, so the read goes through
         // operator[] and not test(): the latter is the checked accessor whose throw would escape this
         // noexcept, and bugprone-exception-escape is right to say so.
         [[nodiscard]] static constexpr auto contains(Bits const& c, std::size_t n) noexcept
                 -> bool
         {
                 if constexpr (bitset_vocabulary<Bits>) {
-                        if constexpr (static_bit_extent<Bits>) {
-                                // The assert is on its own line: the coverage job drops assert branches by matching the start of the line.
-                                assert(n < max_size(c));
-                        } else if (n >= max_size(c)) {
+                        if (n >= max_size(c)) {
                                 return false;
                         }
                         return c[n];
@@ -116,15 +114,26 @@ struct set_ops
                 }
         }
 
-        // Written through the subscript, not through set(n) and reset(n): those check the
-        // position a second time and throw out of these noexcept functions, where the position
-        // is a precondition asserted here. Every type in the vocabulary hands out a proxy that
+        // insert carries no noexcept, for the reason std::set::insert carries none: growing a
+        // dynamic extent allocates. It is the one operation a set can be unable to satisfy, and
+        // only a static extent ever is: a fixed capacity cannot come to hold a position outside it, so that is the
+        // precondition violation. A dynamic extent grows to hold it, [set] giving insert no way
+        // to fail. Erasing stays total like contains -- a position past the width is a key the
+        // set does not hold, and removing what is not there is the no-op returning zero that
+        // std::set::erase is.
+        //
+        // The write goes through the subscript rather than set(n) and reset(n), which check the
+        // position a second time and throw. Every type in the vocabulary hands out a proxy that
         // writes without checking -- xstd::bitset's since its operator[] stopped being a TODO.
-        static constexpr void insert(Bits& c, std::size_t n) noexcept
+        static constexpr void insert(Bits& c, std::size_t n)
         {
-                // The assert is on its own line: the coverage job drops assert branches by matching the start of the line.
-                assert(n < max_size(c));
                 if constexpr (bitset_vocabulary<Bits>) {
+                        if constexpr (static_bit_extent<Bits>) {
+                                // The assert is on its own line: the coverage job drops assert branches by matching the start of the line.
+                                assert(n < max_size(c));
+                        } else if (n >= max_size(c)) {
+                                c.resize(n + 1UZ);
+                        }
                         c[n] = true;
                 } else {
                         c.insert(n);
@@ -133,9 +142,10 @@ struct set_ops
 
         static constexpr void erase(Bits& c, std::size_t n) noexcept
         {
-                // The assert is on its own line: the coverage job drops assert branches by matching the start of the line.
-                assert(n < max_size(c));
                 if constexpr (bitset_vocabulary<Bits>) {
+                        if (n >= max_size(c)) {
+                                return;
+                        }
                         c[n] = false;
                 } else {
                         c.erase(n);
@@ -397,7 +407,7 @@ public:
         [[nodiscard]] constexpr auto max_size() const noexcept -> size_type { return ops::max_size(*m_ptr); }
 
         // Modifiers, present only where Bits is not const, returning what [set] says they return.
-        constexpr auto insert(key_type x) const noexcept  // NOLINT(modernize-use-nodiscard)
+        constexpr auto insert(key_type x) const  // NOLINT(modernize-use-nodiscard)
                 -> std::pair<const_iterator, bool>
                 requires (not std::is_const_v<Bits>)
         {
@@ -406,7 +416,7 @@ public:
                 return { const_iterator{ m_ptr, x }, inserted };
         }
 
-        constexpr auto insert(const_iterator, key_type x) const noexcept  // NOLINT(modernize-use-nodiscard)
+        constexpr auto insert(const_iterator, key_type x) const  // NOLINT(modernize-use-nodiscard)
                 -> const_iterator
                 requires (not std::is_const_v<Bits>)
         {
@@ -415,7 +425,7 @@ public:
         }
 
         template<std::input_iterator I, std::sentinel_for<I> S>
-        constexpr void insert(I first, S last) const noexcept
+        constexpr void insert(I first, S last) const
                 requires (not std::is_const_v<Bits>)
         {
                 for (; first != last; ++first) {
@@ -423,7 +433,7 @@ public:
                 }
         }
 
-        constexpr void insert(std::initializer_list<key_type> ilist) const noexcept
+        constexpr void insert(std::initializer_list<key_type> ilist) const
                 requires (not std::is_const_v<Bits>)
         {
                 insert(ilist.begin(), ilist.end());
@@ -476,6 +486,12 @@ public:
         [[nodiscard]] constexpr auto upper_bound(key_type x) const noexcept
                 -> const_iterator
         {
+                // Total like the rest of the asking: past the width there is nothing above x
+                // either. set_find::next is the primitive that scans from a position the set
+                // has, and x + 1 is not one of those once x reaches the width.
+                if (x >= max_size()) {
+                        return end();
+                }
                 return const_iterator{ m_ptr, set_find<bits_type>::next(*m_ptr, x) };
         }
 

--- a/include/xstd/bits/ranges/set_view.hpp
+++ b/include/xstd/bits/ranges/set_view.hpp
@@ -116,12 +116,16 @@ struct set_ops
                 }
         }
 
+        // Written through the subscript, not through set(n) and reset(n): those check the
+        // position a second time and throw out of these noexcept functions, where the position
+        // is a precondition asserted here. Every type in the vocabulary hands out a proxy that
+        // writes without checking -- xstd::bitset's since its operator[] stopped being a TODO.
         static constexpr void insert(Bits& c, std::size_t n) noexcept
         {
                 // The assert is on its own line: the coverage job drops assert branches by matching the start of the line.
                 assert(n < max_size(c));
                 if constexpr (bitset_vocabulary<Bits>) {
-                        c.set(n);
+                        c[n] = true;
                 } else {
                         c.insert(n);
                 }
@@ -129,8 +133,10 @@ struct set_ops
 
         static constexpr void erase(Bits& c, std::size_t n) noexcept
         {
+                // The assert is on its own line: the coverage job drops assert branches by matching the start of the line.
+                assert(n < max_size(c));
                 if constexpr (bitset_vocabulary<Bits>) {
-                        c.reset(n);
+                        c[n] = false;
                 } else {
                         c.erase(n);
                 }

--- a/include/xstd/bits/ranges/set_view.hpp
+++ b/include/xstd/bits/ranges/set_view.hpp
@@ -118,6 +118,8 @@ struct set_ops
 
         static constexpr void insert(Bits& c, std::size_t n) noexcept
         {
+                // The assert is on its own line: the coverage job drops assert branches by matching the start of the line.
+                assert(n < max_size(c));
                 if constexpr (bitset_vocabulary<Bits>) {
                         c.set(n);
                 } else {

--- a/include/xstd/bits/ranges/set_view.hpp
+++ b/include/xstd/bits/ranges/set_view.hpp
@@ -17,7 +17,7 @@
 #include <functional>                        // less
 #include <initializer_list>                  // initializer_list
 #include <iterator>                          // bidirectional_iterator_tag, make_reverse_iterator, reverse_iterator
-#include <ranges>                            // distance, equal, view_base
+#include <ranges>                            // equal, view_base
 #include <type_traits>                       // is_class_v, is_const_v, is_convertible_v, is_nothrow_constructible_v, remove_const_t
 #include <utility>                           // pair
 

--- a/include/xstd/bits/ranges/set_view.hpp
+++ b/include/xstd/bits/ranges/set_view.hpp
@@ -375,7 +375,7 @@ public:
         [[nodiscard]] constexpr auto max_size() const noexcept -> size_type { return ops::max_size(*m_ptr); }
 
         // Modifiers, present only where Bits is not const, returning what [set] says they return.
-        constexpr auto insert(key_type x) const noexcept
+        constexpr auto insert(key_type x) const noexcept  // NOLINT(modernize-use-nodiscard)
                 -> std::pair<const_iterator, bool>
                 requires (not std::is_const_v<Bits>)
         {
@@ -384,7 +384,7 @@ public:
                 return { const_iterator{ m_ptr, x }, inserted };
         }
 
-        constexpr auto insert(const_iterator, key_type x) const noexcept
+        constexpr auto insert(const_iterator, key_type x) const noexcept  // NOLINT(modernize-use-nodiscard)
                 -> const_iterator
                 requires (not std::is_const_v<Bits>)
         {
@@ -417,7 +417,7 @@ public:
                 return erased;
         }
 
-        constexpr auto erase(const_iterator pos) const noexcept
+        constexpr auto erase(const_iterator pos) const noexcept  // NOLINT(modernize-use-nodiscard)
                 -> const_iterator
                 requires (not std::is_const_v<Bits>)
         {

--- a/include/xstd/bits/ranges/set_view.hpp
+++ b/include/xstd/bits/ranges/set_view.hpp
@@ -132,6 +132,12 @@ struct set_ops
                                 // The assert is on its own line: the coverage job drops assert branches by matching the start of the line.
                                 assert(n < max_size(c));
                         } else if (n >= max_size(c)) {
+                                // Growing has a limit of its own, and n + 1 must be a width the
+                                // container can address: dynamic_bitset's max_size() is SIZE_MAX,
+                                // so the one position this rules out is the one whose successor
+                                // wraps to zero -- where resize would grow nothing and the write
+                                // below would land SIZE_MAX bits past the end.
+                                assert(n < c.max_size());
                                 c.resize(n + 1UZ);
                         }
                         c[n] = true;

--- a/include/xstd/bits/ranges/set_view.hpp
+++ b/include/xstd/bits/ranges/set_view.hpp
@@ -92,11 +92,25 @@ struct set_ops
                 }
         }
 
+        // Two models meet here. A static extent is a fixed-capacity set that cannot grow, so -- as with
+        // std::array -- a position outside it is a precondition violation and not a question worth an
+        // answer. A dynamic extent can still grow, so it is a std::set: any key may be asked about, and one
+        // past the current size is simply absent, which is what lets set_view::find(x) return end().
+        //
+        // Either way the position is in range by the time the bitset is read, so the read goes through
+        // operator[] and not test(): the latter is the checked accessor whose throw would escape this
+        // noexcept, and bugprone-exception-escape is right to say so.
         [[nodiscard]] static constexpr auto contains(Bits const& c, std::size_t n) noexcept
                 -> bool
         {
                 if constexpr (bitset_vocabulary<Bits>) {
-                        return c.test(n);
+                        if constexpr (static_bit_extent<Bits>) {
+                                // The assert is on its own line: the coverage job drops assert branches by matching the start of the line.
+                                assert(n < max_size(c));
+                        } else if (n >= max_size(c)) {
+                                return false;
+                        }
+                        return c[n];
                 } else {
                         return c.contains(n);
                 }

--- a/test/.clang-tidy
+++ b/test/.clang-tidy
@@ -1,0 +1,19 @@
+#          Copyright Rein Halbersma 2014-2026.
+# Distributed under the Boost Software License, Version 1.0.
+#    (See accompanying file LICENSE_1_0.txt or copy at
+#          http://www.boost.org/LICENSE_1_0.txt)
+
+---
+# Static analysis for the Boost.Test sources, extending the root config rather than replacing it.
+# The generated header self-sufficiency units live under the build directory and resolve to the root.
+# Two checks are dropped, neither saying anything true about a fixture:
+# - misc-use-internal-linkage: BOOST_AUTO_TEST_CASE and BOOST_AUTO_TEST_CASE_TEMPLATE expand to a
+#   struct at namespace scope, which the framework registers by external linkage; an anonymous
+#   namespace would unregister the case. All 89 reports are those structs.
+# - readability-magic-numbers: an exhaustive ladder is nothing but literals -- the widths a bitset
+#   is instantiated over, the positions set in it, and the cardinalities expected back. All 247
+#   reports are those. Naming each would say the same thing twice and hide the ladder.
+InheritParentConfig: true
+Checks: >
+  -misc-use-internal-linkage,
+  -readability-magic-numbers

--- a/test/include/test/bitset/exhaustive.hpp
+++ b/test/include/test/bitset/exhaustive.hpp
@@ -10,7 +10,6 @@
 #include <test/dynamic.hpp>        // dynamic
 #include <algorithm>               // max
 #include <cassert>                 // assert
-#include <cstddef>                 // size_t
 #include <ranges>                  // iota
 
 #ifdef _MSC_VER

--- a/test/include/test/bitset/exhaustive.hpp
+++ b/test/include/test/bitset/exhaustive.hpp
@@ -13,7 +13,7 @@
 #include <cstddef>                 // size_t
 #include <ranges>                  // iota
 
-#if defined(_MSC_VER)
+#ifdef _MSC_VER
         // std::bitset<0> and xstd::bit_finite_set<0> give bogus "unreachable code" warnings
         __pragma(warning(disable: 4702))
 #endif

--- a/test/include/test/bitset/primitives.hpp
+++ b/test/include/test/bitset/primitives.hpp
@@ -21,6 +21,14 @@
 
 namespace test::bitset {
 
+// Nine of the primitives below carry NOLINT(bugprone-exception-escape) on a noexcept operator().
+// Each guards on pos < self.size() and calls a member the standard specifies as throwing outside
+// that width -- set, reset, flip, test, at -- checking in the other arm that it does throw. The
+// check reads the callee's signature and cannot read the guard, so it reports every instantiation:
+// 104 of them across the two std_bitset units. The noexcept is the claim being made, that a
+// primitive answering about a position inside the bitset never throws, and it is what would fail
+// the suite loudly were the guard ever wrong.
+
 // These checks are on xstd::bitset's basic_string_view overload: std::bitset has none, and dynamic_bitset answers to its own contract.
 template<class X>
 concept fixed_string_view_constructible = requires { X(std::string_view()); } and not dynamic<X>;
@@ -28,7 +36,7 @@ concept fixed_string_view_constructible = requires { X(std::string_view()); } an
 template<class X>
 struct constructor
 {
-        auto operator()() const noexcept
+        auto operator()() const noexcept  // NOLINT(bugprone-exception-escape)
         {
                 X a;
                 BOOST_CHECK(a.none());                                          // [bitset.cons]/1
@@ -173,7 +181,7 @@ struct mem_set
                 BOOST_CHECK_EQUAL(std::addressof(dst), std::addressof(self));           // [bitset.members]/14
         }
 
-        auto operator()(auto& self, std::size_t pos, bool val = true) const noexcept
+        auto operator()(auto& self, std::size_t pos, bool val = true) const noexcept  // NOLINT(bugprone-exception-escape)
         {
                 if (auto const N = self.size(); pos < N) {
                         auto const src = self;
@@ -197,7 +205,7 @@ struct mem_reset
                 BOOST_CHECK_EQUAL(std::addressof(dst), std::addressof(self));           // [bitset.members]/19
         }
 
-        auto operator()(auto& self, std::size_t pos) const noexcept
+        auto operator()(auto& self, std::size_t pos) const noexcept  // NOLINT(bugprone-exception-escape)
         {
                 if (auto const N = self.size(); pos < N) {
                         auto const src = self;
@@ -234,7 +242,7 @@ struct mem_flip
                 BOOST_CHECK_EQUAL(std::addressof(dst), std::addressof(self));           // [bitset.members]/26
         }
 
-        auto operator()(auto& self, std::size_t pos) const noexcept
+        auto operator()(auto& self, std::size_t pos) const noexcept  // NOLINT(bugprone-exception-escape)
         {
                 if (auto const N = self.size(); pos < N) {
                         auto const src = self;
@@ -251,7 +259,7 @@ struct mem_flip
 
 struct mem_at
 {
-        auto operator()(const auto& self, std::size_t pos) const noexcept
+        auto operator()(const auto& self, std::size_t pos) const noexcept  // NOLINT(bugprone-exception-escape)
         {
                 auto const N = self.size();
                 BOOST_CHECK(pos < N);                                                   // [bitset.members]/30
@@ -365,7 +373,7 @@ struct mem_compare_three_way
 
 struct mem_test
 {
-        auto operator()(const auto& self, std::size_t pos) const noexcept
+        auto operator()(const auto& self, std::size_t pos) const noexcept  // NOLINT(bugprone-exception-escape)
         {
                 if (auto const N = self.size(); pos < N) {
                         BOOST_CHECK_EQUAL(self.test(pos), self[pos]);                                   // [bitset.members]/46
@@ -441,7 +449,7 @@ struct mem_is_proper_subset_of
 struct mem_is_proper_subset_of_edges
 {
         template<class X>
-        auto operator()(X& a, X&) const noexcept
+        auto operator()(X& a, X&) const noexcept  // NOLINT(bugprone-exception-escape)
         {
                 auto const N = a.size();
                 if (N == 0) {
@@ -521,7 +529,7 @@ struct op_bit_minus
 struct op_iostream
 {
         template<class X>
-        auto operator()(const X& x) const noexcept
+        auto operator()(const X& x) const noexcept  // NOLINT(bugprone-exception-escape)
         {
                 std::stringstream sstr;
                 X y;
@@ -535,7 +543,7 @@ struct op_iostream
 template<class X>
 struct op_istream_failure
 {
-        auto operator()() const noexcept
+        auto operator()() const noexcept  // NOLINT(bugprone-exception-escape)
         {
                 if constexpr (fixed_string_view_constructible<X>) {
                         constexpr auto N = X().size();

--- a/test/include/test/bitset/primitives.hpp
+++ b/test/include/test/bitset/primitives.hpp
@@ -320,7 +320,7 @@ struct mem_equal_to
                 );                                                              // [bitset.members]/45
                 auto const lhs_view = xstd::set_view(self);
                 auto const rhs_view = xstd::set_view(rhs);
-#if defined(_MSC_VER)
+#ifdef _MSC_VER
                 BOOST_CHECK_EQUAL(
                         self == rhs,
                         std::ranges::equal(

--- a/test/include/test/bitset/primitives.hpp
+++ b/test/include/test/bitset/primitives.hpp
@@ -6,18 +6,16 @@
 #ifndef TEST_BITSET_PRIMITIVES_HPP
 #define TEST_BITSET_PRIMITIVES_HPP
 
-#include <boost/test/unit_test.hpp>      // BOOST_CHECK, BOOST_CHECK_EQUAL, BOOST_CHECK_EQUAL_COLLECTIONS, BOOST_CHECK_NE, BOOST_CHECK_THROW
+#include <boost/test/unit_test.hpp>      // BOOST_CHECK, BOOST_CHECK_EQUAL, BOOST_CHECK_NE, BOOST_CHECK_THROW
 #include <test/dynamic.hpp>              // dynamic
 #include <xstd/bits/ranges/set_view.hpp> // view
-#include <cstddef>                       // ptrdiff_t, size_t
-#include <iterator>                      // distance, inserter
+#include <cstddef>                       // size_t
 #include <memory>                        // addressof
 #include <set>                           // set
 #include <sstream>                       // istringstream, stringstream
 #include <stdexcept>                     // invalid_argument, out_of_range
 #include <string>                        // string
 #include <string_view>                   // string_view
-#include <type_traits>                   // remove_cvref_t
 
 namespace test::bitset {
 

--- a/test/include/test/block_types.hpp
+++ b/test/include/test/block_types.hpp
@@ -24,7 +24,7 @@ using word_types = std::tuple
 ,       std::uint16_t
 ,       std::uint32_t
 ,       std::uint64_t
-#if defined(__GNUG__)
+#ifdef __GNUG__
 ,       __uint128_t
 #endif
 >;

--- a/test/include/test/flat_set.hpp
+++ b/test/include/test/flat_set.hpp
@@ -9,7 +9,7 @@
 #include <version> // __cpp_lib_flat_set
 #ifdef __cpp_lib_flat_set
 #define TEST_HAS_FLAT_SET
-#include <flat_set> // flat_set
+#include <flat_set> // IWYU pragma: export; flat_set
 #endif
 
 // VS 2022's MSVC STL has no <flat_set>; the probe lives here because <version> has to precede it.

--- a/test/include/test/flat_set.hpp
+++ b/test/include/test/flat_set.hpp
@@ -7,7 +7,7 @@
 #define TEST_FLAT_SET_HPP
 
 #include <version> // __cpp_lib_flat_set
-#if defined(__cpp_lib_flat_set)
+#ifdef __cpp_lib_flat_set
 #define TEST_HAS_FLAT_SET
 #include <flat_set> // flat_set
 #endif

--- a/test/include/test/set/exhaustive.hpp
+++ b/test/include/test/set/exhaustive.hpp
@@ -9,10 +9,8 @@
 #include <algorithm>        // max
 #include <array>            // array
 #include <cassert>          // assert
-#include <concepts>         // integral
 #include <initializer_list> // initializer_list
 #include <ranges>           // iota, to
-#include <utility>          // declval
 
 #ifdef _MSC_VER
         // xstd::bit_finite_set<0> gives bogus "unreachable code" warnings

--- a/test/include/test/set/exhaustive.hpp
+++ b/test/include/test/set/exhaustive.hpp
@@ -14,7 +14,7 @@
 #include <ranges>           // iota, to
 #include <utility>          // declval
 
-#if defined(_MSC_VER)
+#ifdef _MSC_VER
         // xstd::bit_finite_set<0> gives bogus "unreachable code" warnings
         __pragma(warning(disable: 4702))
 #endif

--- a/test/include/test/set/primitives.hpp
+++ b/test/include/test/set/primitives.hpp
@@ -6,18 +6,16 @@
 #ifndef TEST_SET_PRIMITIVES_HPP
 #define TEST_SET_PRIMITIVES_HPP
 
-#include <boost/test/unit_test.hpp>     // BOOST_CHECK, BOOST_CHECK_EQUAL, BOOST_CHECK_EQUAL_COLLECTIONS, BOOST_CHECK_NE
+#include <boost/test/unit_test.hpp>     // BOOST_CHECK, BOOST_CHECK_EQUAL
 #include <xstd/bits/bit_finite_set.hpp> // bit_finite_set
 #include <algorithm>                    // equal_range, lexicographical_compare_three_way
 #include <compare>                      // strong_ordering
 #include <concepts>                     // convertible_to, default_initializable, equality_comparable, integral, same_as, unsigned_integral
 #include <cstddef>                      // ptrdiff_t
 #include <initializer_list>             // initializer_list
-#include <iterator>                     // distance, empty, iter_difference_t, iter_value_t, next, prev, reverse_ierator, size, ssize
-#include <limits>                       // max
-#include <memory>                       // addressof
+#include <iterator>                     // distance, empty, iter_difference_t, iter_value_t, next, prev, reverse_iterator, size, ssize
 #include <ranges>                       // count, equal, find, lexicographical_compare, lower_bound, , subrange, upper_bound
-#include <type_traits>                  // add_const_t, common_type, make_signed_t, remove_reference_t
+#include <type_traits>                  // add_const_t, common_type_t, make_signed_t, remove_reference_t
 #include <utility>                      // declval, pair
 
 namespace test::set {

--- a/test/src/bits.cpp
+++ b/test/src/bits.cpp
@@ -27,10 +27,10 @@ BOOST_AUTO_TEST_CASE(EveryContainerArrivesThroughTheOneDoor)
         // xstd::bitset is deliberately not a range, reproducing std::bitset, so the door has to deliver a working view over it.
         static_assert(not std::ranges::range<xstd::bitset<8>>);
 
-        auto legacy = xstd::bitset<8>();
+        auto const legacy = xstd::bitset<8>();
         static_assert(std::ranges::bidirectional_range<decltype(xstd::set_view(legacy))>);
 
-        auto packed = xstd::bit_array<8>();
+        auto const packed = xstd::bit_array<8>();
         static_assert(std::ranges::random_access_range<decltype(xstd::array_view(packed))>);
 }
 

--- a/test/src/bits.cpp
+++ b/test/src/bits.cpp
@@ -14,7 +14,7 @@
 #include <ranges>                     // bidirectional_range, random_access_range
 #include <set>                        // set
 #include <tuple>                      // tuple_element_t, tuple_size_v
-#include <utility>                    // declval, index_sequence, make_index_sequence
+#include <utility>                    // index_sequence, make_index_sequence
 
 
 // Every entity the front door promises, reached through it alone: no leaf test sees the door at all.

--- a/test/src/bits.cpp
+++ b/test/src/bits.cpp
@@ -5,7 +5,7 @@
 
 #include <boost/test/unit_test.hpp>   // BOOST_AUTO_TEST_CASE
 #include <test/block_types.hpp>       // graded_extents
-#include <test/flat_set.hpp>          // TEST_HAS_FLAT_SET
+#include <test/flat_set.hpp>          // IWYU pragma: keep; TEST_HAS_FLAT_SET
 #include <test/sequence/concepts.hpp> // bit_sequence
 #include <test/set/concepts.hpp>      // bit_set
 #include <xstd/bits.hpp>              // the whole bits surface

--- a/test/src/bits/bitset.cpp
+++ b/test/src/bits/bitset.cpp
@@ -3,11 +3,12 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/test/unit_test.hpp> // BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
-#include <test/block_types.hpp>     // graded_extents
-#include <xstd/bits/bitset.hpp>     // bitset
-#include <concepts>                 // regular, totally_ordered
-#include <type_traits>              // is_nothrow_*, is_trivially_*
+#include <boost/test/unit_test.hpp>      // BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
+#include <test/block_types.hpp>          // graded_extents
+#include <xstd/bits/bitset.hpp>          // bitset
+#include <xstd/bits/ranges/set_view.hpp> // set_view
+#include <concepts>                      // regular, totally_ordered
+#include <type_traits>                   // is_nothrow_*, is_trivially_*
 
 BOOST_AUTO_TEST_SUITE(Bitset)
 

--- a/test/src/bits/bitset.cpp
+++ b/test/src/bits/bitset.cpp
@@ -48,4 +48,44 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(IsTrivial, T, Types)
         static_assert(    std::is_trivially_move_assignable_v<T>);
 }
 
+// The proxy operator[] hands out, ported from array_view: assignment either way round, the
+// flipped reading, flip itself, and the three swaps. b[i] = b[j] is checked to move the bit
+// rather than the proxy, which is also what makes swap work.
+BOOST_AUTO_TEST_CASE(TheMutableSubscriptHandsOutAnAssignableProxy)
+{
+        auto b = xstd::bitset<8>{};
+
+        b[3] = true;
+        BOOST_CHECK(b[3]);
+        BOOST_CHECK(b.test(3));
+        BOOST_CHECK_EQUAL(b.count(), 1);
+
+        b[3] = false;
+        BOOST_CHECK(not b[3]);
+
+        b[1] = true;
+        b[2] = b[1];
+        BOOST_CHECK(b[1]);
+        BOOST_CHECK(b[2]);
+
+        BOOST_CHECK_EQUAL(~b[2], false);
+        b[2].flip();
+        BOOST_CHECK(not b[2]);
+
+        auto x = b[1];
+        auto y = b[2];
+        swap(x, y);
+        BOOST_CHECK(not b[1]);
+        BOOST_CHECK(b[2]);
+
+        auto z = false;
+        swap(b[2], z);
+        BOOST_CHECK(not b[2]);
+        BOOST_CHECK(z);
+
+        swap(z, b[2]);
+        BOOST_CHECK(b[2]);
+        BOOST_CHECK(not z);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/bits/bitset.cpp
+++ b/test/src/bits/bitset.cpp
@@ -72,8 +72,8 @@ BOOST_AUTO_TEST_CASE(TheMutableSubscriptHandsOutAnAssignableProxy)
         b[2].flip();
         BOOST_CHECK(not b[2]);
 
-        auto x = b[1];
-        auto y = b[2];
+        auto const x = b[1];
+        auto const y = b[2];
         swap(x, y);
         BOOST_CHECK(not b[1]);
         BOOST_CHECK(b[2]);

--- a/test/src/bits/block/type_traits.cpp
+++ b/test/src/bits/block/type_traits.cpp
@@ -19,7 +19,7 @@ using Types = std::tuple
 ,       uint16_t
 ,       uint32_t
 ,       uint64_t
-#if defined(__GNUG__)
+#ifdef __GNUG__
 ,       __uint128_t
 #endif
 >;

--- a/test/src/bits/block/type_traits.cpp
+++ b/test/src/bits/block/type_traits.cpp
@@ -8,7 +8,7 @@
 #include <cstdint>                  // uint8_t, uint16_t, uint32_t, uint64_t
 #include <limits>                   // digits
 #include <tuple>                    // tuple
-#include <type_traits>              // is_integral, is_unsigned
+#include <type_traits>              // is_integral_v, is_unsigned_v
 
 BOOST_AUTO_TEST_SUITE(Block)
 BOOST_AUTO_TEST_SUITE(TypeTraits)

--- a/test/src/bits/block/type_traits.cpp
+++ b/test/src/bits/block/type_traits.cpp
@@ -5,7 +5,6 @@
 
 #include <boost/test/unit_test.hpp> // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE_TEMPLATE
 #include <bit>                      // popcount
-#include <cstddef>                  // size_t
 #include <cstdint>                  // uint8_t, uint16_t, uint32_t, uint64_t
 #include <limits>                   // digits
 #include <tuple>                    // tuple

--- a/test/src/bits/ext/boost.cpp
+++ b/test/src/bits/ext/boost.cpp
@@ -3,9 +3,12 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/test/unit_test.hpp> // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
-#include <xstd/bits/ext/boost.hpp>  // the Boost adaptors, asked for by name
-#include <span>                     // dynamic_extent
+#include <boost/test/unit_test.hpp>        // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
+#include <xstd/bits/ext/boost.hpp>         // the Boost adaptors, asked for by name
+#include <xstd/bits/ranges/array_view.hpp> // array_range
+#include <xstd/bits/ranges/bit_extent.hpp> // bit_extent
+#include <xstd/bits/ranges/set_view.hpp>   // set_range
+#include <span>                            // dynamic_extent
 
 BOOST_AUTO_TEST_SUITE(Ext)
 BOOST_AUTO_TEST_SUITE(Boost)

--- a/test/src/bits/ext/boost/dynamic_bitset.cpp
+++ b/test/src/bits/ext/boost/dynamic_bitset.cpp
@@ -5,7 +5,7 @@
 
 #include <boost/test/unit_test.hpp>               // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
 #include <test/dynamic.hpp>                       // dynamic
-#include <xstd/bits/ext/boost/dynamic_bitset.hpp> // bit_extent, set_find, set_compare, array_find
+#include <xstd/bits/ext/boost/dynamic_bitset.hpp> // the hooks that make dynamic_bitset a bit range
 #include <xstd/bits/ranges/array_view.hpp>        // array_range
 #include <xstd/bits/ranges/set_view.hpp>          // set_range, set_view
 #include <algorithm>                              // lexicographical_compare

--- a/test/src/bits/ext/boost/dynamic_bitset.cpp
+++ b/test/src/bits/ext/boost/dynamic_bitset.cpp
@@ -10,7 +10,6 @@
 #include <compare>                                // strong_ordering
 #include <concepts>                               // regular, totally_ordered
 #include <cstddef>                                // size_t
-#include <ranges>                                 // range
 #include <set>                                    // set
 #include <type_traits>                            // is_trivially_copyable_v
 

--- a/test/src/bits/ext/boost/dynamic_bitset.cpp
+++ b/test/src/bits/ext/boost/dynamic_bitset.cpp
@@ -36,18 +36,20 @@ BOOST_AUTO_TEST_CASE(TheViewReplacesItsOrderingRatherThanTrustingIt)
         auto disagreements = 0;
         for (auto i = 0UZ; i < (1UZ << N); ++i) {
                 for (auto j = 0UZ; j < (1UZ << N); ++j) {
-                        auto x = T(N), y = T(N);
-                        auto kx = std::set<std::size_t>(), ky = std::set<std::size_t>();
+                        auto x = T(N);
+                        auto y = T(N);
+                        auto kx = std::set<std::size_t>();
+                        auto ky = std::set<std::size_t>();
                         for (auto k = 0UZ; k < N; ++k) {
-                                if (i >> k & 1UZ) { x.set(k); kx.insert(k); }
-                                if (j >> k & 1UZ) { y.set(k); ky.insert(k); }
+                                if ((i >> k & 1UZ) != 0UZ) { x.set(k); kx.insert(k); }
+                                if ((j >> k & 1UZ) != 0UZ) { y.set(k); ky.insert(k); }
                         }
 
                         // What the keys themselves say, which is what the set reading means.
-                        auto const expected = std::lexicographical_compare(kx.begin(), kx.end(), ky.begin(), ky.end());
+                        auto const expected = std::ranges::lexicographical_compare(kx, ky);
 
                         BOOST_CHECK_EQUAL((xstd::set_view(x) <=> xstd::set_view(y)) < 0, expected);
-                        disagreements += (x < y) != expected;
+                        disagreements += static_cast<int>((x < y) != expected);
                 }
         }
 

--- a/test/src/bits/ext/boost/dynamic_bitset.cpp
+++ b/test/src/bits/ext/boost/dynamic_bitset.cpp
@@ -6,6 +6,8 @@
 #include <boost/test/unit_test.hpp>               // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
 #include <test/dynamic.hpp>                       // dynamic
 #include <xstd/bits/ext/boost/dynamic_bitset.hpp> // bit_extent, set_find, set_compare, array_find
+#include <xstd/bits/ranges/array_view.hpp>        // array_range
+#include <xstd/bits/ranges/set_view.hpp>          // set_range, set_view
 #include <algorithm>                              // lexicographical_compare
 #include <compare>                                // strong_ordering
 #include <concepts>                               // regular, totally_ordered

--- a/test/src/bits/ext/std.cpp
+++ b/test/src/bits/ext/std.cpp
@@ -3,10 +3,12 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/test/unit_test.hpp> // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
-#include <xstd/bits/ext/std.hpp>    // the std adaptors, asked for by name
-#include <bitset>                   // bitset
-#include <span>                     // dynamic_extent
+#include <boost/test/unit_test.hpp>        // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
+#include <xstd/bits/ext/std.hpp>           // the std adaptors, asked for by name
+#include <xstd/bits/ranges/array_view.hpp> // array_range
+#include <xstd/bits/ranges/set_view.hpp>   // set_range
+#include <bitset>                          // bitset
+#include <span>                            // dynamic_extent
 
 BOOST_AUTO_TEST_SUITE(Ext)
 BOOST_AUTO_TEST_SUITE(Std)

--- a/test/src/bits/ext/std.cpp
+++ b/test/src/bits/ext/std.cpp
@@ -6,7 +6,6 @@
 #include <boost/test/unit_test.hpp> // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
 #include <xstd/bits/ext/std.hpp>    // the std adaptors, asked for by name
 #include <bitset>                   // bitset
-#include <cstddef>                  // size_t
 #include <span>                     // dynamic_extent
 
 BOOST_AUTO_TEST_SUITE(Ext)

--- a/test/src/bits/ext/std/bitset.cpp
+++ b/test/src/bits/ext/std/bitset.cpp
@@ -8,7 +8,6 @@
 #include <xstd/bits/ext/std/bitset.hpp> // bit_extent, set_find, set_compare, array_find
 #include <bitset>                       // bitset
 #include <concepts>                     // regular, totally_ordered
-#include <cstddef>                      // size_t
 #include <ranges>                       // range
 #include <tuple>                        // tuple
 #include <type_traits>                  // is_nothrow_*, is_trivially_*

--- a/test/src/bits/ext/std/bitset.cpp
+++ b/test/src/bits/ext/std/bitset.cpp
@@ -5,7 +5,7 @@
 
 #include <boost/test/unit_test.hpp>        // BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
 #include <xstd/bits/bitset.hpp>            // bitset
-#include <xstd/bits/ext/std/bitset.hpp>    // bit_extent, set_find, set_compare, array_find
+#include <xstd/bits/ext/std/bitset.hpp>    // bit_extent, set_find, array_find
 #include <xstd/bits/ranges/array_view.hpp> // array_range
 #include <xstd/bits/ranges/set_view.hpp>   // set_range, set_view
 #include <bitset>                          // bitset

--- a/test/src/bits/ext/std/bitset.cpp
+++ b/test/src/bits/ext/std/bitset.cpp
@@ -3,14 +3,16 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
-#include <xstd/bits/bitset.hpp>         // bitset
-#include <xstd/bits/ext/std/bitset.hpp> // bit_extent, set_find, set_compare, array_find
-#include <bitset>                       // bitset
-#include <concepts>                     // regular, totally_ordered
-#include <ranges>                       // range
-#include <tuple>                        // tuple
-#include <type_traits>                  // is_nothrow_*, is_trivially_*
+#include <boost/test/unit_test.hpp>        // BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
+#include <xstd/bits/bitset.hpp>            // bitset
+#include <xstd/bits/ext/std/bitset.hpp>    // bit_extent, set_find, set_compare, array_find
+#include <xstd/bits/ranges/array_view.hpp> // array_range
+#include <xstd/bits/ranges/set_view.hpp>   // set_range, set_view
+#include <bitset>                          // bitset
+#include <concepts>                        // regular, totally_ordered
+#include <ranges>                          // range
+#include <tuple>                           // tuple
+#include <type_traits>                     // is_nothrow_*, is_trivially_*
 
 BOOST_AUTO_TEST_SUITE(Ext)
 BOOST_AUTO_TEST_SUITE(Std)

--- a/test/src/bits/ext/xstd/bitset.cpp
+++ b/test/src/bits/ext/xstd/bitset.cpp
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE(IteratingVisitsTheOneBitsAsKeys)
         BOOST_CHECK_EQUAL(std::distance(std::ranges::begin(c), std::ranges::end(c)), 3);
 
         auto keys = std::vector<std::size_t>();
-        for (auto k : c) {
+        for (auto const k : c) {
                 keys.push_back(k);
         }
         BOOST_CHECK((keys == std::vector<std::size_t>{1, 7, 15}));

--- a/test/src/bits/ranges.cpp
+++ b/test/src/bits/ranges.cpp
@@ -10,6 +10,7 @@
 #include <concepts>                     // same_as
 #include <cstddef>                      // size_t
 #include <type_traits>                  // is_convertible_v
+#include <utility>                      // declval
 
 BOOST_AUTO_TEST_SUITE(Ranges)
 

--- a/test/src/bits/ranges/array_view.cpp
+++ b/test/src/bits/ranges/array_view.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(TheSequenceReadingIsTheArrayOfBools)
                 auto packed = xstd::bitset<N>();
                 auto plain  = std::array<bool, N>{};
                 for (auto k = 0UZ; k < N; ++k) {
-                        if (i >> k & 1UZ) { packed.set(k); plain[k] = true; }
+                        if ((i >> k & 1UZ) != 0UZ) { packed.set(k); plain[k] = true; }
                 }
 
                 auto const view = xstd::array_view(packed);

--- a/test/src/bits/ranges/array_view.cpp
+++ b/test/src/bits/ranges/array_view.cpp
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(TheSequenceReadingIsTheArrayOfBools)
 BOOST_AUTO_TEST_CASE(WritingThroughTheViewWritesTheBits)
 {
         auto packed = xstd::bitset<8>();
-        auto view = xstd::array_view(packed);
+        auto const view = xstd::array_view(packed);
 
         view[3] = true;
         BOOST_CHECK(packed.test(3));

--- a/test/src/bits/ranges/array_view.cpp
+++ b/test/src/bits/ranges/array_view.cpp
@@ -14,7 +14,6 @@
 #include <algorithm>                              // equal
 #include <array>                                  // array
 #include <bitset>                                 // bitset
-#include <cstddef>                                // size_t
 #include <ranges>                                 // random_access_range
 
 BOOST_AUTO_TEST_SUITE(Ranges)

--- a/test/src/bits/ranges/bit_extent.cpp
+++ b/test/src/bits/ranges/bit_extent.cpp
@@ -9,7 +9,6 @@
 #include <xstd/bits/ext/std/bitset.hpp>           // bit_extent over std::bitset
 #include <xstd/bits/ranges/bit_extent.hpp>        // bit_extent, static_bit_extent
 #include <bitset>                                 // bitset
-#include <cstddef>                                // size_t
 #include <span>                                   // dynamic_extent
 
 BOOST_AUTO_TEST_SUITE(Ranges)

--- a/test/src/bits/ranges/block_access.cpp
+++ b/test/src/bits/ranges/block_access.cpp
@@ -15,7 +15,6 @@
 #include <xstd/bits/ranges/set_view.hpp>          // set_view
 #include <algorithm>                              // lexicographical_compare, lexicographical_compare_three_way
 #include <bitset>                                 // bitset
-#include <compare>                                // strong_ordering
 #include <cstddef>                                // size_t
 #include <cstdint>                                // uint8_t
 #include <set>                                    // set

--- a/test/src/bits/ranges/block_access.cpp
+++ b/test/src/bits/ranges/block_access.cpp
@@ -49,8 +49,8 @@ auto sweep() -> void
                                 if (j >> k & 1UZ) { sy.insert(k); ay[k] = true; ky.insert(k); vy[k] = true; }
                         }
 
-                        set_disagreements   += ((sx <=> sy) < 0) != std::lexicographical_compare(kx.begin(), kx.end(), ky.begin(), ky.end());
-                        array_disagreements += ((ax <=> ay) < 0) != std::lexicographical_compare(vx.begin(), vx.end(), vy.begin(), vy.end());
+                        set_disagreements   += ((sx <=> sy) < 0) != std::ranges::lexicographical_compare(kx, ky);
+                        array_disagreements += ((ax <=> ay) < 0) != std::ranges::lexicographical_compare(vx, vy);
 
                         // The invariant proper: these two stream blocks and never iterate, and must still mean what iterating would.
                         opaque_disagreements += (sx <=> sy) != std::lexicographical_compare_three_way(sx.begin(), sx.end(), sy.begin(), sy.end());

--- a/test/src/bits/ranges/block_access.cpp
+++ b/test/src/bits/ranges/block_access.cpp
@@ -11,7 +11,7 @@
 #include <xstd/bits/ext/boost/dynamic_bitset.hpp> // the one that stays element-wise
 #include <xstd/bits/ext/std/bitset.hpp>           // block_access over std::bitset, where the words are reachable
 #include <xstd/bits/ranges/array_view.hpp>        // array_view
-#include <xstd/bits/ranges/block_access.hpp>      // block_access, block_range
+#include <xstd/bits/ranges/block_access.hpp>      // block_range
 #include <xstd/bits/ranges/set_view.hpp>          // set_view
 #include <algorithm>                              // lexicographical_compare, lexicographical_compare_three_way
 #include <bitset>                                 // bitset

--- a/test/src/bits/ranges/set_view.cpp
+++ b/test/src/bits/ranges/set_view.cpp
@@ -10,8 +10,6 @@
 #include <xstd/bits/ext/std/bitset.hpp>           // set_find, set_compare over std::bitset
 #include <xstd/bits/ranges/set_view.hpp>          // set_view, set_range
 #include <bitset>                                 // bitset
-#include <concepts>                               // totally_ordered
-#include <cstddef>                                // size_t
 #include <ranges>                                 // bidirectional_range
 
 BOOST_AUTO_TEST_SUITE(Ranges)

--- a/test/src/bits/ranges/set_view.cpp
+++ b/test/src/bits/ranges/set_view.cpp
@@ -31,6 +31,23 @@ BOOST_AUTO_TEST_CASE(TheViewedTypesAreTheOnesHoldingASetWithoutOfferingIt)
         static_assert(std::ranges::bidirectional_range<xstd::set_view<boost::dynamic_bitset<>>>);
 }
 
+// A dynamic extent is a std::set: it can still grow, so a position past its current size is absent rather than a
+// precondition violation, and the query answers instead of asserting. A static extent asserts, which is why only
+// this half is testable.
+BOOST_AUTO_TEST_CASE(ADynamicExtentAnswersForPositionsBeyondItsCurrentSize)
+{
+        auto bits = boost::dynamic_bitset<>(8);
+        bits.set(3);
+        auto const v = xstd::set_view(bits);
+
+        BOOST_CHECK(v.contains(3));
+        BOOST_CHECK(not v.contains(8));
+        BOOST_CHECK(not v.contains(99));
+        BOOST_CHECK_EQUAL(v.count(99), 0);
+        BOOST_CHECK(v.find(99) == v.end());
+        BOOST_CHECK(v.lower_bound(99) == v.end());
+}
+
 // The set ordering against std::set rather than a restatement of it, for every viewed type including the one whose own <=> disagrees.
 BOOST_AUTO_TEST_CASE(EveryViewedTypeOrdersLikeAStdSet)
 {

--- a/test/src/bits/ranges/set_view.cpp
+++ b/test/src/bits/ranges/set_view.cpp
@@ -10,10 +10,31 @@
 #include <xstd/bits/ext/std/bitset.hpp>           // set_find, set_compare over std::bitset
 #include <xstd/bits/ranges/set_view.hpp>          // set_view, set_range
 #include <bitset>                                 // bitset
+#include <concepts>                               // same_as
 #include <ranges>                                 // bidirectional_range
+#include <tuple>                                  // tuple
 
 BOOST_AUTO_TEST_SUITE(Ranges)
 BOOST_AUTO_TEST_SUITE(SetView)
+
+namespace {
+
+// One static extent of each library, and the dynamic one.
+using ViewedTypes = std::tuple<std::bitset<8>, xstd::bitset<8>, boost::dynamic_bitset<>>;
+
+// dynamic_bitset alone needs its width at construction; the others carry theirs in the type.
+template<class T>
+auto eight_bits_with_three_set() -> T
+{
+        auto bits = T();
+        if constexpr (std::same_as<T, boost::dynamic_bitset<>>) {
+                bits.resize(8);
+        }
+        bits.set(3);
+        return bits;
+}
+
+}  // namespace
 
 // The types a set_view exists for: those holding a set of positions without offering it, which bit_finite_set already does.
 BOOST_AUTO_TEST_CASE(TheViewedTypesAreTheOnesHoldingASetWithoutOfferingIt)
@@ -31,14 +52,13 @@ BOOST_AUTO_TEST_CASE(TheViewedTypesAreTheOnesHoldingASetWithoutOfferingIt)
         static_assert(std::ranges::bidirectional_range<xstd::set_view<boost::dynamic_bitset<>>>);
 }
 
-// A dynamic extent is a std::set: it can still grow, so a position past its current size is absent rather than a
-// precondition violation, and the query answers instead of asserting. A static extent asserts, which is why only
-// this half is testable.
-BOOST_AUTO_TEST_CASE(ADynamicExtentAnswersForPositionsBeyondItsCurrentSize)
+// Asking is total whatever the extent: a position past the width is a key the set does not hold,
+// which every one of these answers rather than refuses, exactly as [set] has it.
+BOOST_AUTO_TEST_CASE_TEMPLATE(EveryExtentAnswersForPositionsPastItsWidth, T, ViewedTypes)
 {
-        auto bits = boost::dynamic_bitset<>(8);
-        bits.set(3);
+        auto bits = eight_bits_with_three_set<T>();
         auto const v = xstd::set_view(bits);
+        auto const width = v.max_size();
 
         // Both ways round, so that find and lower_bound are each seen taking either arm.
         BOOST_CHECK(v.contains(3));
@@ -48,11 +68,48 @@ BOOST_AUTO_TEST_CASE(ADynamicExtentAnswersForPositionsBeyondItsCurrentSize)
         BOOST_CHECK(v.find(3) != v.end());  // NOLINT(readability-container-contains)
         BOOST_CHECK(v.lower_bound(3) == v.find(3));
 
-        BOOST_CHECK(not v.contains(8));
         BOOST_CHECK(not v.contains(99));
         BOOST_CHECK_EQUAL(v.count(99), 0);
         BOOST_CHECK(v.find(99) == v.end());  // NOLINT(readability-container-contains)
         BOOST_CHECK(v.lower_bound(99) == v.end());
+
+        // Asked from inside the width, where the scan actually runs: nothing is above 3 here.
+        BOOST_CHECK(v.upper_bound(3) == v.end());
+        BOOST_CHECK(v.upper_bound(99) == v.end());
+
+        // Erasing what is not there is the no-op returning zero that std::set::erase is, and it
+        // neither shrinks the width nor disturbs what is held.
+        BOOST_CHECK_EQUAL(v.erase(99), 0);
+        BOOST_CHECK(v.contains(3));
+        BOOST_CHECK_EQUAL(v.size(), 1);
+        BOOST_CHECK_EQUAL(v.max_size(), width);
+}
+
+// The other half of the std::set reading: [set] gives insert no way to fail, so a dynamic
+// extent grows to hold a position past its current size rather than asserting on it.
+BOOST_AUTO_TEST_CASE(ADynamicExtentGrowsToHoldAPositionPastItsCurrentSize)
+{
+        auto bits = boost::dynamic_bitset<>(8);
+        bits.set(3);
+        auto const v = xstd::set_view(bits);
+
+        auto const [ where, inserted ] = v.insert(99);
+        BOOST_CHECK(inserted);
+        BOOST_CHECK(where != v.end());
+        BOOST_CHECK(v.contains(99));
+        BOOST_CHECK(v.contains(3));
+        BOOST_CHECK_EQUAL(v.size(), 2);
+        BOOST_CHECK_EQUAL(v.max_size(), 100);
+        BOOST_CHECK_EQUAL(bits.size(), 100);
+
+        // And within the size it is the plain write, growing nothing.
+        v.insert(5);
+        BOOST_CHECK(v.contains(5));
+        BOOST_CHECK_EQUAL(v.max_size(), 100);
+
+        v.erase(99);
+        BOOST_CHECK(not v.contains(99));
+        BOOST_CHECK_EQUAL(v.max_size(), 100);
 }
 
 // The set ordering against std::set rather than a restatement of it, for every viewed type including the one whose own <=> disagrees.

--- a/test/src/bits/ranges/set_view.cpp
+++ b/test/src/bits/ranges/set_view.cpp
@@ -43,13 +43,15 @@ BOOST_AUTO_TEST_CASE(ADynamicExtentAnswersForPositionsBeyondItsCurrentSize)
         // Both ways round, so that find and lower_bound are each seen taking either arm.
         BOOST_CHECK(v.contains(3));
         BOOST_CHECK_EQUAL(v.count(3), 1);
-        BOOST_CHECK(v.find(3) != v.end());
+        // contains is checked just above; find is the subject here, so readability-container-contains
+        // is asking for the one call this case exists to make.
+        BOOST_CHECK(v.find(3) != v.end());  // NOLINT(readability-container-contains)
         BOOST_CHECK(v.lower_bound(3) == v.find(3));
 
         BOOST_CHECK(not v.contains(8));
         BOOST_CHECK(not v.contains(99));
         BOOST_CHECK_EQUAL(v.count(99), 0);
-        BOOST_CHECK(v.find(99) == v.end());
+        BOOST_CHECK(v.find(99) == v.end());  // NOLINT(readability-container-contains)
         BOOST_CHECK(v.lower_bound(99) == v.end());
 }
 

--- a/test/src/bits/ranges/set_view.cpp
+++ b/test/src/bits/ranges/set_view.cpp
@@ -40,7 +40,12 @@ BOOST_AUTO_TEST_CASE(ADynamicExtentAnswersForPositionsBeyondItsCurrentSize)
         bits.set(3);
         auto const v = xstd::set_view(bits);
 
+        // Both ways round, so that find and lower_bound are each seen taking either arm.
         BOOST_CHECK(v.contains(3));
+        BOOST_CHECK_EQUAL(v.count(3), 1);
+        BOOST_CHECK(v.find(3) != v.end());
+        BOOST_CHECK(v.lower_bound(3) == v.find(3));
+
         BOOST_CHECK(not v.contains(8));
         BOOST_CHECK(not v.contains(99));
         BOOST_CHECK_EQUAL(v.count(99), 0);

--- a/test/src/bits/std_bitset/o0.cpp
+++ b/test/src/bits/std_bitset/o0.cpp
@@ -56,7 +56,7 @@ using Types = std::tuple
 ,        xstd::bitset< 63, uint64_t>
 ,        xstd::bitset< 64, uint64_t>
 ,        xstd::bitset< 65, uint64_t>
-#if defined(__GNUG__)
+#ifdef __GNUG__
 ,        xstd::bitset<  0, __uint128_t>
 ,        xstd::bitset<  1, __uint128_t>
 ,        xstd::bitset<127, __uint128_t>

--- a/test/src/bits/std_bitset/o0.cpp
+++ b/test/src/bits/std_bitset/o0.cpp
@@ -6,9 +6,11 @@
 #include <boost/test/unit_test.hpp>               // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE_TEMPLATE
 #include <test/bitset/exhaustive.hpp>             // empty_set_pair
 #include <test/bitset/primitives.hpp>             // constructor,
+#include <xstd/bits/bitset.hpp>                   // bitset
 #include <xstd/bits/ext/boost/dynamic_bitset.hpp> // dynamic_bitset
 #include <xstd/bits/ext/std/bitset.hpp>           // bitset
 #include <xstd/bits/ext/xstd/bitset.hpp>          // bitset
+#include <bitset>                                 // bitset
 #include <cstdint>                                // uint8_t, uint16_t, uint32_t, uint64_t
 #include <tuple>                                  // tuple
 

--- a/test/src/bits/std_bitset/o1.cpp
+++ b/test/src/bits/std_bitset/o1.cpp
@@ -30,7 +30,7 @@ using Types = std::tuple
 ,        xstd::bitset<24, uint16_t>
 ,        xstd::bitset<24, uint32_t>
 ,        xstd::bitset<24, uint64_t>
-#if defined(__GNUG__)
+#ifdef __GNUG__
 ,        xstd::bitset<24, __uint128_t>
 #endif
 >;

--- a/test/src/bits/std_bitset/o1.cpp
+++ b/test/src/bits/std_bitset/o1.cpp
@@ -9,6 +9,7 @@
 #include <xstd/bits/bitset.hpp>                   // bitset
 #include <xstd/bits/ext/boost/dynamic_bitset.hpp> // dynamic_bitset
 #include <xstd/bits/ext/std/bitset.hpp>           // bitset
+#include <bitset>                                 // bitset
 #include <cstdint>                                // uint8_t, uint16_t, uint32_t, uint64_t
 #include <tuple>                                  // tuple
 

--- a/test/src/bits/std_bitset/o2.cpp
+++ b/test/src/bits/std_bitset/o2.cpp
@@ -6,9 +6,11 @@
 #include <boost/test/unit_test.hpp>               // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE_TEMPLATE
 #include <test/bitset/exhaustive.hpp>             // all_singleton_sets, all_singleton_set_pairs, all_doubleton_sets, any_value, empty_set, full_set
 #include <test/bitset/primitives.hpp>             // mem_bit_and_assign, mem_bit_or_assign, mem_bit_xor_assign, mem_bit_minus_assign,
+#include <xstd/bits/bitset.hpp>                   // bitset
 #include <xstd/bits/ext/boost/dynamic_bitset.hpp> // dynamic_bitset
 #include <xstd/bits/ext/std/bitset.hpp>           // bitset
 #include <xstd/bits/ext/xstd/bitset.hpp>          // bitset
+#include <bitset>                                 // bitset
 #include <cstdint>                                // uint8_t, uint16_t, uint32_t, uint64_t
 #include <tuple>                                  // tuple
 

--- a/test/src/bits/std_bitset/o2.cpp
+++ b/test/src/bits/std_bitset/o2.cpp
@@ -26,7 +26,7 @@ using Types = std::tuple
 ,        xstd::bitset< 8, uint16_t>
 ,        xstd::bitset< 8, uint32_t>
 ,        xstd::bitset< 8, uint64_t>
-#if defined(__GNUG__)
+#ifdef __GNUG__
 ,        xstd::bitset< 8, __uint128_t>
 #endif
 >;

--- a/test/src/bits/std_bitset/o3.cpp
+++ b/test/src/bits/std_bitset/o3.cpp
@@ -28,7 +28,7 @@ using Types = std::tuple
 ,        xstd::bitset<17, uint16_t>
 ,        xstd::bitset<17, uint32_t>
 ,        xstd::bitset<17, uint64_t>
-#if defined(__GNUG__)
+#ifdef __GNUG__
 ,        xstd::bitset<17, __uint128_t>
 #endif
 >;

--- a/test/src/bits/std_bitset/o3.cpp
+++ b/test/src/bits/std_bitset/o3.cpp
@@ -6,9 +6,11 @@
 #include <boost/test/unit_test.hpp>               // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE_TEMPLATE
 #include <test/bitset/exhaustive.hpp>             // all_singleton_sets, all_doubleton_sets, all_triplet_sets, empty_set, full_set
 #include <test/bitset/primitives.hpp>             // mem_compare_three_way
+#include <xstd/bits/bitset.hpp>                   // bitset
 #include <xstd/bits/ext/boost/dynamic_bitset.hpp> // dynamic_bitset
 #include <xstd/bits/ext/std/bitset.hpp>           // bitset
 #include <xstd/bits/ext/xstd/bitset.hpp>          // bitset
+#include <bitset>                                 // bitset
 #include <cstdint>                                // uint8_t, uint16_t, uint32_t, uint64_t
 #include <tuple>                                  // tuple
 

--- a/test/src/bits/std_bitset/o4.cpp
+++ b/test/src/bits/std_bitset/o4.cpp
@@ -28,7 +28,7 @@ using Types = std::tuple
 ,        xstd::bitset<17, uint16_t>
 ,        xstd::bitset<17, uint32_t>
 ,        xstd::bitset<17, uint64_t>
-#if defined(__GNUG__)
+#ifdef __GNUG__
 ,        xstd::bitset<17, __uint128_t>
 #endif
 >;

--- a/test/src/bits/std_bitset/o4.cpp
+++ b/test/src/bits/std_bitset/o4.cpp
@@ -6,9 +6,11 @@
 #include <boost/test/unit_test.hpp>               // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE_TEMPLATE
 #include <test/bitset/exhaustive.hpp>             // all_doubleton_set_pairs
 #include <test/bitset/primitives.hpp>             // mem_compare_three_way, mem_is_subset_of, mem_is_proper_subset_of
+#include <xstd/bits/bitset.hpp>                   // bitset
 #include <xstd/bits/ext/boost/dynamic_bitset.hpp> // dynamic_bitset
 #include <xstd/bits/ext/std/bitset.hpp>           // bitset
 #include <xstd/bits/ext/xstd/bitset.hpp>          // bitset
+#include <bitset>                                 // bitset
 #include <cstdint>                                // uint8_t, uint16_t, uint32_t, uint64_t
 #include <tuple>                                  // tuple
 

--- a/test/src/bits/std_bitset/sieve.cpp
+++ b/test/src/bits/std_bitset/sieve.cpp
@@ -5,7 +5,7 @@
 
 #include <boost/test/unit_test.hpp>               // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE
 #include <fmt/format.h>                           // format
-#include <fmt/ranges.h>
+#include <fmt/ranges.h>                           // IWYU pragma: keep; the range formatters
 #include <opt/bitset/sieve.hpp>                   // filter_twins, sift_primes0, sift_primes1
 #include <xstd/bits/bit_finite_set.hpp>           // bit_finite_set
 #include <xstd/bits/bitset.hpp>                   // bitset

--- a/test/src/bits/std_bitset/sieve.cpp
+++ b/test/src/bits/std_bitset/sieve.cpp
@@ -19,7 +19,7 @@
 BOOST_AUTO_TEST_SUITE(StdBitset)
 BOOST_AUTO_TEST_SUITE(Sieve)
 
-inline constexpr auto N = 100uz;
+inline constexpr auto N = 100UZ;
 
 using Types = std::tuple
 <       boost::dynamic_bitset<>

--- a/test/src/bits/std_bitset/sieve.cpp
+++ b/test/src/bits/std_bitset/sieve.cpp
@@ -12,7 +12,7 @@
 #include <xstd/bits/ext/boost/dynamic_bitset.hpp> // dynamic_bitset
 #include <xstd/bits/ext/std/bitset.hpp>           // bitset
 #include <xstd/bits/ext/xstd/bitset.hpp>          // bitset
-#include <xstd/bits/ranges/set_view.hpp>          // view
+#include <xstd/bits/ranges/set_view.hpp>          // set_view
 #include <bitset>                                 // bitset
 #include <tuple>                                  // tuple
 

--- a/test/src/bits/std_bitset/sieve.cpp
+++ b/test/src/bits/std_bitset/sieve.cpp
@@ -8,10 +8,12 @@
 #include <fmt/ranges.h>
 #include <opt/bitset/sieve.hpp>                   // filter_twins, sift_primes0, sift_primes1
 #include <xstd/bits/bit_finite_set.hpp>           // bit_finite_set
+#include <xstd/bits/bitset.hpp>                   // bitset
 #include <xstd/bits/ext/boost/dynamic_bitset.hpp> // dynamic_bitset
 #include <xstd/bits/ext/std/bitset.hpp>           // bitset
 #include <xstd/bits/ext/xstd/bitset.hpp>          // bitset
 #include <xstd/bits/ranges/set_view.hpp>          // view
+#include <bitset>                                 // bitset
 #include <tuple>                                  // tuple
 
 BOOST_AUTO_TEST_SUITE(StdBitset)

--- a/test/src/bits/std_set/constexpr.cpp
+++ b/test/src/bits/std_set/constexpr.cpp
@@ -6,6 +6,7 @@
 #include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_CHECK_EQUAL_COLLECTIONS
 #include <xstd/bits/bit_finite_set.hpp> // bit_finite_set
 #include <compare>                      // strong_ordering
+#include <cstdint>                      // uint8_t, uint16_t, uint32_t, uint64_t
 #include <tuple>                        // tuple
 
 BOOST_AUTO_TEST_SUITE(StdSet)

--- a/test/src/bits/std_set/constexpr.cpp
+++ b/test/src/bits/std_set/constexpr.cpp
@@ -44,7 +44,7 @@ using Types = std::tuple
 ,       xstd::bit_finite_set< 63, uint64_t>
 ,       xstd::bit_finite_set< 64, uint64_t>
 ,       xstd::bit_finite_set< 65, uint64_t>
-#if defined(__GNUG__)
+#ifdef __GNUG__
 ,       xstd::bit_finite_set<  0, __uint128_t>
 ,       xstd::bit_finite_set<  1, __uint128_t>
 ,       xstd::bit_finite_set<127, __uint128_t>

--- a/test/src/bits/std_set/constexpr.cpp
+++ b/test/src/bits/std_set/constexpr.cpp
@@ -3,7 +3,7 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_CHECK_EQUAL_COLLECTIONS
+#include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE_TEMPLATE
 #include <xstd/bits/bit_finite_set.hpp> // bit_finite_set
 #include <compare>                      // strong_ordering
 #include <cstdint>                      // uint8_t, uint16_t, uint32_t, uint64_t

--- a/test/src/bits/std_set/constexpr.cpp
+++ b/test/src/bits/std_set/constexpr.cpp
@@ -60,8 +60,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(AnEmptySetIsUsableInAConstantExpression, T, Types)
         static_assert(b.empty());
         static_assert(b.size() == 0);
         static_assert(b.begin() == b.end());
-        static_assert(b == b);
-        static_assert((b <=> b) == std::strong_ordering::equal);
+        // Reflexivity is the property under test, and there is no writing it without naming the
+        // object twice; misc-redundant-expression sees only that the two operands match.
+        static_assert(b == b);                                   // NOLINT(misc-redundant-expression)
+        static_assert((b <=> b) == std::strong_ordering::equal); // NOLINT(misc-redundant-expression)
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(AFullSetIsUsableInAConstantExpression, T, Types)
@@ -71,8 +73,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(AFullSetIsUsableInAConstantExpression, T, Types)
         static_assert(b.size() == b.max_size());
         static_assert(b.empty() or b.front() == *b.cbegin());
         static_assert(b.empty() or b.back()  == *b.crbegin());
-        static_assert(b == b);
-        static_assert((b <=> b) == std::strong_ordering::equal);
+        // Reflexivity is the property under test, and there is no writing it without naming the
+        // object twice; misc-redundant-expression sees only that the two operands match.
+        static_assert(b == b);                                   // NOLINT(misc-redundant-expression)
+        static_assert((b <=> b) == std::strong_ordering::equal); // NOLINT(misc-redundant-expression)
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/bits/std_set/implicit.cpp
+++ b/test/src/bits/std_set/implicit.cpp
@@ -37,7 +37,7 @@ using Types = std::tuple
 ,       xstd::bit_finite_set<128, uint64_t>
 ,       xstd::bit_finite_set<129, uint64_t>
 ,       xstd::bit_finite_set<192, uint64_t>
-#if defined(__GNUG__)
+#ifdef __GNUG__
 ,       xstd::bit_finite_set<128, __uint128_t>
 ,       xstd::bit_finite_set<129, __uint128_t>
 ,       xstd::bit_finite_set<256, __uint128_t>

--- a/test/src/bits/std_set/implicit.cpp
+++ b/test/src/bits/std_set/implicit.cpp
@@ -4,7 +4,7 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_CHECK_EQUAL_COLLECTIONS
-#include <test/flat_set.hpp>            // TEST_HAS_FLAT_SET
+#include <test/flat_set.hpp>            // IWYU pragma: keep; TEST_HAS_FLAT_SET
 #include <xstd/bits/bit_finite_set.hpp> // bit_finite_set
 #include <algorithm>                    // copy
 #include <cstddef>                      // size_t

--- a/test/src/bits/std_set/implicit.cpp
+++ b/test/src/bits/std_set/implicit.cpp
@@ -7,7 +7,6 @@
 #include <test/flat_set.hpp>            // TEST_HAS_FLAT_SET
 #include <xstd/bits/bit_finite_set.hpp> // bit_finite_set
 #include <algorithm>                    // copy
-#include <concepts>                     // integral
 #include <cstddef>                      // size_t
 #include <cstdint>                      // uint8_t, uint16_t, uint32_t, uint64_t
 #include <iterator>                     // inserter

--- a/test/src/bits/std_set/implicit.cpp
+++ b/test/src/bits/std_set/implicit.cpp
@@ -8,7 +8,7 @@
 #include <xstd/bits/bit_finite_set.hpp> // bit_finite_set
 #include <algorithm>                    // copy
 #include <cstddef>                      // size_t
-#include <cstdint>                      // uint8_t, uint16_t, uint32_t, uint64_t
+#include <cstdint>                      // uint16_t, uint32_t, uint64_t
 #include <iterator>                     // inserter
 #include <set>                          // set
 #include <tuple>                        // tuple

--- a/test/src/bits/std_set/implicit.cpp
+++ b/test/src/bits/std_set/implicit.cpp
@@ -51,12 +51,14 @@ class Implicit
 
 public:
         [[nodiscard]] constexpr explicit(false) Implicit(std::size_t v) noexcept : m_value(v) {}
-        [[nodiscard]] constexpr explicit(false) operator std::size_t() const noexcept { return m_value; }
+        // Implicit is the point: this class exists to be converted from and to without a cast,
+        // which is what the case below checks.
+        [[nodiscard]] constexpr explicit(false) operator std::size_t() const noexcept { return m_value; }  // NOLINT(misc-explicit-constructor)
 };
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(TheKeysCopyIntoASetOfAnImplicitlyConstructibleType, T, Types)
 {
-        auto src = T({ 2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31 });
+        auto const src = T({ 2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31 });
         std::set<Implicit> dst;
         std::ranges::copy(src, std::inserter(dst, dst.end()));
         BOOST_CHECK_EQUAL_COLLECTIONS(src.begin(), src.end(), dst.begin(), dst.end());

--- a/test/src/bits/std_set/o0.cpp
+++ b/test/src/bits/std_set/o0.cpp
@@ -68,7 +68,7 @@ using Types = std::tuple
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(TheSetOperationsHoldOnAnEmptyPair, T, Types)
 {
-        [[maybe_unused]] auto _ = nested_types<T>();
+        [[maybe_unused]] auto const _ = nested_types<T>();
         constructor<T>()();
 
         on0::empty_set_pair<T>(mem_swap());

--- a/test/src/bits/std_set/o0.cpp
+++ b/test/src/bits/std_set/o0.cpp
@@ -57,7 +57,7 @@ using Types = std::tuple
 ,       xstd::bit_finite_set< 63, uint64_t>
 ,       xstd::bit_finite_set< 64, uint64_t>
 ,       xstd::bit_finite_set< 65, uint64_t>
-#if defined(__GNUG__)
+#ifdef __GNUG__
 ,       xstd::bit_finite_set<  0, __uint128_t>
 ,       xstd::bit_finite_set<  1, __uint128_t>
 ,       xstd::bit_finite_set<127, __uint128_t>

--- a/test/src/bits/std_set/o0.cpp
+++ b/test/src/bits/std_set/o0.cpp
@@ -3,10 +3,10 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <test/flat_set.hpp>       // TEST_HAS_FLAT_SET
-#include <test/set/composable.hpp> // includes, set_difference, set_intersection, set_symmetric_difference, set_union
-#include <test/set/exhaustive.hpp> // empty_set_pair
-#include <test/set/primitives.hpp> // constructor mem_swap,fn_swap, op_equal, op_not_equal_to,
+#include <test/flat_set.hpp>            // IWYU pragma: keep; TEST_HAS_FLAT_SET
+#include <test/set/composable.hpp>      // includes, set_difference, set_intersection, set_symmetric_difference, set_union
+#include <test/set/exhaustive.hpp>      // empty_set_pair
+#include <test/set/primitives.hpp>      // constructor mem_swap,fn_swap, op_equal, op_not_equal_to,
                                         // op_compare_three_way op_less, op_greater, op_less_equal, op_greater_equal,
 #include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE_TEMPLATE
 #include <xstd/bits/bit_finite_set.hpp> // bit_finite_set

--- a/test/src/bits/std_set/o1.cpp
+++ b/test/src/bits/std_set/o1.cpp
@@ -35,7 +35,7 @@ using Types = std::tuple
 ,       xstd::bit_finite_set<24, uint16_t>
 ,       xstd::bit_finite_set<24, uint32_t>
 ,       xstd::bit_finite_set<24, uint64_t>
-#if defined(__GNUG__)
+#ifdef __GNUG__
 ,       xstd::bit_finite_set<24, __uint128_t>
 #endif
 >;

--- a/test/src/bits/std_set/o1.cpp
+++ b/test/src/bits/std_set/o1.cpp
@@ -11,6 +11,7 @@
 #include <xstd/bits/bit_finite_set.hpp> // bit_finite_set
 #include <cstddef>                      // size_t
 #include <cstdint>                      // uint8_t, uint16_t, uint32_t, uint64_t
+#include <ranges>                       // from_range
 #include <set>                          // set
 #include <tuple>                        // tuple
 

--- a/test/src/bits/std_set/o2.cpp
+++ b/test/src/bits/std_set/o2.cpp
@@ -37,7 +37,7 @@ using Types = std::tuple
 ,       xstd::bit_finite_set<24, uint16_t>
 ,       xstd::bit_finite_set<24, uint32_t>
 ,       xstd::bit_finite_set<24, uint64_t>
-#if defined(__GNUG__)
+#ifdef __GNUG__
 ,       xstd::bit_finite_set<24, __uint128_t>
 #endif
 >;

--- a/test/src/bits/std_set/o2.cpp
+++ b/test/src/bits/std_set/o2.cpp
@@ -13,6 +13,7 @@
 #include <xstd/bits/bit_finite_set.hpp> // bit_finite_set
 #include <cstddef>                      // size_t
 #include <cstdint>                      // uint8_t, uint16_t, uint32_t, uint64_t
+#include <ranges>                       // from_range
 #include <set>                          // set
 #include <tuple>                        // tuple
 

--- a/test/src/bits/std_set/o3.cpp
+++ b/test/src/bits/std_set/o3.cpp
@@ -6,7 +6,7 @@
 #include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE_TEMPLATE
 #include <test/flat_set.hpp>            // IWYU pragma: keep; TEST_HAS_FLAT_SET
 #include <test/set/exhaustive.hpp>      // all_singleton_set_triples
-#include <test/set/primitives.hpp>      // op_equal_to, op_less
+#include <test/set/primitives.hpp>      // op_less
 #include <xstd/bits/bit_finite_set.hpp> // bit_finite_set
 #include <cstddef>                      // size_t
 #include <cstdint>                      // uint8_t, uint16_t, uint32_t, uint64_t

--- a/test/src/bits/std_set/o3.cpp
+++ b/test/src/bits/std_set/o3.cpp
@@ -4,7 +4,7 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE_TEMPLATE
-#include <test/flat_set.hpp>            // TEST_HAS_FLAT_SET
+#include <test/flat_set.hpp>            // IWYU pragma: keep; TEST_HAS_FLAT_SET
 #include <test/set/exhaustive.hpp>      // all_singleton_set_triples
 #include <test/set/primitives.hpp>      // op_equal_to, op_less
 #include <xstd/bits/bit_finite_set.hpp> // bit_finite_set

--- a/test/src/bits/std_set/o3.cpp
+++ b/test/src/bits/std_set/o3.cpp
@@ -31,7 +31,7 @@ using Types = std::tuple
 ,       xstd::bit_finite_set<17, uint16_t>
 ,       xstd::bit_finite_set<17, uint32_t>
 ,       xstd::bit_finite_set<17, uint64_t>
-#if defined(__GNUG__)
+#ifdef __GNUG__
 ,       xstd::bit_finite_set<17, __uint128_t>
 #endif
 >;

--- a/test/src/bits/std_set/o4.cpp
+++ b/test/src/bits/std_set/o4.cpp
@@ -32,7 +32,7 @@ using Types = std::tuple
 ,       xstd::bit_finite_set<17, uint16_t>
 ,       xstd::bit_finite_set<17, uint32_t>
 ,       xstd::bit_finite_set<17, uint64_t>
-#if defined(__GNUG__)
+#ifdef __GNUG__
 ,       xstd::bit_finite_set<17, __uint128_t>
 #endif
 >;

--- a/test/src/bits/std_set/o4.cpp
+++ b/test/src/bits/std_set/o4.cpp
@@ -4,7 +4,7 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE_TEMPLATE
-#include <test/flat_set.hpp>            // TEST_HAS_FLAT_SET
+#include <test/flat_set.hpp>            // IWYU pragma: keep; TEST_HAS_FLAT_SET
 #include <test/set/composable.hpp>      // includes
 #include <test/set/exhaustive.hpp>      // all_doubleton_set_pairs
 #include <test/set/primitives.hpp>      // op_compare_three_way

--- a/test/src/bits/std_set/sieve.cpp
+++ b/test/src/bits/std_set/sieve.cpp
@@ -5,9 +5,9 @@
 
 #include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE_TEMPLATE
 #include <fmt/format.h>                 // format
-#include <fmt/ranges.h>
+#include <fmt/ranges.h>                 // IWYU pragma: keep; the range formatters
 #include <opt/set/sieve.hpp>            // filter_twins, sift_primes0, sift_primes1
-#include <test/flat_set.hpp>            // TEST_HAS_FLAT_SET
+#include <test/flat_set.hpp>            // IWYU pragma: keep; TEST_HAS_FLAT_SET
 #include <xstd/bits/bit_finite_set.hpp> // bit_finite_set
 #include <cstddef>                      // size_t
 #include <set>                          // set

--- a/test/src/bits/std_set/sieve.cpp
+++ b/test/src/bits/std_set/sieve.cpp
@@ -16,7 +16,7 @@
 BOOST_AUTO_TEST_SUITE(StdSet)
 BOOST_AUTO_TEST_SUITE(Sieve)
 
-inline constexpr auto N = 100uz;
+inline constexpr auto N = 100UZ;
 
 using Types = std::tuple
 <       std::set<std::size_t>


### PR DESCRIPTION
Started as five one-line markers. It grew into the thing those markers were a symptom of: the Boost.Test sources were never linted, and instantiating the library's templates says things about the headers that the per-header pass structurally cannot.

`clang-tidy.yml` now passes `sources_regex`, as xstd's and tabula's already did, with a `test/.clang-tidy` alongside — bit_set was the only one of the three without either.

## Why the header pass could not see any of this

The self-sufficiency units compile each header without instantiating a class template's members, so a call that throws inside one is invisible to them. Measured over the same tree:

| pass | findings in `include/` |
| --- | ---: |
| generated per-header units | 0 |
| test sources instantiating the templates | 12 |

MSVC's `/analyze` has been reading `test/` all along — it is a compiler flag, not a file selection — so this closes an asymmetry on the Clang side rather than opening a new surface.

## Bugs

**`set_view(std::bitset<8>{}).find(99)` terminated.** `set_ops::contains` is `noexcept` and reached `std::bitset::test`, which throws `out_of_range`:

```
terminate called after throwing an instance of 'std::out_of_range'
  what():  bitset::test: __position (which is 99) >= _Nb (which is 8)
```

Two models meet in that function. A static extent is a fixed-capacity set that cannot grow, so a position outside it is a precondition violation, as it is for `std::array` — and `bit_finite_set::contains` already read that way, being `m_bits[x]`, which asserts. A dynamic extent can still grow, so it is a `std::set`: any key may be asked about, and one past the current size is simply absent. The first asserts, the second answers, and the read then goes through the unchecked `operator[]`.

**`set_ops::insert`, `set_ops::erase` and `array_ops::assign` were `noexcept` over a throwing setter.** All three now write through the subscript. `erase` was never reported; `reset(n)` throws identically.

## Gaps

**36 includes arrived transitively through an `ext/` adapter.** The annotation is what let it drift — `#include <xstd/bits/ext/std/bitset.hpp> // bitset` reads as though the adapter supplies the type rather than the hooks over it, so the `std_bitset` ladder named `std::bitset<>` and `xstd::bitset<>` while including neither `<bitset>` nor `<xstd/bits/bitset.hpp>`. Ten more includes were stale, each self-proving against the same annotation convention: the named symbol appears nowhere in the file.

**`xstd::bitset::operator[](size_t) -> reference` was `= delete; // TODO`**, and the nested `reference` beside it was declarations without bodies. Both are now `array_view`'s proxy, ported. Two departures were forced: it holds a pointer where `array_reference` holds a reference, so the copy constructor can stay defaulted as `[bitset.refs]` declares it; and the copy assignment could not stay defaulted, because for a proxy that rebinds rather than assigns — and the three `swap` friends declared below it are written as `b[i] = b[j]`, so they would have swapped nothing.

**The `ext/` leaf adapters carried neither `always_keep` nor an export of the adapted entity**, though the umbrellas above them carry both. The chain stopped one level short of the adapted type, so a source reaching `std::bitset` through the adapter looked to include-cleaner like a source using neither. xstd's `ext/` adapters export `<absl/numeric/int128.h>` and `<boost/int128.hpp>`; these now export `<bitset>`, `<boost/dynamic_bitset.hpp>` and `<xstd/bits/bitset.hpp>`.

## The lint

Two checks are dropped in `test/.clang-tidy`, neither saying anything true about a fixture: `misc-use-internal-linkage` (89 reports, the structs `BOOST_AUTO_TEST_CASE` expands to, which the framework registers by external linkage) and `readability-magic-numbers` (247, the exhaustive ladders of widths and positions).

Of what remained, findings were fixed where the check pointed at something better — `std::ranges::lexicographical_compare`, explicit bit tests, `const` on fifteen variables that never give it up, `100uz` → `100UZ` — and marked where it did not:

- Nine bitset primitives guard on `pos < self.size()` and call a member the standard specifies as throwing outside that width, checking in the other arm that it does throw. The `noexcept` is the claim being made and stays.
- `basic_string(N, zero)` "creates an empty string" only when `N == 0`, which is what `bitset<0>::to_string()` returns; and `state` is assigned inside an `if constexpr (N > 0)` that the same instantiation discards, so the `const` asked for would stop every other one compiling.
- `find` is the subject of the case that calls it; reflexivity cannot be asserted without naming the object twice; and `Implicit`'s conversion operator, in `implicit.cpp`, exists to convert without a cast.

## Verification

All 86 checks green, including `clang_tidy` on 22, 23 and 24-SVN — the first run of any of them over `test/src`. Coverage holds at 100% lines and 100% branches under `fail_under_line: 100` / `fail_under_branch: 100`, with the new `operator[]` proxy and the dynamic-extent guard both covered by tests added here.

Worth recording for the next change: the first CI run with `sources_regex` on failed all three legs with 27 findings after a local sweep reported zero. A container without `<flat_set>`, without clang-tidy 23 or 24, and with a libstdc++ that mishandles `std::ranges::to` under Clang cannot stand in for CI. A clean local sweep is necessary, not sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KN9Nqf5PjTfd75nCGx46zy