### PR TITLE
Give block_sequence one scan primitive, and take the range adaptors out of the find_ family

### DIFF
--- a/include/xstd/bits/bit_finite_set.hpp
+++ b/include/xstd/bits/bit_finite_set.hpp
@@ -72,8 +72,8 @@ class bit_finite_set
 
         [[nodiscard]] friend constexpr auto find_first(const bit_finite_set& c)                noexcept -> std::size_t { return c.m_bits.find_first(); }
         [[nodiscard]] friend constexpr auto find_last (const bit_finite_set& c)                noexcept -> std::size_t { return c.m_bits.find_last();  }
-        [[nodiscard]] friend constexpr auto find_next (const bit_finite_set& c, std::size_t n) noexcept -> std::size_t { return c.m_bits.find_next(n); }
-        [[nodiscard]] friend constexpr auto find_prev (const bit_finite_set& c, std::size_t n) noexcept -> std::size_t { return c.m_bits.find_prev(n); }
+        [[nodiscard]] friend constexpr auto find_next (const bit_finite_set& c, std::size_t n) noexcept -> std::size_t { return c.m_bits.find_next_exclusive(n); }
+        [[nodiscard]] friend constexpr auto find_prev (const bit_finite_set& c, std::size_t n) noexcept -> std::size_t { return c.m_bits.find_prev_exclusive(n); }
 
         template<class Provider, class Hash, class Flavor>
         friend constexpr void tag_invoke(boost::hash2::hash_append_tag const&, Provider const&, Hash& h, Flavor const& f, bit_finite_set const* v) noexcept

--- a/include/xstd/bits/block_sequence.hpp
+++ b/include/xstd/bits/block_sequence.hpp
@@ -283,14 +283,14 @@ public:
                                 ++index;
                                 n += bits_per_block - offset;
                         }
-                        auto const rg = m_blocks | std::views::drop(index);
-                        // next is an iterator. That std::array's is a pointer is
-                        // implementation-defined -- [array.overview] requires only that it model
-                        // contiguous_iterator -- so readability-qualified-auto's auto const *const
-                        // would encode a detail this code never relies on: next is dereferenced and
-                        // passed to distance, both pure iterator operations.
-                        if (auto const next = std::ranges::find_if(rg, [](auto block) { return block != zero; }); next != std::ranges::end(rg)) {  // NOLINT(readability-qualified-auto)
-                                return n + detail::bits::countr_zero(*next) + (bits_per_block * distance(std::ranges::begin(rg), next));
+                        // A plain index walk rather than drop + find_if. The iterator form had to
+                        // recover the block's position with distance(); the index is that position,
+                        // so it never needed recovering. Both exits are exercised: falling out is
+                        // how "nothing at or above n" reaches the return below.
+                        for (auto i = index; i < num_blocks(); ++i) {
+                                if (auto const block = m_blocks[i]; block != zero) {
+                                        return n + detail::bits::countr_zero(block) + (bits_per_block * (i - index));
+                                }
                         }
                 }
                 return size();
