### PR TITLE
Make bit_finite_set's lookups total over key_type, as std::set's are

### DIFF
--- a/include/xstd/bits/bit_finite_set.hpp
+++ b/include/xstd/bits/bit_finite_set.hpp
@@ -213,7 +213,9 @@ public:
         constexpr auto erase(const key_type& x) noexcept
                 -> size_type
         {
-                return m_bits.erase(x);
+                // The one guard here that stops a write rather than a read: without it an
+                // out-of-range key clears a bit in whatever follows the blocks.
+                return x < N and m_bits.erase(x);
         }
 
         constexpr auto erase(const_iterator first, const_iterator last) noexcept
@@ -258,8 +260,13 @@ public:
         [[nodiscard]] constexpr auto value_comp() const noexcept -> value_compare { return {}; }
 
         // set operations
-        [[nodiscard]] constexpr auto contains(const key_type& x) const noexcept -> bool      { return m_bits[x]; }
-        [[nodiscard]] constexpr auto count   (const key_type& x) const noexcept -> size_type { return m_bits[x]; }
+        // Every lookup below is total over key_type, because std::set's is: a key outside
+        // [0, N) names no element, so it answers "absent" rather than reaching the bit.
+        // block_sequence asserts is_valid on every position it accepts and offers no total
+        // spelling of any of these -- that is the layering working, not a gap in it. The
+        // precondition is the sequence's, the guard is the container's.
+        [[nodiscard]] constexpr auto contains(const key_type& x) const noexcept -> bool      { return x < N and m_bits[x]; }
+        [[nodiscard]] constexpr auto count   (const key_type& x) const noexcept -> size_type { return contains(x);         }
 
         [[nodiscard]] constexpr auto find(this auto&& self, const key_type& x) noexcept -> iterator
         {
@@ -268,8 +275,12 @@ public:
                 }
                 return self.end();
         }
-        [[nodiscard]] constexpr auto lower_bound(this auto&& self, const key_type& x) noexcept -> iterator                      { return { &self, (x ? find_next(self, x - 1) : find_first(self)) }; }
-        [[nodiscard]] constexpr auto upper_bound(this auto&& self, const key_type& x) noexcept -> iterator                      { return { &self, find_next(self, x) };                              }
+        // The bound is find_next_inclusive at x, and its exclusive twin one past it. The x ? :
+        // that used to stand here was find_next's exclusivity showing through: x - 1 wraps at
+        // 0, so the 0 case had to be spelled separately. An inclusive primitive has no such
+        // seam, so the two bounds now differ by the + 1 that actually separates them.
+        [[nodiscard]] constexpr auto lower_bound(this auto&& self, const key_type& x) noexcept -> iterator                      { return { &self, x < N ? self.m_bits.find_next_inclusive(x    ) : N }; }
+        [[nodiscard]] constexpr auto upper_bound(this auto&& self, const key_type& x) noexcept -> iterator                      { return { &self, x < N ? self.m_bits.find_next_inclusive(x + 1) : N }; }
         [[nodiscard]] constexpr auto equal_range(this auto&& self, const key_type& x) noexcept -> std::pair<iterator, iterator> { return { self.lower_bound(x), self.upper_bound(x) };               }
 
         [[nodiscard]] constexpr auto is_subset_of       (const bit_finite_set& other) const noexcept -> bool { return this->m_bits.is_subset_of       (other.m_bits); }

--- a/test/src/bits/bit_finite_set.cpp
+++ b/test/src/bits/bit_finite_set.cpp
@@ -9,8 +9,10 @@
 #include <test/value_reference.hpp>     // value_reference
 #include <xstd/bits/bit_finite_set.hpp> // bit_finite_set
 #include <concepts>                     // regular, totally_ordered
+#include <cstddef>                      // size_t
+#include <cstdint>                      // uint8_t, uint64_t
 #include <iterator>                     // bidirectional_iterator
-#include <ranges>                       // bidirectional_range
+#include <ranges>                       // bidirectional_range, iota, to
 
 BOOST_AUTO_TEST_SUITE(BitFiniteSet)
 
