### PR TITLE
Name the sequence reading after the reading: sequence_ rather than array_

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,9 +83,9 @@ target_sources(
         include/xstd/bits/ext/xstd.hpp
         include/xstd/bits/ext/xstd/bitset.hpp
         include/xstd/bits/ranges.hpp
-        include/xstd/bits/ranges/array_view.hpp
         include/xstd/bits/ranges/bit_extent.hpp
         include/xstd/bits/ranges/block_access.hpp
+        include/xstd/bits/ranges/sequence_view.hpp
         include/xstd/bits/ranges/set_view.hpp
 )
 

--- a/doc/design.md
+++ b/doc/design.md
@@ -56,7 +56,7 @@ xstd/bits/bit_array.hpp       one header per container, named for the type
 xstd/bits/bitset.hpp
 xstd/bits/bit_finite_set.hpp
 xstd/bits/detail/             the vehicles and the block operations, namespace xstd::detail::bits
-xstd/bits/ranges/             set_view, array_view, bit_extent
+xstd/bits/ranges/             set_view, sequence_view, bit_extent
 xstd/bits/ext/                the adaptors, asked for by name
 ```
 
@@ -118,11 +118,11 @@ container typedefs, bidirectional iterators, `empty`/`size`/`max_size`,
 `insert`/`erase`/`clear`, `find`/`count`/`contains`/`lower_bound`/`upper_bound`/
 `equal_range`, and `==`/`<=>`.
 
-`xstd::array_view<Bits, Extent>(b)` presents the same storage as a sequence of
+`xstd::sequence_view<Bits, Extent>(b)` presents the same storage as a sequence of
 `bool`, span-shaped with a `dynamic_extent` default: `operator[]`, `at`, `front`,
-`back`, `size`, `empty`, `fill`, and `==`/`<=>`. One template rather than an
-`array_view`/`vector_view` pair, for the reason `std::span` is one template: the
-two differ only in whether `size()` is a constant expression.
+`back`, `size`, `empty`, `fill`, and `==`/`<=>`. One template rather than a
+static/dynamic pair, for the reason `std::span` is one template: the two differ
+only in whether `size()` is a constant expression.
 
 The proxies are a closed pair: `*it` yields a proxy reference, `&ref` yields the
 iterator back, and the value -- a key or a `bool` -- is reached only by converting
@@ -140,12 +140,12 @@ opinion here and its implementations disagree about all of it:
 | `bitset`'s const `operator[]` gives `bool`| yes       | no     |
 
 libc++ already builds its bit references this way and libstdc++ does neither half
--- but that is a statement about `array_view` alone, and it is worth being exact
+-- but that is a statement about `sequence_view` alone, and it is worth being exact
 about which of the two views the standard library prefigures.
 
 `std::bitset::reference`, and libc++'s `__bit_reference` behind `vector<bool>`,
 have `value_type = bool` and `iterator_category = random_access_iterator_tag`.
-That is the sequence reading, and `array_view` recapitulates it -- the proxy pair,
+That is the sequence reading, and `sequence_view` recapitulates it -- the proxy pair,
 the extent, the writing through. Nothing here is new.
 
 The set reading is absent from both. Neither offers `value_type = size_t`, and
@@ -156,7 +156,7 @@ this needs, quickly -- `__find_bool` and `__count_bool` specialize `find` and
 comes from -- but exposes it only as a search returning a bool-sequence iterator.
 
 `set_find<Bits>::next` is that same operation surfaced as iteration, with
-`operator*` yielding the position rather than `true`. So `array_view` is libc++'s
+`operator*` yielding the position rather than `true`. So `sequence_view` is libc++'s
 design made a guarantee, and `set_view` is the reading it does not offer, built on
 the primitive it already has. The two together are why a bit sequence needs no
 third vocabulary.
@@ -241,7 +241,7 @@ source, the way `exact_width_types.hpp` does it in xstd:
 - set-like: `std::set<size_t>`, `std::flat_set<size_t>`, `bit_finite_set<N, Block>`,
   `bit_set<Block, Alloc>`, and `set_view` over each legacy bitset.
 - sequence-like: `std::array<bool, N>`, `bit_array<N, Block>`, `std::vector<bool>`,
-  `bit_vector<Block, Alloc>`, and `array_view` over each legacy bitset.
+  `bit_vector<Block, Alloc>`, and `sequence_view` over each legacy bitset.
 - `[bitset]` members: `std::bitset<N>`, `xstd::bitset<N, Block>`,
   `boost::dynamic_bitset<>`, `xstd::dynamic_bitset<Block, Alloc>`.
 

--- a/include/xstd/bits.hpp
+++ b/include/xstd/bits.hpp
@@ -11,6 +11,6 @@
 #include <xstd/bits/bit_finite_set.hpp> // IWYU pragma: export; bit_finite_set
 #include <xstd/bits/bitset.hpp>         // IWYU pragma: export; bitset
 #include <xstd/bits/block_sequence.hpp> // IWYU pragma: export; block_sequence, block_array, block_vector
-#include <xstd/bits/ranges.hpp>         // IWYU pragma: export; set_view, array_view
+#include <xstd/bits/ranges.hpp>         // IWYU pragma: export; set_view, sequence_view
 
 #endif // XSTD_BITS_HPP

--- a/include/xstd/bits/bit_array.hpp
+++ b/include/xstd/bits/bit_array.hpp
@@ -72,12 +72,12 @@ struct bit_array
         using block_type             = Block;
         using pointer                = void;
         using const_pointer          = pointer;
-        using reference              = xstd::ranges::array_reference<bit_array, false>;
-        using const_reference        = xstd::ranges::array_reference<bit_array, true >;
+        using reference              = xstd::ranges::sequence_reference<bit_array, false>;
+        using const_reference        = xstd::ranges::sequence_reference<bit_array, true >;
         using size_type              = std::size_t;
         using difference_type        = std::ptrdiff_t;
-        using iterator               = xstd::ranges::array_iterator<bit_array, false>;
-        using const_iterator         = xstd::ranges::array_iterator<bit_array, true >;
+        using iterator               = xstd::ranges::sequence_iterator<bit_array, false>;
+        using const_iterator         = xstd::ranges::sequence_iterator<bit_array, true >;
         using reverse_iterator       = std::reverse_iterator<iterator>;
         using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
@@ -98,8 +98,8 @@ struct bit_array
         } 
 
         // iterators
-        [[nodiscard]] constexpr auto begin (this auto&& self) noexcept { return xstd::ranges::array_begin(self); }
-        [[nodiscard]] constexpr auto end   (this auto&& self) noexcept { return xstd::ranges::array_end  (self); }
+        [[nodiscard]] constexpr auto begin (this auto&& self) noexcept { return xstd::ranges::sequence_begin(self); }
+        [[nodiscard]] constexpr auto end   (this auto&& self) noexcept { return xstd::ranges::sequence_end  (self); }
         [[nodiscard]] constexpr auto rbegin(this auto&& self) noexcept { return std::make_reverse_iterator(self.end()  ); }
         [[nodiscard]] constexpr auto rend  (this auto&& self) noexcept { return std::make_reverse_iterator(self.begin()); }
 
@@ -154,7 +154,7 @@ template<std::size_t N, xstd::unsigned_integer Block>
 [[nodiscard]] constexpr auto operator<=>(const bit_array<N, Block>& x, const bit_array<N, Block>& y) noexcept
         -> std::strong_ordering
 {
-        return ranges::array_three_way(x, y);
+        return ranges::sequence_three_way(x, y);
 }
 
 template<std::size_t N, xstd::unsigned_integer Block> constexpr void swap(bit_array<N, Block>& x, bit_array<N, Block>& y) noexcept(noexcept(x.swap(y))) { x.swap(y); }

--- a/include/xstd/bits/bitset.hpp
+++ b/include/xstd/bits/bitset.hpp
@@ -31,8 +31,8 @@ template<class charT, class traits, std::size_t N, xstd::unsigned_integer Block>
 #include <boost/hash2/fnv1a.hpp>                   // fnv1a_64
 #include <boost/hash2/hash_append.hpp>             // hash_append
 #include <xstd/bits/block_sequence.hpp>            // block_array
-#include <xstd/bits/ranges/array_view.hpp>         // array_find
 #include <xstd/bits/ranges/bit_extent.hpp>         // bit_extent
+#include <xstd/bits/ranges/sequence_view.hpp>      // sequence_find
 #include <xstd/bits/ranges/set_view.hpp>           // set_find, set_compare
 #include <algorithm>                               // find_if, min
 #include <cassert>                                 // assert
@@ -56,7 +56,7 @@ namespace xstd {
 template<std::size_t N, xstd::unsigned_integer Block>
 class bitset
 {
-        // No iteration and no <=> here by design, because std::bitset has neither: choose set_view or array_view.
+        // No iteration and no <=> here by design, because std::bitset has neither: choose set_view or sequence_view.
         block_array<Block, N> m_bits{};
 
         // ADL rather than a specialization, because this type is ours to add hidden friends to.
@@ -72,13 +72,13 @@ class bitset
 public:
         using block_type = Block;
 
-        // array_view's proxy, ported to the member [bitset.refs] asks for: the bits and a position,
+        // sequence_view's proxy, ported to the member [bitset.refs] asks for: the bits and a position,
         // handed out by operator[] and reaching them only when read or written. Every such reach
         // goes through xstd::block_sequence, whose set, reset, flip and operator[] are noexcept and
         // asserted, so the proxy never takes the checked set(pos, val) beside it that throws.
         class reference
         {
-                // A pointer, not the reference array_view's proxy holds, so that the copy
+                // A pointer, not the reference sequence_view's proxy holds, so that the copy
                 // constructor below can stay defaulted as [bitset.refs] declares it.
                 bitset* m_ptr{};
                 std::size_t m_idx{};
@@ -403,7 +403,7 @@ struct set_find<xstd::bitset<N, Block>>
 
 // The other reading, trivial because operator[] answers every position; without it we would be a set and not a sequence.
 template<std::size_t N, xstd::unsigned_integer Block>
-struct array_find<xstd::bitset<N, Block>>
+struct sequence_find<xstd::bitset<N, Block>>
 {
         [[nodiscard]] static constexpr auto first(xstd::bitset<N, Block> const&) noexcept -> std::size_t { return 0UZ; }
         [[nodiscard]] static constexpr auto last (xstd::bitset<N, Block> const&) noexcept -> std::size_t { return N;   }

--- a/include/xstd/bits/ext/boost/dynamic_bitset.hpp
+++ b/include/xstd/bits/ext/boost/dynamic_bitset.hpp
@@ -9,7 +9,7 @@
 // IWYU pragma: always_keep
 
 #include <boost/dynamic_bitset.hpp>                // IWYU pragma: export; dynamic_bitset
-#include <xstd/bits/ranges/array_view.hpp>         // array_find
+#include <xstd/bits/ranges/sequence_view.hpp>      // sequence_find
 #include <xstd/bits/ranges/set_view.hpp>           // set_find, set_view
 #include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer
 #include <algorithm>                               // find_if, min
@@ -70,7 +70,7 @@ struct set_compare<boost::dynamic_bitset<Block, Allocator>>
 namespace xstd::ranges {
 
 template<xstd::unsigned_integer Block, class Allocator>
-struct array_find<boost::dynamic_bitset<Block, Allocator>>
+struct sequence_find<boost::dynamic_bitset<Block, Allocator>>
 {
         [[nodiscard]] static constexpr auto first(boost::dynamic_bitset<Block, Allocator> const&) noexcept -> std::size_t { return 0UZ; }
         [[nodiscard]] static constexpr auto last (boost::dynamic_bitset<Block, Allocator> const& c) noexcept -> std::size_t { return c.size(); }

--- a/include/xstd/bits/ext/std/bitset.hpp
+++ b/include/xstd/bits/ext/std/bitset.hpp
@@ -8,9 +8,9 @@
 
 // IWYU pragma: always_keep
 
-#include <xstd/bits/ranges/array_view.hpp>         // array_find, array_view
 #include <xstd/bits/ranges/bit_extent.hpp>         // bit_extent
 #include <xstd/bits/ranges/block_access.hpp>       // block_access
+#include <xstd/bits/ranges/sequence_view.hpp>      // sequence_find, sequence_view
 #include <xstd/bits/ranges/set_view.hpp>           // set_find, set_view
 #include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer
 #include <algorithm>                               // find_if
@@ -26,7 +26,7 @@
 // std::bitset's only associated namespace is std, where [namespace.std] forbids adding ADL hooks, so specialize set_find instead.
 namespace xstd::ranges {
 
-// The width is in the type, so set_view's max_size() and array_view's size() are constant expressions.
+// The width is in the type, so set_view's max_size() and sequence_view's size() are constant expressions.
 template<std::size_t N>
 inline constexpr std::size_t bit_extent<std::bitset<N>> = N;
 
@@ -114,7 +114,7 @@ struct block_access<std::bitset<N>>
 };
 
 template<std::size_t N>
-struct array_find<std::bitset<N>>
+struct sequence_find<std::bitset<N>>
 {
         [[nodiscard]] static constexpr auto first(const std::bitset<N>&) noexcept -> std::size_t { return 0UZ; }
         [[nodiscard]] static constexpr auto last (const std::bitset<N>&) noexcept -> std::size_t { return N;   }

--- a/include/xstd/bits/ranges.hpp
+++ b/include/xstd/bits/ranges.hpp
@@ -7,9 +7,9 @@
 #define XSTD_BITS_RANGES_HPP
 
 // The two things a sequence of bits is: the set of positions that are on, and the sequence of bools at every position.
-#include <xstd/bits/ranges/array_view.hpp>   // IWYU pragma: export; array_view, array_find, array_ops
-#include <xstd/bits/ranges/bit_extent.hpp>   // IWYU pragma: export; bit_extent
-#include <xstd/bits/ranges/block_access.hpp> // IWYU pragma: export; block_access, block_range
-#include <xstd/bits/ranges/set_view.hpp>     // IWYU pragma: export; set_view, set_find, set_ops, set_compare
+#include <xstd/bits/ranges/bit_extent.hpp>    // IWYU pragma: export; bit_extent
+#include <xstd/bits/ranges/block_access.hpp>  // IWYU pragma: export; block_access, block_range
+#include <xstd/bits/ranges/sequence_view.hpp> // IWYU pragma: export; sequence_view, sequence_find, sequence_ops
+#include <xstd/bits/ranges/set_view.hpp>      // IWYU pragma: export; set_view, set_find, set_ops, set_compare
 
 #endif // XSTD_BITS_RANGES_HPP

--- a/include/xstd/bits/ranges/sequence_view.hpp
+++ b/include/xstd/bits/ranges/sequence_view.hpp
@@ -3,8 +3,8 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef XSTD_BITS_RANGES_ARRAY_VIEW_HPP
-#define XSTD_BITS_RANGES_ARRAY_VIEW_HPP
+#ifndef XSTD_BITS_RANGES_SEQUENCE_VIEW_HPP
+#define XSTD_BITS_RANGES_SEQUENCE_VIEW_HPP
 
 #include <xstd/bits/detail/intrin.hpp>       // countr_zero
 #include <xstd/bits/ranges/bit_extent.hpp>   // bit_extent, static_bit_extent
@@ -26,7 +26,7 @@ namespace xstd::ranges {
 
 // Where the bits are; same ADL-with-explicit-specialization design as set_find, and see set_view.hpp for why.
 template<class Bits>
-struct array_find
+struct sequence_find
 {
         [[nodiscard]] static constexpr auto first(Bits const& c) noexcept
                 -> std::size_t
@@ -52,7 +52,7 @@ struct array_find
 
 // The vocabulary, rewired: only writing needs renaming, a bitset's size() being already a sequence's size().
 template<class Bits>
-struct array_ops
+struct sequence_ops
 {
         [[nodiscard]] static constexpr auto size(Bits const& c) noexcept
                 -> std::size_t
@@ -103,7 +103,7 @@ struct array_ops
 
 // The sequence ordering, defined once: the bools in position order, compared lexicographically through value_type.
 template<std::ranges::input_range X, std::ranges::input_range Y>
-[[nodiscard]] constexpr auto array_three_way(X const& x, Y const& y) noexcept
+[[nodiscard]] constexpr auto sequence_three_way(X const& x, Y const& y) noexcept
         -> std::strong_ordering
 {
         return std::lexicographical_compare_three_way(
@@ -115,7 +115,7 @@ template<std::ranges::input_range X, std::ranges::input_range Y>
 
 // The same ordering a word at a time; at the lowest differing bit the sequence LACKING it is smaller, with no prefix clause.
 template<block_range Bits>
-[[nodiscard]] constexpr auto array_three_way(Bits const& x, Bits const& y) noexcept
+[[nodiscard]] constexpr auto sequence_three_way(Bits const& x, Bits const& y) noexcept
         -> std::strong_ordering
 {
         using access = block_access<Bits>;
@@ -133,29 +133,29 @@ template<block_range Bits>
 }
 
 template<class Bits_cv, class Bits = std::remove_const_t<Bits_cv>>
-concept array_range =
+concept sequence_range =
         requires(Bits const& c)
         {
-                { array_find<Bits>::first(c) } -> std::convertible_to<std::size_t>;
-                { array_find<Bits>::last (c) } -> std::convertible_to<std::size_t>;
+                { sequence_find<Bits>::first(c) } -> std::convertible_to<std::size_t>;
+                { sequence_find<Bits>::last (c) } -> std::convertible_to<std::size_t>;
         } and
         requires(Bits const& c, std::size_t n)
         {
-                { array_find<Bits>::at(c, n) } -> std::convertible_to<bool>;
+                { sequence_find<Bits>::at(c, n) } -> std::convertible_to<bool>;
         }
 ;
 
-template<class, bool> class array_iterator;
-template<class, bool> class array_reference;
+template<class, bool> class sequence_iterator;
+template<class, bool> class sequence_reference;
 
-// Forward-declared so array_iterator's dependent friend template-ids have a template to name; Clang requires it, GCC does not.
-template<array_range Bits> [[nodiscard]] constexpr auto array_begin(      Bits& c) noexcept -> array_iterator<Bits, false>;
-template<array_range Bits> [[nodiscard]] constexpr auto array_begin(Bits const& c) noexcept -> array_iterator<Bits, true >;
-template<array_range Bits> [[nodiscard]] constexpr auto array_end  (      Bits& c) noexcept -> array_iterator<Bits, false>;
-template<array_range Bits> [[nodiscard]] constexpr auto array_end  (Bits const& c) noexcept -> array_iterator<Bits, true >;
+// Forward-declared so sequence_iterator's dependent friend template-ids have a template to name; Clang requires it, GCC does not.
+template<sequence_range Bits> [[nodiscard]] constexpr auto sequence_begin(      Bits& c) noexcept -> sequence_iterator<Bits, false>;
+template<sequence_range Bits> [[nodiscard]] constexpr auto sequence_begin(Bits const& c) noexcept -> sequence_iterator<Bits, true >;
+template<sequence_range Bits> [[nodiscard]] constexpr auto sequence_end  (      Bits& c) noexcept -> sequence_iterator<Bits, false>;
+template<sequence_range Bits> [[nodiscard]] constexpr auto sequence_end  (Bits const& c) noexcept -> sequence_iterator<Bits, true >;
 
 template<class Bits, bool IsConst>
-class array_iterator
+class sequence_iterator
 {
         using ptr_const_t = std::conditional_t<IsConst, Bits const*, Bits*>;
 
@@ -163,13 +163,13 @@ class array_iterator
         std::size_t m_idx{};
 
         friend Bits;
-        friend class array_reference<Bits, IsConst>;
-        friend constexpr auto array_begin <>(      Bits& c) noexcept -> array_iterator<Bits, false>;
-        friend constexpr auto array_begin <>(Bits const& c) noexcept -> array_iterator<Bits, true >;
-        friend constexpr auto array_end   <>(      Bits& c) noexcept -> array_iterator<Bits, false>;
-        friend constexpr auto array_end   <>(Bits const& c) noexcept -> array_iterator<Bits, true >;
+        friend class sequence_reference<Bits, IsConst>;
+        friend constexpr auto sequence_begin <>(      Bits& c) noexcept -> sequence_iterator<Bits, false>;
+        friend constexpr auto sequence_begin <>(Bits const& c) noexcept -> sequence_iterator<Bits, true >;
+        friend constexpr auto sequence_end   <>(      Bits& c) noexcept -> sequence_iterator<Bits, false>;
+        friend constexpr auto sequence_end   <>(Bits const& c) noexcept -> sequence_iterator<Bits, true >;
 
-        [[nodiscard]] constexpr array_iterator(ptr_const_t ptr, std::size_t idx) noexcept
+        [[nodiscard]] constexpr sequence_iterator(ptr_const_t ptr, std::size_t idx) noexcept
         :
                 m_ptr(ptr),
                 m_idx(idx)
@@ -182,18 +182,18 @@ public:
         using value_type        = bool;
         using difference_type   = std::ptrdiff_t;
         using pointer           = void;
-        using reference         = array_reference<Bits, IsConst>;
+        using reference         = sequence_reference<Bits, IsConst>;
 
-        [[nodiscard]] constexpr array_iterator() noexcept = default;
+        [[nodiscard]] constexpr sequence_iterator() noexcept = default;
 
-        [[nodiscard]] friend constexpr auto operator==(array_iterator lhs, array_iterator rhs) noexcept
+        [[nodiscard]] friend constexpr auto operator==(sequence_iterator lhs, sequence_iterator rhs) noexcept
                 -> bool
         {
                 assert(lhs.m_ptr == rhs.m_ptr);
                 return lhs.m_idx == rhs.m_idx;
         }
 
-        [[nodiscard]] friend constexpr auto operator<=>(array_iterator lhs, array_iterator rhs) noexcept
+        [[nodiscard]] friend constexpr auto operator<=>(sequence_iterator lhs, sequence_iterator rhs) noexcept
                 -> std::strong_ordering
         {
                 assert(lhs.m_ptr == rhs.m_ptr);
@@ -207,16 +207,16 @@ public:
                 return { *m_ptr, m_idx };
         }
 
-        constexpr auto operator++() noexcept -> array_iterator& { ++m_idx; return *this; }
-        constexpr auto operator--() noexcept -> array_iterator& { --m_idx; return *this; }
+        constexpr auto operator++() noexcept -> sequence_iterator& { ++m_idx; return *this; }
+        constexpr auto operator--() noexcept -> sequence_iterator& { --m_idx; return *this; }
 
-        constexpr auto operator++(int) noexcept -> array_iterator { auto nrv = *this; ++*this; return nrv; }
-        constexpr auto operator--(int) noexcept -> array_iterator { auto nrv = *this; --*this; return nrv; }
+        constexpr auto operator++(int) noexcept -> sequence_iterator { auto nrv = *this; ++*this; return nrv; }
+        constexpr auto operator--(int) noexcept -> sequence_iterator { auto nrv = *this; --*this; return nrv; }
 
-        constexpr auto operator+=(difference_type n) noexcept -> array_iterator& { m_idx = static_cast<std::size_t>(static_cast<difference_type>(m_idx) + n); return *this; }
-        constexpr auto operator-=(difference_type n) noexcept -> array_iterator& { m_idx = static_cast<std::size_t>(static_cast<difference_type>(m_idx) - n); return *this; }
+        constexpr auto operator+=(difference_type n) noexcept -> sequence_iterator& { m_idx = static_cast<std::size_t>(static_cast<difference_type>(m_idx) + n); return *this; }
+        constexpr auto operator-=(difference_type n) noexcept -> sequence_iterator& { m_idx = static_cast<std::size_t>(static_cast<difference_type>(m_idx) - n); return *this; }
 
-        [[nodiscard]] friend constexpr auto operator-(array_iterator lhs, array_iterator rhs) noexcept
+        [[nodiscard]] friend constexpr auto operator-(sequence_iterator lhs, sequence_iterator rhs) noexcept
                 -> difference_type
         {
                 return static_cast<difference_type>(lhs.m_idx) - static_cast<difference_type>(rhs.m_idx);
@@ -230,18 +230,18 @@ public:
         }
 };
 
-template<array_range Bits, bool IsConst> [[nodiscard]] constexpr auto operator+(array_iterator<Bits, IsConst> lhs, std::ptrdiff_t n) noexcept -> array_iterator<Bits, IsConst> { auto nrv = lhs; nrv += n; return nrv; }
-template<array_range Bits, bool IsConst> [[nodiscard]] constexpr auto operator+(std::ptrdiff_t n, array_iterator<Bits, IsConst> rhs) noexcept -> array_iterator<Bits, IsConst> { auto nrv = rhs; nrv += n; return nrv; }
-template<array_range Bits, bool IsConst> [[nodiscard]] constexpr auto operator-(array_iterator<Bits, IsConst> lhs, std::ptrdiff_t n) noexcept -> array_iterator<Bits, IsConst> { auto nrv = lhs; nrv -= n; return nrv; }
+template<sequence_range Bits, bool IsConst> [[nodiscard]] constexpr auto operator+(sequence_iterator<Bits, IsConst> lhs, std::ptrdiff_t n) noexcept -> sequence_iterator<Bits, IsConst> { auto nrv = lhs; nrv += n; return nrv; }
+template<sequence_range Bits, bool IsConst> [[nodiscard]] constexpr auto operator+(std::ptrdiff_t n, sequence_iterator<Bits, IsConst> rhs) noexcept -> sequence_iterator<Bits, IsConst> { auto nrv = rhs; nrv += n; return nrv; }
+template<sequence_range Bits, bool IsConst> [[nodiscard]] constexpr auto operator-(sequence_iterator<Bits, IsConst> lhs, std::ptrdiff_t n) noexcept -> sequence_iterator<Bits, IsConst> { auto nrv = lhs; nrv -= n; return nrv; }
 
-template<array_range Bits> [[nodiscard]] constexpr auto array_begin(      Bits& c) noexcept -> array_iterator<Bits, false> { return { &c, array_find<Bits>::first(c) }; }
-template<array_range Bits> [[nodiscard]] constexpr auto array_begin(Bits const& c) noexcept -> array_iterator<Bits, true > { return { &c, array_find<Bits>::first(c) }; }
-template<array_range Bits> [[nodiscard]] constexpr auto array_end  (      Bits& c) noexcept -> array_iterator<Bits, false> { return { &c, array_find<Bits>::last (c) }; }
-template<array_range Bits> [[nodiscard]] constexpr auto array_end  (Bits const& c) noexcept -> array_iterator<Bits, true > { return { &c, array_find<Bits>::last (c) }; }
+template<sequence_range Bits> [[nodiscard]] constexpr auto sequence_begin(      Bits& c) noexcept -> sequence_iterator<Bits, false> { return { &c, sequence_find<Bits>::first(c) }; }
+template<sequence_range Bits> [[nodiscard]] constexpr auto sequence_begin(Bits const& c) noexcept -> sequence_iterator<Bits, true > { return { &c, sequence_find<Bits>::first(c) }; }
+template<sequence_range Bits> [[nodiscard]] constexpr auto sequence_end  (      Bits& c) noexcept -> sequence_iterator<Bits, false> { return { &c, sequence_find<Bits>::last (c) }; }
+template<sequence_range Bits> [[nodiscard]] constexpr auto sequence_end  (Bits const& c) noexcept -> sequence_iterator<Bits, true > { return { &c, sequence_find<Bits>::last (c) }; }
 
 // A proxy bool assigning back into the bits, with std::vector<bool>::reference the precedent, const-qualified assignment included.
 template<class Bits, bool IsConst>
-class array_reference
+class sequence_reference
 {
         using ref_const_t = std::conditional_t<IsConst, Bits const&, Bits&>;
 
@@ -249,9 +249,9 @@ class array_reference
         std::size_t m_idx;
 
         friend Bits;
-        friend class array_iterator<Bits, IsConst>;
+        friend class sequence_iterator<Bits, IsConst>;
 
-        [[nodiscard]] constexpr array_reference(ref_const_t ref, std::size_t idx) noexcept
+        [[nodiscard]] constexpr sequence_reference(ref_const_t ref, std::size_t idx) noexcept
         :
                 m_ref(ref),
                 m_idx(idx)
@@ -259,7 +259,7 @@ class array_reference
 
 public:
         using value_type = bool;
-        using iterator   = array_iterator<Bits, IsConst>;
+        using iterator   = sequence_iterator<Bits, IsConst>;
 
         [[nodiscard]] constexpr auto operator&() const noexcept
                 -> iterator
@@ -269,67 +269,67 @@ public:
 
         [[nodiscard]] constexpr explicit(false) operator value_type() const noexcept  // NOLINT(misc-explicit-constructor)
         {
-                return array_find<Bits>::at(m_ref, m_idx);
+                return sequence_find<Bits>::at(m_ref, m_idx);
         }
 
         template<std::constructible_from<value_type> T>
         [[nodiscard]] constexpr explicit(not std::is_convertible_v<value_type, T>) operator T() const noexcept(std::is_nothrow_constructible_v<T, value_type>)  // NOLINT(misc-explicit-constructor)
                 requires std::is_class_v<T>
         {
-                return array_find<Bits>::at(m_ref, m_idx);
+                return sequence_find<Bits>::at(m_ref, m_idx);
         }
 
         // const-qualified and returning a const reference, the proxy shape P2321R2 gave std::vector<bool>::reference.
         constexpr auto operator=(bool value) const noexcept  // NOLINT(misc-unconventional-assign-operator)
-                -> array_reference const&
-                requires (not IsConst) and requires(Bits& c) { array_ops<Bits>::assign(c, 0UZ, true); }
+                -> sequence_reference const&
+                requires (not IsConst) and requires(Bits& c) { sequence_ops<Bits>::assign(c, 0UZ, true); }
         {
-                array_ops<Bits>::assign(m_ref, m_idx, value);
+                sequence_ops<Bits>::assign(m_ref, m_idx, value);
                 return *this;
         }
 
-        constexpr auto operator=(array_reference const& other) const noexcept  // NOLINT(misc-unconventional-assign-operator)
-                -> array_reference const&
-                requires (not IsConst) and requires(Bits& c) { array_ops<Bits>::assign(c, 0UZ, true); }
+        constexpr auto operator=(sequence_reference const& other) const noexcept  // NOLINT(misc-unconventional-assign-operator)
+                -> sequence_reference const&
+                requires (not IsConst) and requires(Bits& c) { sequence_ops<Bits>::assign(c, 0UZ, true); }
         {
                 return *this = static_cast<bool>(other);
         }
 
         constexpr auto flip() const noexcept  // NOLINT(modernize-use-nodiscard)
-                -> array_reference const&
-                requires (not IsConst) and requires(Bits& c) { array_ops<Bits>::assign(c, 0UZ, true); }
+                -> sequence_reference const&
+                requires (not IsConst) and requires(Bits& c) { sequence_ops<Bits>::assign(c, 0UZ, true); }
         {
                 return *this = not static_cast<bool>(*this);
         }
 };
 
-template<array_range Bits, bool IsConst>
-[[nodiscard]] constexpr auto format_as(array_reference<Bits, IsConst> ref) noexcept
-        -> array_reference<Bits, IsConst>::value_type
+template<sequence_range Bits, bool IsConst>
+[[nodiscard]] constexpr auto format_as(sequence_reference<Bits, IsConst> ref) noexcept
+        -> sequence_reference<Bits, IsConst>::value_type
 {
         return ref;
 }
 
 // Deliberately no key_type, unlike set_view: fmt should print this as a sequence rather than with set delimiters.
-template<array_range Bits_cv, std::size_t Extent = bit_extent<std::remove_const_t<Bits_cv>>>
-class array_view : public std::ranges::view_base
+template<sequence_range Bits_cv, std::size_t Extent = bit_extent<std::remove_const_t<Bits_cv>>>
+class sequence_view : public std::ranges::view_base
 {
         static constexpr bool is_const = std::is_const_v<Bits_cv>;
 
         using bits_type = std::remove_const_t<Bits_cv>;
-        using ops       = array_ops<bits_type>;
+        using ops       = sequence_ops<bits_type>;
 
         Bits_cv* m_ptr;
 
         // A view is as block-accessible as the thing it views; constrained, so one over an opaque type keeps the element-wise path.
-        [[nodiscard]] friend constexpr auto block_count(array_view v) noexcept
+        [[nodiscard]] friend constexpr auto block_count(sequence_view v) noexcept
                 -> std::size_t
                 requires block_range<bits_type>
         {
                 return block_access<bits_type>::num_blocks(*v.m_ptr);
         }
 
-        [[nodiscard]] friend constexpr auto block_at(array_view v, std::size_t i) noexcept
+        [[nodiscard]] friend constexpr auto block_at(sequence_view v, std::size_t i) noexcept
                 requires block_range<bits_type>
         {
                 return block_access<bits_type>::block(*v.m_ptr, i);
@@ -340,25 +340,25 @@ public:
         using value_type             = bool;
         using size_type              = std::size_t;
         using difference_type        = std::ptrdiff_t;
-        using const_reference        = array_reference<bits_type, true>;
-        using reference              = array_reference<bits_type, is_const>;
-        using const_iterator         = array_iterator<bits_type, true>;
-        using iterator               = array_iterator<bits_type, is_const>;
+        using const_reference        = sequence_reference<bits_type, true>;
+        using reference              = sequence_reference<bits_type, is_const>;
+        using const_iterator         = sequence_iterator<bits_type, true>;
+        using iterator               = sequence_iterator<bits_type, is_const>;
         using const_reverse_iterator = std::reverse_iterator<const_iterator>;
         using reverse_iterator       = std::reverse_iterator<iterator>;
 
         static constexpr std::size_t extent = Extent;
 
-        [[nodiscard]] constexpr explicit array_view(Bits_cv& c) noexcept : m_ptr(&c) {}
+        [[nodiscard]] constexpr explicit sequence_view(Bits_cv& c) noexcept : m_ptr(&c) {}
 
-        [[nodiscard]] constexpr auto begin() const noexcept -> iterator { return array_begin(*m_ptr); }
-        [[nodiscard]] constexpr auto end()   const noexcept -> iterator { return array_end  (*m_ptr); }
+        [[nodiscard]] constexpr auto begin() const noexcept -> iterator { return sequence_begin(*m_ptr); }
+        [[nodiscard]] constexpr auto end()   const noexcept -> iterator { return sequence_end  (*m_ptr); }
 
         [[nodiscard]] constexpr auto rbegin() const noexcept -> reverse_iterator { return std::make_reverse_iterator(end());   }
         [[nodiscard]] constexpr auto rend()   const noexcept -> reverse_iterator { return std::make_reverse_iterator(begin()); }
 
-        [[nodiscard]] constexpr auto cbegin()  const noexcept -> const_iterator         { return array_begin(std::as_const(*m_ptr)); }
-        [[nodiscard]] constexpr auto cend()    const noexcept -> const_iterator         { return array_end  (std::as_const(*m_ptr)); }
+        [[nodiscard]] constexpr auto cbegin()  const noexcept -> const_iterator         { return sequence_begin(std::as_const(*m_ptr)); }
+        [[nodiscard]] constexpr auto cend()    const noexcept -> const_iterator         { return sequence_end  (std::as_const(*m_ptr)); }
         [[nodiscard]] constexpr auto crbegin() const noexcept -> const_reverse_iterator { return std::make_reverse_iterator(cend());   }
         [[nodiscard]] constexpr auto crend()   const noexcept -> const_reverse_iterator { return std::make_reverse_iterator(cbegin()); }
 
@@ -386,7 +386,7 @@ public:
                 -> reference
         {
                 if (n >= size()) {
-                        throw std::out_of_range("xstd::array_view::at");
+                        throw std::out_of_range("xstd::sequence_view::at");
                 }
                 return (*this)[n];
         }
@@ -400,7 +400,7 @@ public:
                 ops::fill(*m_ptr, value);
         }
 
-        [[nodiscard]] friend constexpr auto operator==(array_view lhs, array_view rhs) noexcept
+        [[nodiscard]] friend constexpr auto operator==(sequence_view lhs, sequence_view rhs) noexcept
                 -> bool
         {
                 if constexpr (requires { *lhs.m_ptr == *rhs.m_ptr; }) {
@@ -411,24 +411,24 @@ public:
         }
 
         // Sequence order, index 0 first, always computed from the sequence: nothing to trust, and no set_compare analogue.
-        [[nodiscard]] friend constexpr auto operator<=>(array_view lhs, array_view rhs) noexcept
+        [[nodiscard]] friend constexpr auto operator<=>(sequence_view lhs, sequence_view rhs) noexcept
                 -> std::strong_ordering
         {
-                return array_three_way(lhs, rhs);
+                return sequence_three_way(lhs, rhs);
         }
 };
 
 // Deduces both the constness of the argument and the extent the Bits declares.
 template<class Bits>
-array_view(Bits&) -> array_view<Bits, bit_extent<std::remove_const_t<Bits>>>;
+sequence_view(Bits&) -> sequence_view<Bits, bit_extent<std::remove_const_t<Bits>>>;
 
 } // namespace xstd::ranges
 
 namespace xstd {
 
-using ranges::array_range;
-using ranges::array_view;
+using ranges::sequence_range;
+using ranges::sequence_view;
 
 } // namespace xstd
 
-#endif // XSTD_BITS_RANGES_ARRAY_VIEW_HPP
+#endif // XSTD_BITS_RANGES_SEQUENCE_VIEW_HPP

--- a/include/xstd/bits/ranges/set_view.hpp
+++ b/include/xstd/bits/ranges/set_view.hpp
@@ -96,7 +96,7 @@ struct set_ops
         // hold, which is an answer and not a precondition violation. That is what [set] gives
         // contains and find -- s.find(k) returns end() for any k it does not hold, never refuses the
         // question -- and it is the difference between the set reading and the sequence reading,
-        // where array_view's operator[] indexes and out of range is out of bounds.
+        // where sequence_view's operator[] indexes and out of range is out of bounds.
         //
         // The position is in range by the time the bitset is read, so the read goes through
         // operator[] and not test(): the latter is the checked accessor whose throw would escape this

--- a/test/include/test/sequence/ordering.hpp
+++ b/test/include/test/sequence/ordering.hpp
@@ -6,17 +6,17 @@
 #ifndef TEST_SEQUENCE_ORDERING_HPP
 #define TEST_SEQUENCE_ORDERING_HPP
 
-#include <boost/test/unit_test.hpp>        // BOOST_CHECK_EQUAL
-#include <test/bitset/factory.hpp>         // make_bitset
-#include <xstd/bits/ranges/array_view.hpp> // array_view
-#include <algorithm>                       // lexicographical_compare
-#include <compare>                         // strong_ordering
-#include <cstddef>                         // size_t
-#include <vector>                          // vector
+#include <boost/test/unit_test.hpp>           // BOOST_CHECK_EQUAL
+#include <test/bitset/factory.hpp>            // make_bitset
+#include <xstd/bits/ranges/sequence_view.hpp> // sequence_view
+#include <algorithm>                          // lexicographical_compare
+#include <compare>                            // strong_ordering
+#include <cstddef>                            // size_t
+#include <vector>                             // vector
 
 namespace test::sequence {
 
-// What the sequence reading must order like, against the container defining the relation; both of array_view's routes must agree.
+// What the sequence reading must order like, against the container defining the relation; both of sequence_view's routes must agree.
 template<class Bits>
 auto ordering_agrees_with_vector_bool(std::size_t universe = 4) -> void
 {
@@ -27,15 +27,15 @@ auto ordering_agrees_with_vector_bool(std::size_t universe = 4) -> void
                         auto y = test::bitset::make_bitset<Bits>(universe);
 
                         // Written through the view; named rather than inlined, because CTAD followed by [k] parses as an array declaration.
-                        auto xw = xstd::array_view(x);
-                        auto yw = xstd::array_view(y);
+                        auto xw = xstd::sequence_view(x);
+                        auto yw = xstd::sequence_view(y);
                         for (auto k = 0UZ; k < universe; ++k) {
                                 xw[k] = (i >> k & 1UZ) != 0UZ;
                                 yw[k] = (j >> k & 1UZ) != 0UZ;
                         }
 
-                        auto const xv = xstd::array_view(x);
-                        auto const yv = xstd::array_view(y);
+                        auto const xv = xstd::sequence_view(x);
+                        auto const yv = xstd::sequence_view(y);
 
                         // The reference holds the same bools at the same positions, over the whole width the view reports.
                         auto vx = std::vector<bool>(xv.size());

--- a/test/src/bits.cpp
+++ b/test/src/bits.cpp
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(EveryContainerArrivesThroughTheOneDoor)
         static_assert(std::ranges::bidirectional_range<decltype(xstd::set_view(legacy))>);
 
         auto const packed = xstd::bit_array<8>();
-        static_assert(std::ranges::random_access_range<decltype(xstd::array_view(packed))>);
+        static_assert(std::ranges::random_access_range<decltype(xstd::sequence_view(packed))>);
 }
 
 // A packed container satisfies the same interface as the one it packs, which means something only because std::array answers to it too.

--- a/test/src/bits/bitset.cpp
+++ b/test/src/bits/bitset.cpp
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(IsTrivial, T, Types)
         static_assert(    std::is_trivially_move_assignable_v<T>);
 }
 
-// The proxy operator[] hands out, ported from array_view: assignment either way round, the
+// The proxy operator[] hands out, ported from sequence_view: assignment either way round, the
 // flipped reading, flip itself, and the three swaps. b[i] = b[j] is checked to move the bit
 // rather than the proxy, which is also what makes swap work.
 BOOST_AUTO_TEST_CASE(TheMutableSubscriptHandsOutAnAssignableProxy)

--- a/test/src/bits/ext/boost.cpp
+++ b/test/src/bits/ext/boost.cpp
@@ -3,12 +3,12 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/test/unit_test.hpp>        // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
-#include <xstd/bits/ext/boost.hpp>         // the Boost adaptors, asked for by name
-#include <xstd/bits/ranges/array_view.hpp> // array_range
-#include <xstd/bits/ranges/bit_extent.hpp> // bit_extent
-#include <xstd/bits/ranges/set_view.hpp>   // set_range
-#include <span>                            // dynamic_extent
+#include <boost/test/unit_test.hpp>           // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
+#include <xstd/bits/ext/boost.hpp>            // the Boost adaptors, asked for by name
+#include <xstd/bits/ranges/bit_extent.hpp>    // bit_extent
+#include <xstd/bits/ranges/sequence_view.hpp> // sequence_range
+#include <xstd/bits/ranges/set_view.hpp>      // set_range
+#include <span>                               // dynamic_extent
 
 BOOST_AUTO_TEST_SUITE(Ext)
 BOOST_AUTO_TEST_SUITE(Boost)
@@ -17,7 +17,7 @@ BOOST_AUTO_TEST_SUITE(Boost)
 BOOST_AUTO_TEST_CASE(AskingForItByNameIsEnough)
 {
         static_assert(xstd::ranges::set_range<boost::dynamic_bitset<>>);
-        static_assert(xstd::ranges::array_range<boost::dynamic_bitset<>>);
+        static_assert(xstd::ranges::sequence_range<boost::dynamic_bitset<>>);
         static_assert(xstd::ranges::bit_extent<boost::dynamic_bitset<>> == std::dynamic_extent);
 }
 

--- a/test/src/bits/ext/boost/dynamic_bitset.cpp
+++ b/test/src/bits/ext/boost/dynamic_bitset.cpp
@@ -6,7 +6,7 @@
 #include <boost/test/unit_test.hpp>               // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
 #include <test/dynamic.hpp>                       // dynamic
 #include <xstd/bits/ext/boost/dynamic_bitset.hpp> // the hooks that make dynamic_bitset a bit range
-#include <xstd/bits/ranges/array_view.hpp>        // array_range
+#include <xstd/bits/ranges/sequence_view.hpp>     // sequence_range
 #include <xstd/bits/ranges/set_view.hpp>          // set_range, set_view
 #include <algorithm>                              // lexicographical_compare
 #include <compare>                                // strong_ordering
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(TheViewReplacesItsOrderingRatherThanTrustingIt)
 BOOST_AUTO_TEST_CASE(BothReadingsAreReachable)
 {
         static_assert(xstd::ranges::set_range<T>);
-        static_assert(xstd::ranges::array_range<T>);
+        static_assert(xstd::ranges::sequence_range<T>);
 }
 
 // It owns its storage, so the extent is a run-time value and the trivial and nothrow batteries do not apply.

--- a/test/src/bits/ext/std.cpp
+++ b/test/src/bits/ext/std.cpp
@@ -3,12 +3,12 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/test/unit_test.hpp>        // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
-#include <xstd/bits/ext/std.hpp>           // the std adaptors, asked for by name
-#include <xstd/bits/ranges/array_view.hpp> // array_range
-#include <xstd/bits/ranges/set_view.hpp>   // set_range
-#include <bitset>                          // bitset
-#include <span>                            // dynamic_extent
+#include <boost/test/unit_test.hpp>           // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
+#include <xstd/bits/ext/std.hpp>              // the std adaptors, asked for by name
+#include <xstd/bits/ranges/sequence_view.hpp> // sequence_range
+#include <xstd/bits/ranges/set_view.hpp>      // set_range
+#include <bitset>                             // bitset
+#include <span>                               // dynamic_extent
 
 BOOST_AUTO_TEST_SUITE(Ext)
 BOOST_AUTO_TEST_SUITE(Std)
@@ -17,7 +17,7 @@ BOOST_AUTO_TEST_SUITE(Std)
 BOOST_AUTO_TEST_CASE(AskingForItByNameIsEnough)
 {
         static_assert(xstd::ranges::set_range<std::bitset<8>>);
-        static_assert(xstd::ranges::array_range<std::bitset<8>>);
+        static_assert(xstd::ranges::sequence_range<std::bitset<8>>);
         static_assert(xstd::ranges::bit_extent<std::bitset<8>> == 8);
         static_assert(xstd::ranges::bit_extent<std::bitset<8>> != std::dynamic_extent);
 }

--- a/test/src/bits/ext/std/bitset.cpp
+++ b/test/src/bits/ext/std/bitset.cpp
@@ -3,16 +3,16 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/test/unit_test.hpp>        // BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
-#include <xstd/bits/bitset.hpp>            // bitset
-#include <xstd/bits/ext/std/bitset.hpp>    // bit_extent, set_find, array_find
-#include <xstd/bits/ranges/array_view.hpp> // array_range
-#include <xstd/bits/ranges/set_view.hpp>   // set_range, set_view
-#include <bitset>                          // bitset
-#include <concepts>                        // regular, totally_ordered
-#include <ranges>                          // range
-#include <tuple>                           // tuple
-#include <type_traits>                     // is_nothrow_*, is_trivially_*
+#include <boost/test/unit_test.hpp>           // BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
+#include <xstd/bits/bitset.hpp>               // bitset
+#include <xstd/bits/ext/std/bitset.hpp>       // bit_extent, set_find, sequence_find
+#include <xstd/bits/ranges/sequence_view.hpp> // sequence_range
+#include <xstd/bits/ranges/set_view.hpp>      // set_range, set_view
+#include <bitset>                             // bitset
+#include <concepts>                           // regular, totally_ordered
+#include <ranges>                             // range
+#include <tuple>                              // tuple
+#include <type_traits>                        // is_nothrow_*, is_trivially_*
 
 BOOST_AUTO_TEST_SUITE(Ext)
 BOOST_AUTO_TEST_SUITE(Std)
@@ -40,12 +40,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(OrderedThroughTheViewRatherThanInfix, T, Types)
         static_assert(    std::totally_ordered<xstd::set_view<T>>);
 }
 
-// Both readings are reachable, which is what bit_extent, set_find and array_find are specialized here for.
+// Both readings are reachable, which is what bit_extent, set_find and sequence_find are specialized here for.
 BOOST_AUTO_TEST_CASE_TEMPLATE(BothReadingsAreReachable, T, Types)
 {
         static_assert(not std::ranges::range<T>);
         static_assert(xstd::ranges::set_range<T>);
-        static_assert(xstd::ranges::array_range<T>);
+        static_assert(xstd::ranges::sequence_range<T>);
 }
 
 // Ours answers the same type-trait battery at the same widths, so nothing is given up by building it over the packed array.

--- a/test/src/bits/ranges.cpp
+++ b/test/src/bits/ranges.cpp
@@ -5,7 +5,7 @@
 
 #include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE
 #include <xstd/bits/ext/std/bitset.hpp> // the hooks that make std::bitset a bit range
-#include <xstd/bits/ranges.hpp>         // array_view, set_view and their proxies
+#include <xstd/bits/ranges.hpp>         // sequence_view, set_view and their proxies
 #include <bitset>                       // bitset
 #include <concepts>                     // same_as
 #include <cstddef>                      // size_t
@@ -20,8 +20,8 @@ using Bits = std::bitset<64>;
 
 using SetIt   = xstd::ranges::set_iterator<Bits>;
 using SetRef  = xstd::ranges::set_reference<Bits>;
-using ArrIt   = xstd::ranges::array_iterator<Bits, false>;
-using ArrRef  = xstd::ranges::array_reference<Bits, false>;
+using ArrIt   = xstd::ranges::sequence_iterator<Bits, false>;
+using ArrRef  = xstd::ranges::sequence_reference<Bits, false>;
 
 // Dependent, so a type without the member is a substitution failure rather than a hard error.
 template<class R>
@@ -54,12 +54,12 @@ BOOST_AUTO_TEST_CASE(AddressOfAProxyYieldsAnIterator)
 // The const path is a proxy too, the same one minus the assignment -- not the plain bool libstdc++ hands back.
 BOOST_AUTO_TEST_CASE(TheConstPathIsAProxyAsWell)
 {
-        using ConstArrRef = xstd::ranges::array_reference<Bits, true>;
+        using ConstArrRef = xstd::ranges::sequence_reference<Bits, true>;
 
         static_assert(std::is_convertible_v<ConstArrRef, bool>);
         static_assert(has_address_of<ConstArrRef>);
         static_assert(std::same_as<decltype(&std::declval<ConstArrRef const&>()),
-                                   xstd::ranges::array_iterator<Bits, true>>);
+                                   xstd::ranges::sequence_iterator<Bits, true>>);
 
         // and it is exactly the assignment that the const one drops.
         static_assert(    std::is_assignable_v<ArrRef const&, bool>);
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(TheValueArrivesByImplicitConversion)
         BOOST_CHECK_EQUAL(key, 3UZ);
         BOOST_CHECK(*v.begin() == 3UZ);
 
-        auto const a = xstd::array_view(b);
+        auto const a = xstd::sequence_view(b);
         bool const bit = a[3];
         BOOST_CHECK(bit);
         BOOST_CHECK(a[5] == true);
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(TheProxyPairRoundTrips)
                 BOOST_CHECK(*&*it == *it);
         }
 
-        auto const a = xstd::array_view(b);
+        auto const a = xstd::sequence_view(b);
         for (auto it = a.begin(); it != a.end(); ++it) {
                 BOOST_CHECK(&*it == it);
                 BOOST_CHECK(static_cast<bool>(*&*it) == static_cast<bool>(*it));

--- a/test/src/bits/ranges/block_access.cpp
+++ b/test/src/bits/ranges/block_access.cpp
@@ -10,8 +10,8 @@
 #include <xstd/bits/bitset.hpp>                   // bitset
 #include <xstd/bits/ext/boost/dynamic_bitset.hpp> // the one that stays element-wise
 #include <xstd/bits/ext/std/bitset.hpp>           // block_access over std::bitset, where the words are reachable
-#include <xstd/bits/ranges/array_view.hpp>        // array_view
 #include <xstd/bits/ranges/block_access.hpp>      // block_range
+#include <xstd/bits/ranges/sequence_view.hpp>     // sequence_view
 #include <xstd/bits/ranges/set_view.hpp>          // set_view
 #include <algorithm>                              // lexicographical_compare, lexicographical_compare_three_way
 #include <bitset>                                 // bitset
@@ -30,7 +30,7 @@ template<std::size_t N, class Block>
 auto sweep() -> void
 {
         auto set_disagreements    = 0;
-        auto array_disagreements  = 0;
+        auto sequence_disagreements  = 0;
         auto opaque_disagreements = 0;
 
         for (auto i = 0UZ; i < (1UZ << N); ++i) {
@@ -50,7 +50,7 @@ auto sweep() -> void
                         }
 
                         set_disagreements   += ((sx <=> sy) < 0) != std::ranges::lexicographical_compare(kx, ky);
-                        array_disagreements += ((ax <=> ay) < 0) != std::ranges::lexicographical_compare(vx, vy);
+                        sequence_disagreements += ((ax <=> ay) < 0) != std::ranges::lexicographical_compare(vx, vy);
 
                         // The invariant proper: these two stream blocks and never iterate, and must still mean what iterating would.
                         opaque_disagreements += (sx <=> sy) != std::lexicographical_compare_three_way(sx.begin(), sx.end(), sy.begin(), sy.end());
@@ -60,7 +60,7 @@ auto sweep() -> void
 
         // Checked once rather than per pair: a million passing assertions say no more than one, and drown the log if any fails.
         BOOST_CHECK_EQUAL(set_disagreements, 0);
-        BOOST_CHECK_EQUAL(array_disagreements, 0);
+        BOOST_CHECK_EQUAL(sequence_disagreements, 0);
         BOOST_CHECK_EQUAL(opaque_disagreements, 0);
 }
 
@@ -86,8 +86,8 @@ auto views_agree_with_iteration(std::size_t universe) -> void
 
                         auto const sx = xstd::set_view(x);
                         auto const sy = xstd::set_view(y);
-                        auto const ax = xstd::array_view(x);
-                        auto const ay = xstd::array_view(y);
+                        auto const ax = xstd::sequence_view(x);
+                        auto const ay = xstd::sequence_view(y);
 
                         disagreements += (sx <=> sy) != std::lexicographical_compare_three_way(sx.begin(), sx.end(), sy.begin(), sy.end());
                         disagreements += (ax <=> ay) != std::lexicographical_compare_three_way(ax.begin(), ax.end(), ay.begin(), ay.end());
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(OursSayWhereTheirBlocksAre)
         static_assert(xstd::ranges::block_range<xstd::bitset<9, Block>>);
 
         static_assert(xstd::ranges::block_range<xstd::set_view<xstd::bitset<9, Block>>>);
-        static_assert(xstd::ranges::block_range<xstd::array_view<xstd::bitset<9, Block>>>);
+        static_assert(xstd::ranges::block_range<xstd::sequence_view<xstd::bitset<9, Block>>>);
 }
 
 // dynamic_bitset has blocks and will not hand them over, so it keeps the element-wise path -- which must still be right.

--- a/test/src/bits/ranges/sequence_view.cpp
+++ b/test/src/bits/ranges/sequence_view.cpp
@@ -7,29 +7,29 @@
 #include <test/sequence/ordering.hpp>             // ordering_agrees_with_vector_bool
 #include <xstd/bits/bit_array.hpp>                // bit_array
 #include <xstd/bits/bit_finite_set.hpp>           // bit_finite_set
-#include <xstd/bits/bitset.hpp>                   // array_find over xstd::bitset
-#include <xstd/bits/ext/boost/dynamic_bitset.hpp> // array_find over boost::dynamic_bitset
-#include <xstd/bits/ext/std/bitset.hpp>           // array_find over std::bitset
-#include <xstd/bits/ranges/array_view.hpp>        // array_view, array_range
+#include <xstd/bits/bitset.hpp>                   // sequence_find over xstd::bitset
+#include <xstd/bits/ext/boost/dynamic_bitset.hpp> // sequence_find over boost::dynamic_bitset
+#include <xstd/bits/ext/std/bitset.hpp>           // sequence_find over std::bitset
+#include <xstd/bits/ranges/sequence_view.hpp>     // sequence_view, sequence_range
 #include <algorithm>                              // equal
 #include <array>                                  // array
 #include <bitset>                                 // bitset
 #include <ranges>                                 // random_access_range
 
 BOOST_AUTO_TEST_SUITE(Ranges)
-BOOST_AUTO_TEST_SUITE(ArrayView)
+BOOST_AUTO_TEST_SUITE(SequenceView)
 
 BOOST_AUTO_TEST_CASE(TheViewedTypesAreTheOnesHoldingBoolsWithoutOfferingThem)
 {
-        static_assert(xstd::ranges::array_range<std::bitset<8>>);
-        static_assert(xstd::ranges::array_range<xstd::bitset<8>>);
-        static_assert(xstd::ranges::array_range<boost::dynamic_bitset<>>);
+        static_assert(xstd::ranges::sequence_range<std::bitset<8>>);
+        static_assert(xstd::ranges::sequence_range<xstd::bitset<8>>);
+        static_assert(xstd::ranges::sequence_range<boost::dynamic_bitset<>>);
 
-        static_assert(std::ranges::random_access_range<xstd::array_view<std::bitset<8>>>);
-        static_assert(std::ranges::random_access_range<xstd::array_view<xstd::bitset<8>>>);
+        static_assert(std::ranges::random_access_range<xstd::sequence_view<std::bitset<8>>>);
+        static_assert(std::ranges::random_access_range<xstd::sequence_view<xstd::bitset<8>>>);
 
         // bit_finite_set is not a sequence of bools; it is a set of keys.
-        static_assert(not xstd::ranges::array_range<xstd::bit_finite_set<8>>);
+        static_assert(not xstd::ranges::sequence_range<xstd::bit_finite_set<8>>);
 }
 
 // The sequence reading is the bools at every position, checked against the std::array<bool, N> holding the same bits.
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(TheSequenceReadingIsTheArrayOfBools)
                         if ((i >> k & 1UZ) != 0UZ) { packed.set(k); plain[k] = true; }
                 }
 
-                auto const view = xstd::array_view(packed);
+                auto const view = xstd::sequence_view(packed);
                 BOOST_CHECK_EQUAL(view.size(), N);
                 BOOST_CHECK(std::ranges::equal(view, plain));
         }
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(TheSequenceReadingIsTheArrayOfBools)
 BOOST_AUTO_TEST_CASE(WritingThroughTheViewWritesTheBits)
 {
         auto packed = xstd::bitset<8>();
-        auto const view = xstd::array_view(packed);
+        auto const view = xstd::sequence_view(packed);
 
         view[3] = true;
         BOOST_CHECK(packed.test(3));
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(APackedArrayAgreesWithItsOwnView)
         packed[1] = true;
         packed[6] = true;
 
-        auto const view = xstd::array_view(packed);
+        auto const view = xstd::sequence_view(packed);
         for (auto k = 0UZ; k < 8UZ; ++k) {
                 BOOST_CHECK_EQUAL(static_cast<bool>(view[k]), static_cast<bool>(packed[k]));
         }


### PR DESCRIPTION
Every `array_`-prefixed name in the library becomes `sequence_`. Zero `array_` identifiers remain; `bit_array` is untouched, being a public container name rather than part of this prefix.

| | → |
| --- | --- |
| `array_find`, `array_ops` | `sequence_find`, `sequence_ops` |
| `array_range`, `array_three_way` | `sequence_range`, `sequence_three_way` |
| `array_view`, `array_iterator`, `array_reference` | `sequence_view`, `sequence_iterator`, `sequence_reference` |
| `array_begin`, `array_end` | `sequence_begin`, `sequence_end` |
| `ranges/array_view.hpp` | `ranges/sequence_view.hpp`, with its test mirror |

## Why sequence

Three reasons, of which only the first is obvious.

**It matches what the storage is already called.** `block_sequence` sits directly underneath. The essential property of a bit container is packed sequential storage — true even of one wearing a set-like interface, which is exactly why the set reading and this one can share a layer at all.

**It stays true later.** Sequence spans both the static and the dynamic container, so the word does not quietly commit to `bit_array` over `bit_vector` the way `array_` did. #80 names the class `basic_bit_sequence` for the same reason.

**It repairs a mismatch rather than introducing one.** The prose in this header already called this the sequence reading — *"The sequence ordering, defined once"*, *"a bitset's `size()` being already a sequence's `size()`"* — and the test helpers already live in `test/include/test/sequence/`. Only the identifiers were behind.

The word also has to be settled before #80 step 3 folds these traits into `bit_traits`, where the entries sit beside their `set_` counterparts under one door with no enclosing class name left to supply the context.

## Mechanical fallout

Each of these is a consequence of the rename rather than separate work:

- **Include comment columns re-aligned in 11 files**, the path having grown three characters.
- **Four `#include` runs and the CMake `FILE_SET` re-sorted.** `sequence_view` sorts before `set_view` (`seq` < `set`) and after `block_access`, which broke alphabetical order where `array_view` had held it.
- **One sentence in `doc/design.md`** argued for a single template "rather than an `array_view`/`vector_view` pair". Neither name survives, so it now reads "rather than a static/dynamic pair", which is what it meant.

## Test plan

- [x] All 18 public headers compile standalone under `-std=gnu++23` with `-Wall -Wextra -Wpedantic -pedantic-errors -Wconversion -Wsign-conversion`, on top of merged `main`.
- [x] All 9 affected test translation units compile clean under the same flags.
- [x] `sequence_view` + `block_access` + `set_view` linked and run: 18 test cases, no errors.
- [x] `-Weverything` on the renamed header is identical to the control on `main` — 4 pre-existing `-Wc++20-compat` notes, not in the repo's warning set.
- [x] Re-validated after rebasing onto `main` with #85 merged, not only in isolation.
- [ ] CI.

Follows #83 and #85. Groundwork for #80 step 3 rather than one of its seven steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gfTqPbkbmFo2yfGSCDRpU

---
_Generated by [Claude Code](https://claude.ai/code/session_016gfTqPbkbmFo2yfGSCDRpU)_