@@ -306,10 +306,35 @@ public:
         [[nodiscard]] constexpr auto find_prev(std::size_t n) const noexcept
                 -> std::size_t
         {
+                // The mirror of find_next's assert(is_valid(n)): each says the position actually
+                // scanned from is one this container has. n - 1 is that position here, and the
+                // wraparound does the work at the bottom -- 0 - 1 is SIZE_MAX, which no width
+                // admits -- so this states 1 <= n <= size() without a second predicate. is_valid
+                // alone would be wrong: size() is a legitimate argument, meaning "from the end".
+                assert(is_valid(n - 1));
                 assert(any());
                 --n;
                 if constexpr (has_static_size and static_num_blocks == 1) {
                         return n - detail::bits::countl_zero(static_cast<block_type>(m_blocks[0] << (left_bit - n)));
+                } else if constexpr (has_static_size and static_num_blocks == 2) {
+                        // The mirror of lower_bound's two-block case, and simpler than the general
+                        // path below because the fallback is one named block rather than a scan.
+                        //
+                        // No reverse_offset != 0 guard is needed here. Below, that guard is not
+                        // about the shift -- left_bit - offset is in [0, left_bit], so shifting is
+                        // always in range and by zero is the identity -- it is about which block
+                        // the range scan must start at: at index when the whole block is in range,
+                        // below it when the masked block came up empty. Naming the fallback block
+                        // outright makes that distinction disappear.
+                        auto const [ index, offset ] = index_offset(n);
+                        if (auto const block = static_cast<block_type>(m_blocks[index] << (left_bit - offset)); block != zero) {
+                                return n - detail::bits::countl_zero(block);
+                        }
+                        // Reaching here with index 0 means no set bit at or below the caller's n,
+                        // which is the precondition the general path asserts as prev != end(rg).
+                        assert(index == 1);
+                        assert(m_blocks[0] != zero);
+                        return left_bit - detail::bits::countl_zero(m_blocks[0]);
                 } else {
                         auto [ index, offset ] = index_offset(n);
                         if (auto const reverse_offset = left_bit - offset; reverse_offset != 0) {
@@ -319,10 +344,21 @@ public:
                                 --index;
                                 n -= bits_per_block - reverse_offset;
                         }
-                        auto const rg = m_blocks | std::views::reverse | std::views::drop(last_block() - index);
-                        auto const prev = std::ranges::find_if(rg, [](auto block) { return block != zero; });
-                        assert(prev != std::ranges::end(rg));
-                        return n - detail::bits::countl_zero(*prev) - (bits_per_block * distance(std::ranges::begin(rg), prev));
+                        // A descending index walk rather than reverse + drop + find_if, which
+                        // composed two adaptors only to have distance() undo them.
+                        //
+                        // Shaped as a while rather than a for with a fall-through, deliberately.
+                        // The precondition guarantees a set bit at or below, so a loop that could
+                        // run out would carry an exit branch no test can take -- which is exactly
+                        // what the coverage gate would catch, and what find_if hid by keeping that
+                        // branch inside the standard library. Here both branches of the condition
+                        // are exercised: empty blocks are skipped, a non-empty one ends it.
+                        auto i = index;
+                        while (m_blocks[i] == zero) {
+                                assert(i != 0);
+                                --i;
+                        }
+                        return n - detail::bits::countl_zero(m_blocks[i]) - (bits_per_block * (index - i));
                 }
         }
 

--- a/include/xstd/bits/block_sequence.hpp
+++ b/include/xstd/bits/block_sequence.hpp
@@ -289,14 +289,18 @@ public:
                                 return bits_per_block + detail::bits::countr_zero(m_blocks[1]);
                         }
                 } else {
+                        // No offset != 0 guard: >> 0 is the identity, so the masked test is correct
+                        // at a block boundary too, and advancing past that block afterwards is
+                        // right either way. Neither reference implementation guards it -- boost
+                        // shifts by ind then falls to m_do_find_from(blk + 1), libstdc++ masks by
+                        // ~0 << whichbit then does __i++ -- and the guard skips no work: at offset
+                        // 0 it merely moves the same test into the loop's first iteration.
                         auto [ index, offset ] = index_offset(n);
-                        if (offset != 0) {
-                                if (auto const block = static_cast<block_type>(m_blocks[index] >> offset); block != zero) {
-                                        return n + detail::bits::countr_zero(block);
-                                }
-                                ++index;
-                                n += bits_per_block - offset;
+                        if (auto const block = static_cast<block_type>(m_blocks[index] >> offset); block != zero) {
+                                return n + detail::bits::countr_zero(block);
                         }
+                        ++index;
+                        n += bits_per_block - offset;
                         // A plain index walk rather than drop + find_if. The iterator form had to
                         // recover the block's position with distance(); the index is that position,
                         // so it never needed recovering. Both exits are exercised: falling out is

--- a/include/xstd/bits/block_sequence.hpp
+++ b/include/xstd/bits/block_sequence.hpp
@@ -334,6 +334,17 @@ public:
                 return find_next_inclusive(n + 1);
         }
 
+        // The last set position below n. Deliberately NOT total: where find_next_inclusive
+        // answers size() for "nothing at or above", this one has a precondition instead, and
+        // that is the whole of why it is three instructions cheaper at every width -- it never
+        // materializes a not-found value.
+        //
+        // Safe because reverse iteration supplies the guard the function does not.
+        // rend() is make_reverse_iterator(begin()), and std::reverse_iterator stops there, so
+        // operator-- is never applied at begin(). A hand-written loop gets no such help:
+        // the forward idiom terminates itself against size(), the reverse one runs off the
+        // bottom. Totality is the container's contract to keep, per #86 -- not this layer's to
+        // absorb.
         [[nodiscard]] constexpr auto find_prev_exclusive(std::size_t n) const noexcept
                 -> std::size_t
         {

--- a/include/xstd/bits/block_sequence.hpp
+++ b/include/xstd/bits/block_sequence.hpp
@@ -218,26 +218,17 @@ public:
                 }
         }
 