@@ -47,6 +49,59 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ItsConstReferenceIsAValue, T, Types)
 BOOST_AUTO_TEST_CASE_TEMPLATE(IsABitSet, T, Types)
 {
         static_assert(test::set::bit_set<T>);
+}
+
+// std::set's lookups are total over key_type, and so are these: a key naming no possible
+// element answers "absent" rather than reaching into the blocks. Kept here rather than in
+// the exhaustive suite because that suite draws every key from [0, N), which is exactly
+// why this went unseen.
+//
+// The width x key matrix is not decoration. Run against the unguarded header, no single
+// width exposes all six operations and no single key does either, so any one cell alone
+// would have let the bug through. Two cells are worth naming: erase past the last block
+// is an out-of-bounds *write*, and upper_bound fails on the returned value rather than on
+// memory at all -- find_next's ++n wrapped before it could test the bound, so it answered
+// with a real element where end() was due. That second one is what keeps this a gate on
+// the jobs that build without sanitizers.
+template<std::size_t N, class Block>
+auto check_keys_outside_the_domain() -> void
+{
+        using X = xstd::bit_finite_set<N, Block>;
+        auto const full = std::views::iota(0uz, N) | std::ranges::to<X>();
+
+        // Just past the end, past the last block, and the value that would wrap any n + 1.
+        for (auto const x : { N, N + 1, (2 * N) + 1, std::size_t(-1) }) {
+                for (auto const& original : { X(), full }) {
+                        auto a = original;
+
+                        BOOST_CHECK(not a.contains(x));
+                        BOOST_CHECK_EQUAL(a.count(x), 0uz);
+                        BOOST_CHECK(a.find(x)        == a.end());
+                        BOOST_CHECK(a.lower_bound(x) == a.end());
+                        BOOST_CHECK(a.upper_bound(x) == a.end());
+
+                        auto const [ first, last ] = a.equal_range(x);
+                        BOOST_CHECK(first == a.end());
+                        BOOST_CHECK(last  == a.end());
+
+                        // A no-op that must stay one: this is the write.
+                        BOOST_CHECK_EQUAL(a.erase(x), 0uz);
+                        BOOST_CHECK(a == original);
+                }
+        }
+}
+
+BOOST_AUTO_TEST_CASE(LookupIsTotalOverKeyType)
+{
+        // The wide and multi-block widths carry the test. Measured against the unguarded
+        // header, N = 8 over uint8_t is clean for all six at key == N, so a narrow
+        // single-block set on its own proves nothing either way.
+        check_keys_outside_the_domain<  0, std::uint8_t >();
+        check_keys_outside_the_domain<  8, std::uint8_t >();
+        check_keys_outside_the_domain< 24, std::uint8_t >();
+        check_keys_outside_the_domain<  1, std::uint64_t>();
+        check_keys_outside_the_domain< 64, std::uint64_t>();
+        check_keys_outside_the_domain<129, std::uint64_t>();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/bits/bit_finite_set.cpp
+++ b/test/src/bits/bit_finite_set.cpp
@@ -10,7 +10,6 @@
 #include <xstd/bits/bit_finite_set.hpp> // bit_finite_set
 #include <concepts>                     // regular, totally_ordered
 #include <cstddef>                      // size_t
-#include <cstdint>                      // uint8_t, uint64_t
 #include <iterator>                     // bidirectional_iterator
 #include <ranges>                       // bidirectional_range, iota, to
 
@@ -52,56 +51,48 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(IsABitSet, T, Types)
 }
 
 // std::set's lookups are total over key_type, and so are these: a key naming no possible
-// element answers "absent" rather than reaching into the blocks. Kept here rather than in
-// the exhaustive suite because that suite draws every key from [0, N), which is exactly
-// why this went unseen.
+// element answers "absent" rather than reaching into the blocks. Kept out of the exhaustive
+// suite because that suite draws every key from [0, N), which is exactly why this went
+// unseen.
 //