+        // Its own 0. Now that lower_bound carries the 2-block case too, this emits the same
+        // instruction sequence the hand-written version did -- verified, not assumed -- so the
+        // duplication goes without costing the unrolling. libstdc++ writes both scans out and
+        // repeats the word loop and the ctz-plus-index arithmetic between them; boost factors
+        // the shared tail into m_do_find_from, but only at block granularity, so find_next still
+        // needs its own prologue for a mid-block start. Factoring at bit granularity subsumes
+        // both: a block-aligned start is just offset == 0.
         [[nodiscard]] constexpr auto find_first() const noexcept
                 -> std::size_t
         {
-                if constexpr (has_static_size and N > 0 and static_num_blocks == 1) {
-                        if (m_blocks[0] != zero) {
-                                return detail::bits::countr_zero(m_blocks[0]);
-                        }
-                } else if constexpr (has_static_size and static_num_blocks == 2) {
-                        if (m_blocks[0] != zero) {
-                                return detail::bits::countr_zero(m_blocks[0]);
-                        }
-                        if (m_blocks[1] != zero) {
-                                return detail::bits::countr_zero(m_blocks[1]) + bits_per_block;
-                        }
-                } else if constexpr (not (has_static_size and N == 0)) {
-                        if (auto const first = std::ranges::find_if(m_blocks, [](auto block) { return block != zero; }); first != std::ranges::end(m_blocks)) {
-                                return detail::bits::countr_zero(*first) + (bits_per_block * distance(std::ranges::begin(m_blocks), first));
-                        }
-                }
-                return size();
+                return lower_bound(0UZ);
         }
 
         [[nodiscard]] constexpr auto find_last() const noexcept
@@ -265,6 +256,22 @@ public:
                 }
                 if constexpr (has_static_size and static_num_blocks == 1) {
                         if (auto const block = static_cast<block_type>(m_blocks[0] >> n); block != zero) {
+                                return n + detail::bits::countr_zero(block);
+                        }
+                } else if constexpr (has_static_size and static_num_blocks == 2) {
+                        // Two blocks, so the tail is one named block rather than a range: the drop
+                        // and find_if below cost more than the whole scan is worth at this width.
+                        // index is a run-time value here -- n is -- but the block count is not, so
+                        // the second half is a test and not a loop.
+                        auto const [ index, offset ] = index_offset(n);
+                        if (index == 0) {
+                                if (auto const block = static_cast<block_type>(m_blocks[0] >> offset); block != zero) {
+                                        return n + detail::bits::countr_zero(block);
+                                }
+                                if (m_blocks[1] != zero) {
+                                        return bits_per_block + detail::bits::countr_zero(m_blocks[1]);
+                                }
+                        } else if (auto const block = static_cast<block_type>(m_blocks[1] >> offset); block != zero) {
                                 return n + detail::bits::countr_zero(block);
                         }
                 } else {

--- a/include/xstd/bits/block_sequence.hpp
+++ b/include/xstd/bits/block_sequence.hpp
@@ -20,6 +20,7 @@
 #include <concepts>                                            // swap
 #include <cstddef>                                             // ptrdiff_t, size_t
 #include <functional>                                          // plus
+#include <iterator>                                            // prev
 #include <memory>                                              // allocator
 #include <ranges>                                              // begin, drop, iota, size, swap, transform, zip
                                                                // (views::drop_last when P22014R2 is accepted)

--- a/include/xstd/bits/block_sequence.hpp
+++ b/include/xstd/bits/block_sequence.hpp
@@ -14,15 +14,14 @@
 #include <xstd/ints/limits.hpp>                                // numeric_limits
 #include <xstd/ints/memory.hpp>                                // align_up
 #include <xstd/misc/type_traits/conditional_data_member.hpp>   // XSTD_NO_UNIQUE_ADDRESS, conditional_data_member_t
-#include <algorithm>                                           // all_of, any_of, equal, fill, fill_n, find_if, fold_left, max, shift_left, shift_right
+#include <algorithm>                                           // all_of, any_of, equal, fill, fill_n, fold_left, max, shift_left, shift_right
 #include <array>                                               // array
 #include <cassert>                                             // assert
 #include <concepts>                                            // swap
 #include <cstddef>                                             // ptrdiff_t, size_t
 #include <functional>                                          // plus
-#include <iterator>                                            // distance, prev, random_access_iterator, sized_sentinel_for
 #include <memory>                                              // allocator
-#include <ranges>                                              // begin, drop, iota, reverse, size, swap, transform, zip
+#include <ranges>                                              // begin, drop, iota, size, swap, transform, zip
                                                                // (views::drop_last when P22014R2 is accepted)
 #include <span>                                                // dynamic_extent
 #include <type_traits>                                         // conditional_t, is_const_v, is_nothrow_swappable_v, remove_reference_t
@@ -196,9 +195,17 @@ public:
                 } else if constexpr (has_static_size and static_num_blocks == 2) {
                         return m_blocks[0] != zero ? detail::bits::countr_zero(m_blocks[0]) : detail::bits::countr_zero(m_blocks[1]) + bits_per_block;
                 } else {
-                        auto const front = std::ranges::find_if(m_blocks, [](auto block) { return block != zero; });
-                        assert(front != std::ranges::end(m_blocks));
-                        return detail::bits::countr_zero(*front) + (bits_per_block * distance(std::ranges::begin(m_blocks), front));
+                        // A while rather than a for: any() guarantees a non-empty block exists, so
+                        // a loop that could run out would carry an exit branch no test can take.
+                        // Both branches of this condition are exercised instead -- empty blocks are
+                        // skipped, a non-empty one ends it -- and the index is the block's position
+                        // rather than something distance() has to recover.
+                        auto i = 0UZ;
+                        while (m_blocks[i] == zero) {
+                                assert(i != last_block());
+                                ++i;
+                        }
+                        return (bits_per_block * i) + detail::bits::countr_zero(m_blocks[i]);
                 }
         }
 
@@ -211,10 +218,15 @@ public:
                 } else if constexpr (has_static_size and static_num_blocks == 2) {
                         return m_blocks[1] != zero ? last_bit() - detail::bits::countl_zero(m_blocks[1]) : left_bit - detail::bits::countl_zero(m_blocks[0]);
                 } else {
-                        auto const rg = m_blocks | std::views::reverse;
-                        auto const back = std::ranges::find_if(rg, [](auto block) { return block != zero; });
-                        assert(back != std::ranges::end(rg));
-                        return last_bit() - detail::bits::countl_zero(*back) - (bits_per_block * distance(std::ranges::begin(rg), back));
+                        // The mirror of find_front, and the last reverse view in the file. Counting
+                        // up from block i's own base rather than down from last_bit() drops the
+                        // last_block() - i term the reversed range needed.
+                        auto i = last_block();
+                        while (m_blocks[i] == zero) {
+                                assert(i != 0);
+                                --i;
+                        }
+                        return (bits_per_block * i) + left_bit - detail::bits::countl_zero(m_blocks[i]);
                 }
         }
 
@@ -259,20 +271,22 @@ public:
                                 return n + detail::bits::countr_zero(block);
                         }
                 } else if constexpr (has_static_size and static_num_blocks == 2) {
-                        // Two blocks, so the tail is one named block rather than a range: the drop
-                        // and find_if below cost more than the whole scan is worth at this width.
-                        // index is a run-time value here -- n is -- but the block count is not, so
-                        // the second half is a test and not a loop.
+                        // Two blocks, so the tail is one named block rather than a range: the walk
+                        // below costs more than the whole scan is worth at this width. index is a
+                        // run-time value -- n is -- but the block count is not, so the second half
+                        // is a test and not a loop.
+                        //
+                        // Indexed rather than branched: m_blocks[index], not an if on index, so the
+                        // common path is one computed load. Only when the starting block comes up
+                        // empty does it matter which block we started in, and then only to decide
+                        // whether block 1 is still ahead of us. Writing this as a branch instead
+                        // cost 10 instructions at -O3 -march=native.
                         auto const [ index, offset ] = index_offset(n);
-                        if (index == 0) {
-                                if (auto const block = static_cast<block_type>(m_blocks[0] >> offset); block != zero) {
-                                        return n + detail::bits::countr_zero(block);
-                                }
-                                if (m_blocks[1] != zero) {
-                                        return bits_per_block + detail::bits::countr_zero(m_blocks[1]);
-                                }
-                        } else if (auto const block = static_cast<block_type>(m_blocks[1] >> offset); block != zero) {
+                        if (auto const block = static_cast<block_type>(m_blocks[index] >> offset); block != zero) {
                                 return n + detail::bits::countr_zero(block);
+                        }
+                        if (index == 0 and m_blocks[1] != zero) {
+                                return bits_per_block + detail::bits::countr_zero(m_blocks[1]);
                         }
                 } else {
                         auto [ index, offset ] = index_offset(n);
@@ -802,26 +816,6 @@ private:
                 } else if constexpr (not has_static_size) {
                         m_blocks[last_block()] &= used_bits();
                 }
-        }
-
-        // Iterators are taken by value, as std::ranges::distance itself takes them.
-        //
-        // performance-unnecessary-value-param flags both parameters, and only for the
-        // reverse_iterator instantiations. libstdc++ hand-writes that class's copy
-        // constructor -- a pre-"= default" idiom; the copy assignment beside it is
-        // defaulted -- so it is not trivially copyable, where libc++'s is and the check
-        // stays silent. The verdict is a property of the standard library rather than of
-        // this signature.
-        //
-        // Nor is the cost it names paid here. Not trivially copyable means non-trivial
-        // for the purposes of calls under the Itanium ABI, so an out-of-line callee takes
-        // a pointer to a caller-built temporary where a trivially copyable type of the
-        // same eight bytes arrives in a register. This is a static constexpr one-liner:
-        // at -O2 it inlines and both iterators fold away to a pointer subtraction.
-        template<std::random_access_iterator I, std::sized_sentinel_for<I> S>
-        [[nodiscard]] static constexpr auto distance(I first, S last) noexcept  // NOLINT(performance-unnecessary-value-param)
-        {
-                return static_cast<std::size_t>(std::ranges::distance(first, last));
         }
 };
 