-// The width x key matrix is not decoration. Run against the unguarded header, no single
-// width exposes all six operations and no single key does either, so any one cell alone
-// would have let the bug through. Two cells are worth naming: erase past the last block
-// is an out-of-bounds *write*, and upper_bound fails on the returned value rather than on
-// memory at all -- find_next's ++n wrapped before it could test the bound, so it answered
-// with a real element where end() was due. That second one is what keeps this a gate on
-// the jobs that build without sanitizers.
-template<std::size_t N, class Block>
-auto check_keys_outside_the_domain() -> void
+// Two findings from running this against the unguarded header are worth recording, because
+// they are why it sweeps the whole of Types rather than one convenient width. No single
+// width exposed all six operations and no single key did either -- at N = 8 over uint8_t
+// every one of them was clean for key == N, so a narrow single-block set proves nothing on
+// its own. And erase was an out-of-bounds *write*, while upper_bound failed on its returned
+// value rather than on memory at all: find_next's ++n wrapped before it could test the
+// bound, so it answered with a real element where end() was due. That second one is what
+// keeps this a gate on the jobs that build without sanitizers.
+template<class X>
+auto check_key_outside_the_domain(X a, std::size_t x) -> void
 {
-        using X = xstd::bit_finite_set<N, Block>;
-        auto const full = std::views::iota(0uz, N) | std::ranges::to<X>();
+        auto const original = a;
 
-        // Just past the end, past the last block, and the value that would wrap any n + 1.
-        for (auto const x : { N, N + 1, (2 * N) + 1, std::size_t(-1) }) {
-                for (auto const& original : { X(), full }) {
-                        auto a = original;
+        BOOST_CHECK(not a.contains(x));
+        BOOST_CHECK_EQUAL(a.count(x), 0UZ);
+        BOOST_CHECK(a.find(x)        == a.end());
+        BOOST_CHECK(a.lower_bound(x) == a.end());
+        BOOST_CHECK(a.upper_bound(x) == a.end());
 
-                        BOOST_CHECK(not a.contains(x));
-                        BOOST_CHECK_EQUAL(a.count(x), 0uz);
-                        BOOST_CHECK(a.find(x)        == a.end());
-                        BOOST_CHECK(a.lower_bound(x) == a.end());
-                        BOOST_CHECK(a.upper_bound(x) == a.end());
+        auto const [ first, last ] = a.equal_range(x);
+        BOOST_CHECK(first == a.end());
+        BOOST_CHECK(last  == a.end());
 
-                        auto const [ first, last ] = a.equal_range(x);
-                        BOOST_CHECK(first == a.end());
-                        BOOST_CHECK(last  == a.end());
-
-                        // A no-op that must stay one: this is the write.
-                        BOOST_CHECK_EQUAL(a.erase(x), 0uz);
-                        BOOST_CHECK(a == original);
-                }
-        }
+        // A no-op that must stay one: this is the write.
+        BOOST_CHECK_EQUAL(a.erase(x), 0UZ);
+        BOOST_CHECK(a == original);
 }
 
-BOOST_AUTO_TEST_CASE(LookupIsTotalOverKeyType)
+BOOST_AUTO_TEST_CASE_TEMPLATE(LookupIsTotalOverKeyType, T, Types)
 {
-        // The wide and multi-block widths carry the test. Measured against the unguarded
-        // header, N = 8 over uint8_t is clean for all six at key == N, so a narrow
-        // single-block set on its own proves nothing either way.
-        check_keys_outside_the_domain<  0, std::uint8_t >();
-        check_keys_outside_the_domain<  8, std::uint8_t >();
-        check_keys_outside_the_domain< 24, std::uint8_t >();
-        check_keys_outside_the_domain<  1, std::uint64_t>();
-        check_keys_outside_the_domain< 64, std::uint64_t>();
-        check_keys_outside_the_domain<129, std::uint64_t>();
+        auto const N = T::max_size();
+        auto const full = std::views::iota(0UZ, N) | std::ranges::to<T>();
+
+        // Just past the end, past the last block, and the value that would wrap any n + 1.
+        for (auto const x : { N, N + 1, (2 * N) + 1, static_cast<std::size_t>(-1) }) {
+                check_key_outside_the_domain(T(), x);
+                check_key_outside_the_domain(full, x);
+        }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
All six lookups that accept a key — `contains`, `count`, `find`, `lower_bound`, `upper_bound` and `erase` — reached straight into the blocks with it. A key outside `[0, N)` is UB in every one, and **`erase` is an out-of-bounds *write***: it clears a bit past the array.

Closes #86.

## Why the guard belongs here

`block_sequence` asserts `is_valid` on every position it accepts and offers no total spelling of any of these. That is the layering working, not a gap in it — and #88 already settled the principle at the other end, where `find_prev_exclusive` keeps its precondition precisely because it is three instructions cheaper than totality. `std::set` is total over `key_type`, so the container claiming to be a set is what owes the guard. The precondition is the sequence's; the guard is the container's.

`xstd::bitset` was checked and is not affected: it already throws `out_of_range` from `test`, `set`, `reset` and `flip`.

## `lower_bound` loses its ternary

Not a cleanup for its own sake — the seam was `find_next`'s exclusivity showing through:

```cpp
// before
x ? find_next(self, x - 1) : find_first(self)   // x - 1 wraps at 0, so 0 needed its own arm

// after
x < N ? self.m_bits.find_next_inclusive(x    ) : N   // lower_bound
x < N ? self.m_bits.find_next_inclusive(x + 1) : N   // upper_bound
```

Against the inclusive primitive the two bounds differ by exactly the `+ 1` that separates them, and the `0` case needs no spelling of its own. This is the first caller-side payoff of #88's anti-diagonal.

## The test sweeps `Types`

`LookupIsTotalOverKeyType` runs over `test::graded_extents<xstd::bit_finite_set>` — the same list the file's other six cases use — at four keys (`N`, `N + 1`, `2N + 1`, `SIZE_MAX`) against both an empty and a full set. **21 configurations**: every Block model within one block, and `uint8_t` across block boundaries.

The breadth is not decoration. Measured against the unguarded header during development, **no single width exposed all six operations and no single key did either**:

| | key = N | key = SIZE_MAX |
| --- | --- | --- |
| N=8 / `uint8_t` (1 blk) | clean — **all six** | UBSan shift (5 of 6) |
| N=24 / `uint8_t` (3 blk) | ASan OOB (5 of 6) | ASan OOB (5 of 6) |
| N=64 / `uint64_t` (1 blk) | UBSan shift (5 of 6) | UBSan shift (5 of 6) |
| N=129 / `uint64_t` (3 blk) | clean — all six | ASan OOB (5 of 6) |

Two cells are worth naming:

- **`N = 8` over `uint8_t` is clean for all six at `key == N`.** A narrow single-block set proves nothing either way, which is exactly why the exhaustive suite — which draws every key from `[0, N)` — never saw this.
- **`upper_bound` fails on its return value, not on memory.** `find_next`'s `++n` wrapped before it could test the bound, so it answered with a real element where `end()` was due — a silent wrong answer at every width. That is what keeps this test a gate on the jobs that build **without** sanitizers.

The `N = 129` row shows the third mode: for a non-block-aligned width, keys in the unused tail read the padding and answer "absent" by accident, because the unused-tail invariant happens to hold there.

## Second commit: the .cpp lint rules

`clang_tidy` failed the first push with five findings in the new test: cognitive complexity 30 against a threshold of 25, three `uz` suffixes the repo spells `UZ`, and a functional cast.

The suffix rule was invisible from the test tree the idiom was copied from. `HeaderFilterRegex` is `include/xstd/.*`, so `0uz` in `test/include/test/bitset/primitives.hpp` is filtered out while the same literal in a `.cpp` is an error.

Rather than hand-split a function to satisfy the complexity check, the case was driven off `Types`. That removes the nesting level, removes the hand-picked widths `readability-magic-numbers` objected to, and widens the sweep from 6 configurations to 21 — so the lint fix made the test strictly stronger rather than merely quieter.

## Test plan

- [x] `LookupIsTotalOverKeyType` **fails against the unguarded header** — **89 checks**, plus UBSan errors, exit 1 — and passes with the guards. Control taken by reverting the header to `57a1d90` with the test held constant.
- [x] It fails on plain `BOOST_CHECK` value comparisons as well as under sanitizers, so it gates the non-sanitizer jobs too.
- [x] In-range lookups cross-checked against `std::set` over **every subset** at N = 8 and N = 12, and sampled at N = 24, 64, 129 and 200 across `uint8_t`, `uint32_t` and `uint64_t` — `contains`, `find`, `lower_bound` and `upper_bound` compared element-wise, with asserts live under ASan + UBSan. This is what covers `lower_bound`'s rewrite.
- [x] All 48 width × operation × key cells from the development matrix clean and correct after the fix.
- [x] Suite green in Debug (ASan + UBSan, asserts live) and at `-O3 -march=native`.
- [x] The four dependent test TUs green — `std_set/constexpr`, `std_set/implicit`, `std_set/o0`, `ranges/set_view` — the constexpr one confirming the guards fold in constant evaluation.
- [x] clang-tidy clean under the repo's own config, against the finding set it reported before the change.
- [x] Clean under the repo's clang `-Weverything` set and the gcc `-Wall -Wextra -Wpedantic -Wconversion -Wnrvo -Wshadow -Wsign-compare -Wsign-conversion -Wsign-promo -Werror` set, in Debug and Release.
- [x] **CI: all 85 checks green** on `90fb557`, including all three `clang_tidy` legs, `coverage/gcovr` (100% line and branch), both codecov gates, CodeQL, and every compiler and sanitizer leg.

## Scope

`insert`/`emplace` with an out-of-range key are **not** touched. #80 settles this — every set-reading operation is total *except* `insert`, which asserts for a static extent and resizes for a dynamic one. It is a precondition on a set whose domain is fixed at `N`, not a lookup that owes a total answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gfTqPbkbmFo2yfGSCDRpU