--- a/include/xstd/bits/block_sequence.hpp
+++ b/include/xstd/bits/block_sequence.hpp
@@ -246,10 +246,20 @@ public:
                 return size();
         }
 
-        [[nodiscard]] constexpr auto find_next(std::size_t n) const noexcept
+        // The first set position at or above n, or size() if there is none. This is the whole
+        // scan: find_first is lower_bound(0) and find_next is lower_bound(n + 1). Expressed the
+        // other way round -- as a strictly-greater scan, which is what boost::dynamic_bitset and
+        // libstdc++'s _M_do_find_next expose -- find_first would have to be find_next(-1), and
+        // size_t has no such value. That is why the container had to branch on x == 0.
+        //
+        // n == size() rather than n >= size(): the precondition is n <= size(), asserted just
+        // below, so size() is the only value the scan cannot start from. is_valid does not say
+        // this -- it is n < size() -- and size() is a legitimate argument here, meaning "no such
+        // position", exactly as it is for find_prev.
+        [[nodiscard]] constexpr auto lower_bound(std::size_t n) const noexcept
                 -> std::size_t
         {
-                ++n;
+                assert(n <= size());
                 if (n == size()) {
                         return size();
                 }
@@ -277,6 +287,13 @@ public:
                         }
                 }
                 return size();
+        }
+
+        [[nodiscard]] constexpr auto find_next(std::size_t n) const noexcept
+                -> std::size_t
+        {
+                assert(is_valid(n));
+                return lower_bound(n + 1);
         }
 
         [[nodiscard]] constexpr auto find_prev(std::size_t n) const noexcept

--- a/include/xstd/bits/block_sequence.hpp
+++ b/include/xstd/bits/block_sequence.hpp
@@ -230,17 +230,17 @@ public:
                 }
         }
 
-        // Its own 0. Now that lower_bound carries the 2-block case too, this emits the same
+        // Its own 0. Now that find_next_inclusive carries the 2-block case too, this emits the same
         // instruction sequence the hand-written version did -- verified, not assumed -- so the
         // duplication goes without costing the unrolling. libstdc++ writes both scans out and
         // repeats the word loop and the ctz-plus-index arithmetic between them; boost factors
-        // the shared tail into m_do_find_from, but only at block granularity, so find_next still
+        // the shared tail into m_do_find_from, but only at block granularity, so find_next_exclusive still
         // needs its own prologue for a mid-block start. Factoring at bit granularity subsumes
         // both: a block-aligned start is just offset == 0.
         [[nodiscard]] constexpr auto find_first() const noexcept
                 -> std::size_t
         {
-                return lower_bound(0UZ);
+                return find_next_inclusive(0UZ);
         }
 
         [[nodiscard]] constexpr auto find_last() const noexcept
@@ -249,17 +249,30 @@ public:
                 return size();
         }
 
-        // The first set position at or above n, or size() if there is none. This is the whole
-        // scan: find_first is lower_bound(0) and find_next is lower_bound(n + 1). Expressed the
-        // other way round -- as a strictly-greater scan, which is what boost::dynamic_bitset and
-        // libstdc++'s _M_do_find_next expose -- find_first would have to be find_next(-1), and
-        // size_t has no such value. That is why the container had to branch on x == 0.
+        // The first set position at or above n, or size() if there is none.
+        //
+        // Inclusive and exclusive name the only thing that separates the two scans: whether n
+        // itself is a candidate. That is a property of the scan, not of a reading, which is why
+        // this is not called lower_bound -- that is the set reading's word for it, and this layer
+        // serves the sequence reading equally. bit_finite_set::lower_bound is where the set name
+        // belongs, and it maps here one for one.
+        //
+        // The inclusive form is the primitive and the exclusive one is derived, because the
+        // reverse does not close:
+        //
+        //     find_next_exclusive(n) == find_next_inclusive(n + 1)     for every n
+        //     find_first()           == find_next_inclusive(0)
+        //
+        // Exclusive-first would need find_first() == find_next_exclusive(-1), and size_t has no
+        // such value -- which is exactly why the container used to branch on x == 0. boost's
+        // find_next and libstdc++'s _M_do_find_next are both the exclusive form, correctly: their
+        // iteration idiom is find_first() then find_next(i), which never needs the inclusive one.
         //
         // n == size() rather than n >= size(): the precondition is n <= size(), asserted just
         // below, so size() is the only value the scan cannot start from. is_valid does not say
         // this -- it is n < size() -- and size() is a legitimate argument here, meaning "no such
-        // position", exactly as it is for find_prev.
-        [[nodiscard]] constexpr auto lower_bound(std::size_t n) const noexcept
+        // position", exactly as it is for find_prev_exclusive.
+        [[nodiscard]] constexpr auto find_next_inclusive(std::size_t n) const noexcept
                 -> std::size_t
         {
                 assert(n <= size());
@@ -314,17 +327,17 @@ public:
                 return size();
         }
 
-        [[nodiscard]] constexpr auto find_next(std::size_t n) const noexcept
+        [[nodiscard]] constexpr auto find_next_exclusive(std::size_t n) const noexcept
                 -> std::size_t
         {
                 assert(is_valid(n));
-                return lower_bound(n + 1);
+                return find_next_inclusive(n + 1);
         }
 
-        [[nodiscard]] constexpr auto find_prev(std::size_t n) const noexcept
+        [[nodiscard]] constexpr auto find_prev_exclusive(std::size_t n) const noexcept
                 -> std::size_t
         {
-                // The mirror of find_next's assert(is_valid(n)): each says the position actually
+                // The mirror of find_next_exclusive's assert(is_valid(n)): each says the position actually
                 // scanned from is one this container has. n - 1 is that position here, and the
                 // wraparound does the work at the bottom -- 0 - 1 is SIZE_MAX, which no width
                 // admits -- so this states 1 <= n <= size() without a second predicate. is_valid
@@ -335,7 +348,7 @@ public:
                 if constexpr (has_static_size and static_num_blocks == 1) {
                         return n - detail::bits::countl_zero(static_cast<block_type>(m_blocks[0] << (left_bit - n)));
                 } else if constexpr (has_static_size and static_num_blocks == 2) {
-                        // The mirror of lower_bound's two-block case, and simpler than the general
+                        // The mirror of find_next_inclusive's two-block case, and simpler than the general
                         // path below because the fallback is one named block rather than a scan.
                         //
                         // No reverse_offset != 0 guard is needed here. Below, that guard is not
@@ -761,7 +774,7 @@ private:
                 return std::ranges::all_of(first, first + static_cast<std::ptrdiff_t>(last_block()), [](auto block) { return block == ones; });
         }
 
-        // The top bit of the last block, padding included. find_back and find_prev count
+        // The top bit of the last block, padding included. find_back and find_prev_exclusive count
         // down from it and both assert any(), so the zero-width case never reaches here.
         [[nodiscard]] constexpr auto last_bit() const noexcept
                 -> std::size_t

--- a/test/src/bits/block_sequence.cpp
+++ b/test/src/bits/block_sequence.cpp
@@ -124,7 +124,7 @@ public:
                         while (not m_mx[back]) { --back; }
                         unequal(m_x.find_front(), front);
                         unequal(m_x.find_back(),  back);
-                        unequal(m_x.find_prev(m_n), back);
+                        unequal(m_x.find_prev_exclusive(m_n), back);
                 }
 
                 auto first = 0UZ;
@@ -135,22 +135,22 @@ public:
                 for (auto i = 0UZ; i < m_n; ++i) {
                         auto next = i + 1;
                         while (next < m_n and not m_mx[next]) { ++next; }
-                        unequal(m_x.find_next(i), next);
+                        unequal(m_x.find_next_exclusive(i), next);
                 }
 
-                // lower_bound is the primitive; find_first is its 0 and find_next its n + 1. Check
+                // find_next_inclusive is the primitive; find_first is its 0 and find_next_exclusive its n + 1. Check
                 // it directly over its whole precondition domain -- n == size() included, which is
                 // the one value the scan cannot start from and the reason the guard is == at all.
                 for (auto i = 0UZ; i <= m_n; ++i) {
                         auto bound = i;
                         while (bound < m_n and not m_mx[bound]) { ++bound; }
-                        unequal(m_x.lower_bound(i), bound);
+                        unequal(m_x.find_next_inclusive(i), bound);
                 }
                 for (auto i = 1UZ; i <= m_n and m_cardinality != 0; ++i) {
                         auto j = i;
                         while (j-- > 0) {
                                 if (m_mx[j]) {
-                                        unequal(m_x.find_prev(i), j);
+                                        unequal(m_x.find_prev_exclusive(i), j);
                                         break;
                                 }
                         }

--- a/test/src/bits/block_sequence.cpp
+++ b/test/src/bits/block_sequence.cpp
@@ -137,6 +137,15 @@ public:
                         while (next < m_n and not m_mx[next]) { ++next; }
                         unequal(m_x.find_next(i), next);
                 }
+
+                // lower_bound is the primitive; find_first is its 0 and find_next its n + 1. Check
+                // it directly over its whole precondition domain -- n == size() included, which is
+                // the one value the scan cannot start from and the reason the guard is == at all.
+                for (auto i = 0UZ; i <= m_n; ++i) {
+                        auto bound = i;
+                        while (bound < m_n and not m_mx[bound]) { ++bound; }
+                        unequal(m_x.lower_bound(i), bound);
+                }
                 for (auto i = 1UZ; i <= m_n and m_cardinality != 0; ++i) {
                         auto j = i;
                         while (j-- > 0) {


### PR DESCRIPTION
`block_sequence` gains `find_next_inclusive(n)` — the first set position **at or above** `n`, or `size()` if there is none — and the rest of the `find_` family is rebuilt on it or measured against it. No member of the family composes a range adaptor any more.

All figures below are `-O3 -march=native` (what Release builds with), each **paired within a single invocation** — the numbers are not comparable across runs and none here are.

| | before | after |
| --- | --- | --- |
| `find_next_inclusive`, 2 blocks | 58 | **22** |
| `find_next_inclusive`, 3 blocks | 55 | **40** |
| `find_prev_exclusive`, 2 blocks | 72 | **18** |
| `find_prev_exclusive`, 3 blocks | 72 | **35** |

## The naming

Inclusive and exclusive name the only thing separating the two scans: whether `n` itself is a candidate. That is a property of the scan, not of a reading — `lower_bound` is the *set* reading's word for it, and this layer serves the sequence reading equally, so the set name stays at `bit_finite_set::lower_bound` and maps here one for one.

| | inclusive (≥ / ≤) | exclusive (> / <) |
| --- | --- | --- |
| forward | **primitive** — `find_next_inclusive` | derived, `(n + 1)` |
| reverse | not written — derivable, no consumer | **primitive** — `find_prev_exclusive` |

The primitives sit on the **anti-diagonal**, which is not the symmetric arrangement it looks like it should be. Both derivations are `+ 1` and never `− 1`:

```
find_next_exclusive(n) == find_next_inclusive(n + 1)
find_prev_inclusive(n) == find_prev_exclusive(n + 1)
```

which is what lets each primitive name its own extreme directly — `find_first() == find_next_inclusive(0)`, `find_back() == find_prev_exclusive(size())`, both verified. Making inclusive the primitive in *both* directions would need `find_prev_exclusive(n) == find_prev_inclusive(n − 1)`, and that wraps at `n == 0`: the same `size_t` wall that makes `find_first == find_next(−1)` unusable, at the other end of the same argument.

Independent corroboration arrived mid-review: boost's feature branch `add_find_last_one_and_find_previous_one` adds `find_first_one(pos)` (documented "index ≥ pos"), `find_next_one(pos)` (> pos) and `find_previous_one(pos)` (< pos) — our three primitives with the same inclusivity choices, including the exclusive reverse.

## Contracts

`find_next_inclusive`'s guard is `n == size()`, not `n >= size()`. The precondition is `n <= size()`, asserted, so `size()` is the only value the scan cannot start from — and the test is on the caller's own value with no arithmetic in between. That is what makes the same operator an actual bound; the old `find_next` tested `==` *after* `++n`, so any argument past the end skipped straight over it.

`find_prev_exclusive` gains `assert(is_valid(n - 1))`, the mirror of `find_next_exclusive`'s `assert(is_valid(n))`. Unsigned wraparound does the work at the bottom — `0 - 1` is `SIZE_MAX`, which no width admits — so one predicate states `1 <= n <= size()` without a second. Verified to reject `0` and `999` and to admit `size()`.

It is also **deliberately not total**: that is exactly the three instructions it saves, flat at every width, and the reason is documented at the function. Reverse iteration supplies the guard — `rend()` is `make_reverse_iterator(begin())`, so `operator--` is never applied at `begin()`. A hand-written reverse loop gets no such help, which is the same shape as #86; totality is the container's contract, not this layer's to absorb.

## Unrolling, and where it stops

`find_next_inclusive` and `find_prev_exclusive` each gain a `static_num_blocks == 2` case. `find_next` never had one, so every 2-block static container was paying the general path in *both* directions.

`find_next_inclusive`'s 2-block case **indexes rather than branches** — `m_blocks[index]`, not an `if` on `index`. Writing it the other way, which is how it started, cost 10 instructions on its own.

**No case beyond 2 is worth adding.** Timed at 4 blocks, the non-unrolled reverse `while` beats the `for` GCC partially unrolls: 0.7 ms against 1.3 ms sparse, 2.0 against 3.9 at one bit per block, equal when dense. By four blocks the setup the unrolled cases eliminate is amortized, and at realistic densities per-set-bit work dominates the scan structure.

## `find_first` folded; `find_front`/`find_back` deliberately not

`find_first` becomes `find_next_inclusive(0)`, emitting the **identical instruction sequence** to the hand-written version — diffed, not assumed. An earlier attempt was reverted for regressing the 2-block case, and is only free now that the primitive knows every special case its callers did.

`find_front`/`find_back` are **not** folded, though value-equivalent at every width tested. They assume `any()`, so the last block needs no test:

| | `find_front` | `find_first` |
| --- | --- | --- |
| 1 block | **4** | 8 |
| 2 blocks | **12** | 14 |

At `-O2` both measure 9 — without BMI the `bsf` lowering forces a `cmove` into every count and hides the difference entirely, which is why `-march=native` is the only honest baseline here.

## The adaptors

Every general path drops `views::drop` and `views::reverse | views::drop` for a plain index walk. The iterator form had to recover each block's position with `distance()`; the index *is* that position.

Isolated and timed, one adaptor layer costs ~13% and composition roughly doubles that; the versions using adaptors are **smaller and slower**, because GCC vectorises the hand loops and does not vectorise through the iterator layers. So the honest split is that most of the 72→18 above is the 2-block unrolling, and the adaptor removal is a real but modest 30–40% on the general path.

`find_prev_exclusive`, `find_front` and `find_back` are `while` loops rather than `for` loops with a fall-through, deliberately: their preconditions guarantee a hit, so a loop that could run out would carry an exit branch no test can take — which `find_if` had hidden by keeping that branch inside the standard library. `find_next_inclusive`'s fall-through is genuinely reachable, so it stays a `for`.

That leaves the private `distance` helper with no callers, so it goes.

## Also here

- **The `offset != 0` guard is gone** from the general path. `>> 0` is the identity, so the masked test is correct at a block boundary too. Neither reference implementation guards it — boost shifts by `ind` then falls to `m_do_find_from(blk + 1)`, libstdc++ masks by `~0 << _S_whichbit(__prev)` then does `__i++` — and the guard skipped no work, merely moving the same test into the loop's first iteration: 9, 10, 7 and 7 instructions at 3, 4, 6 and 8 blocks.
- **A `<iterator>` regression, found by CI and fixed.** Removing the `distance` helper took `<iterator>` with it; `std::ranges::prev` survived in `erase_unused`, and the grep that cleared the header searched for `std::prev`. libstdc++ includes `<iterator>` transitively, so all 18 headers still compiled standalone — header self-sufficiency is exactly what the compiler cannot check and `misc-include-cleaner` can.

## Test plan

- [x] `find_next_inclusive` cross-checked against a `std::vector<bool>` model over its **whole precondition domain** including `n == size()`, at N = 0, 1, 8, 9, 24, 64, 129 across `uint8_t` and `uint64_t` — the 64-bit widths because integer promotion hides a bad shift at narrower ones.
- [x] A test aimed at what the `offset != 0` guard used to special-case: every subset of non-empty blocks × 4 within-block offsets × every start position, at 1, 2, 3 and 5 blocks of `uint8_t` and 3 of `uint64_t`.
- [x] The exhaustive suite green under ASan + UBSan at `-O0`, `-O2` **and** `-O3 -march=native`, with asserts live, plus a new `find_next_inclusive` cross-check in its `scans()` checker.
- [x] `find_first == find_next_inclusive(0)`, `find_front == find_first`, `find_back == find_prev_exclusive(size())` verified at every width above.
- [x] `assert(is_valid(n - 1))` verified to reject `0` and `999` and admit `size()`.
- [x] 18/18 headers standalone under the repo's warning set; 20 dependent test TUs; clang-18 `-Weverything` clean; include-cleaner clean across all 18 against merged `main`'s own finding set.
- [x] CI: **all 86 checks green** on `5a60724`. The two that were uncertain both passed — `coverage / gcovr`, which the `while`/`for` split was chosen for, and all three `clang_tidy` versions on the `<iterator>` fix.

Follows #87. Step 2b of #80, and closes the primitive half of #86; the container-side range guards that issue actually turns on are **not** here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gfTqPbkbmFo2yfGSCDRpU