### PR TITLE
Add the bit_traits door and its first specialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ target_sources(
         include/xstd/bits/bit_array.hpp
         include/xstd/bits/bitset.hpp
         include/xstd/bits/bit_finite_set.hpp
+        include/xstd/bits/bit_traits.hpp
         include/xstd/bits/block_sequence.hpp
         include/xstd/bits/detail/intrin.hpp
         include/xstd/bits/detail/pred.hpp

--- a/include/xstd/bits/bit_traits.hpp
+++ b/include/xstd/bits/bit_traits.hpp
@@ -39,6 +39,27 @@ concept block_readable =
         }
 ;
 
+// How many blocks a trait's storage has, when the type settles it. Derived rather than declared:
+// extent is already in the floor, and block_access's contract fixes the layout -- block i holds
+// [i * digits, (i + 1) * digits) -- so nothing new has to be supplied to know this.
+//
+// It exists for the coverage gate rather than for speed. gcovr counts branch slots per template
+// instantiation and does not merge them, so a loop that a one-block instantiation can never enter
+// is a branch never taken, whatever every other instantiation does. block_sequence answers the
+// same gate the same way, with if constexpr on static_num_blocks == 1 and == 2: the degenerate
+// case does not get an unreachable loop, it gets different code.
+template<class Traits, class Block>
+[[nodiscard]] consteval auto static_block_count() noexcept
+        -> std::size_t
+{
+        if constexpr (Traits::extent == std::dynamic_extent) {
+                return std::dynamic_extent;
+        } else {
+                constexpr auto digits = static_cast<std::size_t>(std::numeric_limits<Block>::digits);
+                return Traits::extent == 0UZ ? 1UZ : ((Traits::extent + digits - 1UZ) / digits);
+        }
+}
+
 // The fallbacks a specialization calls for whatever it has no native spelling of, so adapting a
 // type is never all-or-nothing.
 //
@@ -101,6 +122,11 @@ struct bit_scan
                 -> std::size_t
         {
                 auto const size = Traits::size(c);
+                // A width fixed at zero holds nothing below anything, and saying so here rather
+                // than at run time leaves the scan below with no arm that cannot be reached.
+                if constexpr (Traits::extent == 0UZ) {
+                        return size;
+                } else {
                 auto i = n < size ? n : size;
                 if (i == 0UZ) {
                         return size;
@@ -121,10 +147,21 @@ struct bit_scan
                         if (auto const block = static_cast<block_type>(Traits::block(c, index) << (left_bit - offset)); block != block_type{}) {
                                 return i - detail::bits::countl_zero(block);
                         }
-                        while (index-- != 0UZ) {
-                                if (auto const block = Traits::block(c, index); block != block_type{}) {
-                                        return (digits * index) + left_bit - detail::bits::countl_zero(block);
+                        // Only where a lower block can exist: at one block the walk is
+                        // unreachable code carrying an untakeable branch.
+                        if constexpr (static_block_count<Traits, block_type>() != 1UZ) {
+                                while (index-- != 0UZ) {
+                                        if (auto const block = Traits::block(c, index); block != block_type{}) {
+                                                return (digits * index) + left_bit - detail::bits::countl_zero(block);
+                                        }
                                 }
+                        }
+                } else if constexpr (Traits::extent == 1UZ) {
+                        // A single position: the descent below would have nowhere to step from,
+                        // so it is written as the one test it reduces to rather than as a loop
+                        // whose exit arm no instantiation could take.
+                        if (Traits::at(c, i)) {
+                                return i;
                         }
                 } else {
                         for (;;) {
@@ -138,6 +175,7 @@ struct bit_scan
                         }
                 }
                 return size;
+                }
         }
 
         // How many positions are set. The block tier is the whole point: popcount per word
@@ -146,7 +184,9 @@ struct bit_scan
         [[nodiscard]] static constexpr auto count(Bits const& c) noexcept
                 -> std::size_t
         {
-                if constexpr (block_readable<Traits, Bits>) {
+                if constexpr (Traits::extent == 0UZ) {
+                        return 0UZ;
+                } else if constexpr (block_readable<Traits, Bits>) {
                         auto n = 0UZ;
                         for (auto i = 0UZ, blocks = Traits::num_blocks(c); i < blocks; ++i) {
                                 n += detail::bits::popcount(Traits::block(c, i));
@@ -169,6 +209,9 @@ struct bit_scan
                 -> std::size_t
         {
                 auto const size = Traits::size(c);
+                if constexpr (Traits::extent == 0UZ) {
+                        return size;
+                } else {
                 if (n >= size) {
                         return size;
                 }
@@ -185,9 +228,13 @@ struct bit_scan
                         if (auto const block = static_cast<block_type>(Traits::block(c, index) >> offset); block != block_type{}) {
                                 return n + detail::bits::countr_zero(block);
                         }
-                        for (++index; index < blocks; ++index) {
-                                if (auto const block = Traits::block(c, index); block != block_type{}) {
-                                        return (digits * index) + detail::bits::countr_zero(block);
+                        // The mirror of prev's guard: at one block there is no later block to
+                        // walk to, so the loop would be an arm no instantiation can take.
+                        if constexpr (static_block_count<Traits, block_type>() != 1UZ) {
+                                for (++index; index < blocks; ++index) {
+                                        if (auto const block = Traits::block(c, index); block != block_type{}) {
+                                                return (digits * index) + detail::bits::countr_zero(block);
+                                        }
                                 }
                         }
                 } else {
@@ -198,6 +245,7 @@ struct bit_scan
                         }
                 }
                 return size;
+                }
         }
 
         // The set ordering: the positions in increasing order, compared lexicographically, which

--- a/include/xstd/bits/bit_traits.hpp
+++ b/include/xstd/bits/bit_traits.hpp
@@ -1,0 +1,215 @@
+//          Copyright Rein Halbersma 2014-2026.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef XSTD_BITS_BIT_TRAITS_HPP
+#define XSTD_BITS_BIT_TRAITS_HPP
+
+#include <xstd/bits/detail/intrin.hpp>             // countl_zero, countr_zero, popcount
+#include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer
+#include <cassert>                                 // assert
+#include <compare>                                 // strong_ordering
+#include <concepts>                                // convertible_to, same_as
+#include <cstddef>                                 // size_t
+#include <limits>                                  // digits
+#include <span>                                    // dynamic_extent
+#include <type_traits>                             // remove_cvref_t
+
+// The one door between a bit container and the readings built on it. Everything above this
+// header asks bit_traits<Bits> and never the type itself, which is what lets a std::bitset, a
+// boost::dynamic_bitset and our own block_sequence wear the same three readings without any of
+// them knowing the others exist.
+namespace xstd {
+
+// Declared, never defined: adaptation is opt-in, never guessed. A type nobody has adapted is a
+// compile error naming an incomplete type rather than a silent fallback onto whatever members
+// happened to answer -- which is the failure that per-operation member probing walks into, and
+// this file's reason for existing. See bit_storage below for the error that reads better.
+template<class Bits>
+struct bit_traits;
+
+// Whether a trait offers block access at all. std::bitset on libc++ and boost::dynamic_bitset
+// do not, so their scans take the element-wise tier; ours and libstdc++'s std::bitset do.
+template<class Traits, class Bits>
+concept block_readable =
+        requires (Bits const& c, std::size_t i)
+        {
+                { Traits::num_blocks(c) } -> std::convertible_to<std::size_t>;
+                { Traits::block(c, i)   } -> xstd::unsigned_integer;
+        }
+;
+
+// The fallbacks a specialization calls for whatever it has no native spelling of, so adapting a
+// type is never all-or-nothing.
+//
+// Static members of a class template rather than free functions, and that is load-bearing.
+// Since C++20 an unqualified scan_first<Traits>(c) parses its '<' as a template argument list
+// and then goes through ADL, explicit arguments included -- so std and boost, the associated
+// namespaces of the very types being adapted, would join the overload set. [namespace.std] bars
+// users from adding to std but not implementations, and boost is under no such constraint.
+// Qualifying every call would close it, but the safety would live in remembering a prefix at
+// every site. Member lookup through a qualified-id never consults associated namespaces, so
+// there is no unqualified call here to hijack in the first place.
+//
+// It is also the shape block_access, set_find and sequence_find already had, so the fold keeps
+// one idiom rather than introducing free functions as a second.
+template<class Traits>
+struct bit_scan
+{
+        // The first set position, or size() if there is none. Total, like every scan here: this
+        // is the layer that answers, not the layer with preconditions.
+        template<class Bits>
+        [[nodiscard]] static constexpr auto first(Bits const& c) noexcept
+                -> std::size_t
+        {
+                return next_inclusive(c, 0UZ);
+        }
+
+        // One past the last position, which for every reading is the width: the end iterator's
+        // position, not a scan at all. Named alongside the scans because callers ask for it in
+        // the same breath.
+        template<class Bits>
+        [[nodiscard]] static constexpr auto last(Bits const& c) noexcept
+                -> std::size_t
+        {
+                return Traits::size(c);
+        }
+
+        // The first set position strictly above n, mirroring block_sequence::find_next_exclusive
+        // and boost's find_next. Total in n: a position at or past the width has nothing above it.
+        template<class Bits>
+        [[nodiscard]] static constexpr auto next(Bits const& c, std::size_t n) noexcept
+                -> std::size_t
+        {
+                auto const size = Traits::size(c);
+                return n >= size ? size : next_inclusive(c, n + 1UZ);
+        }
+
+        // The last set position strictly below n. Unlike block_sequence::find_prev_exclusive
+        // this is total rather than precondition-guarded: that one can demand any() because
+        // reverse iteration supplies the guard, and a fallback synthesised for a foreign type
+        // has no such caller to lean on.
+        template<class Bits>
+        [[nodiscard]] static constexpr auto prev(Bits const& c, std::size_t n) noexcept
+                -> std::size_t
+        {
+                auto const size = Traits::size(c);
+                if (auto i = n < size ? n : size; i != 0UZ) {
+                        do {
+                                --i;
+                                if (Traits::at(c, i)) {
+                                        return i;
+                                }
+                        } while (i != 0UZ);
+                }
+                return size;
+        }
+
+        // How many positions are set. The block tier is the whole point: popcount per word
+        // rather than a test per bit.
+        template<class Bits>
+        [[nodiscard]] static constexpr auto count(Bits const& c) noexcept
+                -> std::size_t
+        {
+                if constexpr (block_readable<Traits, Bits>) {
+                        auto n = 0UZ;
+                        for (auto i = 0UZ, blocks = Traits::num_blocks(c); i < blocks; ++i) {
+                                n += detail::bits::popcount(Traits::block(c, i));
+                        }
+                        return n;
+                } else {
+                        auto n = 0UZ;
+                        for (auto i = 0UZ, size = Traits::size(c); i < size; ++i) {
+                                n += Traits::at(c, i) ? 1UZ : 0UZ;
+                        }
+                        return n;
+                }
+        }
+
+        // The first set position at or above n: the primitive the two forward scans derive from,
+        // exactly as block_sequence's find_next_inclusive is. Both derivations are + 1 and never
+        // - 1, which is what lets first() name its own extreme without size_t wrapping at zero.
+        template<class Bits>
+        [[nodiscard]] static constexpr auto next_inclusive(Bits const& c, std::size_t n) noexcept
+                -> std::size_t
+        {
+                auto const size = Traits::size(c);
+                if (n >= size) {
+                        return size;
+                }
+                if constexpr (block_readable<Traits, Bits>) {
+                        using block_type = std::remove_cvref_t<decltype(Traits::block(c, 0UZ))>;
+                        constexpr auto digits = static_cast<std::size_t>(std::numeric_limits<block_type>::digits);
+
+                        auto const blocks = Traits::num_blocks(c);
+                        auto index = n / digits;
+                        auto const offset = n % digits;
+
+                        // No offset != 0 guard: >> 0 is the identity, so the boundary case needs
+                        // no arm of its own. #88 measured the guard as pure cost.
+                        if (auto const block = static_cast<block_type>(Traits::block(c, index) >> offset); block != block_type{}) {
+                                return n + detail::bits::countr_zero(block);
+                        }
+                        for (++index; index < blocks; ++index) {
+                                if (auto const block = Traits::block(c, index); block != block_type{}) {
+                                        return (digits * index) + detail::bits::countr_zero(block);
+                                }
+                        }
+                } else {
+                        for (auto i = n; i < size; ++i) {
+                                if (Traits::at(c, i)) {
+                                        return i;
+                                }
+                        }
+                }
+                return size;
+        }
+
+        // The set ordering: the positions in increasing order, compared lexicographically, which
+        // is what std::set's <=> means. Deliberately not the magnitude ordering boost::dynamic_bitset
+        // gives its own operator<, and that divergence is documented rather than reconciled.
+        template<class Bits>
+        [[nodiscard]] static constexpr auto lexicographical_three_way(Bits const& x, Bits const& y) noexcept
+                -> std::strong_ordering
+        {
+                auto i = first(x);
+                auto j = first(y);
+                for (auto const nx = Traits::size(x), ny = Traits::size(y); i != nx and j != ny; i = next(x, i), j = next(y, j)) {
+                        if (auto const cmp = i <=> j; cmp != 0) {
+                                return cmp;
+                        }
+                }
+                // One ran out: the shorter sequence of positions is the smaller set, and both
+                // running out together makes them equal.
+                return (i != Traits::size(x)) <=> (j != Traits::size(y));
+        }
+};
+
+// The floor for wrappability: a width, and an indexed read. Everything else -- blocks, native
+// scans, a native ordering -- is an optimization tier a specialization may or may not supply.
+//
+// Gating the adaptors on this rather than on bit_traits<Bits> being complete is what turns
+// "incomplete type" into "constraint not satisfied", which names the actual problem.
+template<class Bits>
+concept bit_storage =
+        requires (Bits const& c, std::size_t n)
+        {
+                // extent is part of the floor rather than an extra: every adapter states its
+                // width policy, dynamic_extent included, which is what lets static_bit_extent
+                // below read it without first proving it exists.
+                { bit_traits<Bits>::extent   } -> std::convertible_to<std::size_t>;
+                { bit_traits<Bits>::size(c)  } -> std::convertible_to<std::size_t>;
+                { bit_traits<Bits>::at(c, n) } -> std::convertible_to<bool>;
+        }
+;
+
+// How many positions a bit sequence has when the type settles it, so a static width reaches the
+// readings as a constant expression. Replaces the bit_extent variable template: one door, and
+// the extent comes through it like everything else.
+template<class Bits>
+concept static_bit_extent = bit_storage<Bits> and bit_traits<Bits>::extent != std::dynamic_extent;
+
+} // namespace xstd
+
+#endif // XSTD_BITS_BIT_TRAITS_HPP

--- a/include/xstd/bits/bit_traits.hpp
+++ b/include/xstd/bits/bit_traits.hpp
@@ -77,6 +77,109 @@ template<class Traits, class Block>
 template<class Traits>
 struct bit_scan
 {
+private:
+        // Each tier of each scan gets its own function. Not decomposition for its own sake:
+        // readability-function-cognitive-complexity counts if constexpr like any other branch,
+        // and the guards that satisfy the coverage gate put both scans over the threshold when
+        // the tier choice sits in the same body. The tier is where the seam was anyway.
+
+        // The last set position at or below i, block at a time.
+        template<class Bits>
+        [[nodiscard]] static constexpr auto prev_by_block(Bits const& c, std::size_t i) noexcept
+                -> std::size_t
+        {
+                using block_type = std::remove_cvref_t<decltype(Traits::block(c, 0UZ))>;
+                constexpr auto digits = static_cast<std::size_t>(std::numeric_limits<block_type>::digits);
+                constexpr auto left_bit = digits - 1UZ;
+
+                auto index = i / digits;
+                auto const offset = i % digits;
+
+                // Shifted up rather than masked, so the bit at offset lands on the top one and
+                // countl_zero measures the distance back down. At offset == left_bit that is a
+                // shift by zero, the identity, so the boundary needs no arm of its own -- the
+                // mirror of next_by_block's missing offset guard.
+                if (auto const block = static_cast<block_type>(Traits::block(c, index) << (left_bit - offset)); block != block_type{}) {
+                        return i - detail::bits::countl_zero(block);
+                }
+                // Only where a lower block can exist: at one block this walk is unreachable code
+                // carrying a branch no instantiation could take.
+                if constexpr (static_block_count<Traits, block_type>() != 1UZ) {
+                        while (index-- != 0UZ) {
+                                if (auto const block = Traits::block(c, index); block != block_type{}) {
+                                        return (digits * index) + left_bit - detail::bits::countl_zero(block);
+                                }
+                        }
+                }
+                return Traits::size(c);
+        }
+
+        // The same, one position at a time, for a type that keeps its blocks to itself.
+        template<class Bits>
+        [[nodiscard]] static constexpr auto prev_by_element(Bits const& c, std::size_t i) noexcept
+                -> std::size_t
+        {
+                if constexpr (Traits::extent == 1UZ) {
+                        // A single position: the descent below would have nowhere to step from,
+                        // so it is written as the one test it reduces to rather than as a loop
+                        // whose exit arm no instantiation could take.
+                        return Traits::at(c, i) ? i : Traits::size(c);
+                } else {
+                        for (;;) {
+                                if (Traits::at(c, i)) {
+                                        return i;
+                                }
+                                if (i == 0UZ) {
+                                        return Traits::size(c);
+                                }
+                                --i;
+                        }
+                }
+        }
+
+        // The first set position at or above n, block at a time.
+        template<class Bits>
+        [[nodiscard]] static constexpr auto next_by_block(Bits const& c, std::size_t n) noexcept
+                -> std::size_t
+        {
+                using block_type = std::remove_cvref_t<decltype(Traits::block(c, 0UZ))>;
+                constexpr auto digits = static_cast<std::size_t>(std::numeric_limits<block_type>::digits);
+
+                auto index = n / digits;
+                auto const offset = n % digits;
+
+                // No offset != 0 guard: >> 0 is the identity, so the boundary case needs no arm
+                // of its own. #88 measured the guard as pure cost.
+                if (auto const block = static_cast<block_type>(Traits::block(c, index) >> offset); block != block_type{}) {
+                        return n + detail::bits::countr_zero(block);
+                }
+                // The mirror of prev_by_block's guard: at one block there is no later block to
+                // walk to.
+                if constexpr (static_block_count<Traits, block_type>() != 1UZ) {
+                        for (auto const blocks = Traits::num_blocks(c); ++index < blocks;) {
+                                if (auto const block = Traits::block(c, index); block != block_type{}) {
+                                        return (digits * index) + detail::bits::countr_zero(block);
+                                }
+                        }
+                }
+                return Traits::size(c);
+        }
+
+        // The same, one position at a time.
+        template<class Bits>
+        [[nodiscard]] static constexpr auto next_by_element(Bits const& c, std::size_t n) noexcept
+                -> std::size_t
+        {
+                auto const size = Traits::size(c);
+                for (auto i = n; i < size; ++i) {
+                        if (Traits::at(c, i)) {
+                                return i;
+                        }
+                }
+                return size;
+        }
+
+public:
         // The first set position, or size() if there is none. Total, like every scan here: this
         // is the layer that answers, not the layer with preconditions.
         template<class Bits>
@@ -109,72 +212,32 @@ struct bit_scan
         // The last set position strictly below n, or size() if there is none.
         //
         // Unlike block_sequence::find_prev_exclusive this is total rather than
-        // precondition-guarded: that one may demand any() because reverse iteration supplies
-        // the guard, and a fallback synthesised for a foreign type has no such caller to lean
-        // on.
+        // precondition-guarded: that one may demand any() because reverse iteration supplies the
+        // guard, and a fallback synthesised for a foreign type has no such caller to lean on.
         //
         // The block tier is not an optimization here so much as a complexity fix. Element-wise,
-        // one step is O(N) and a full reverse traversal is O(N^2) -- which is exactly what
-        // #80 measures boost::dynamic_bitset's missing find_prev to cost. A type that hands
-        // over its blocks does not pay it.
+        // one step is O(N) and a full reverse traversal is O(N^2) -- which is exactly what #80
+        // measures boost::dynamic_bitset's missing find_prev to cost. A type that hands over its
+        // blocks does not pay it.
         template<class Bits>
         [[nodiscard]] static constexpr auto prev(Bits const& c, std::size_t n) noexcept
                 -> std::size_t
         {
                 auto const size = Traits::size(c);
                 // A width fixed at zero holds nothing below anything, and saying so here rather
-                // than at run time leaves the scan below with no arm that cannot be reached.
+                // than at run time leaves the scans with no arm that cannot be reached.
                 if constexpr (Traits::extent == 0UZ) {
                         return size;
                 } else {
-                auto i = n < size ? n : size;
-                if (i == 0UZ) {
-                        return size;
-                }
-                --i;
-                if constexpr (block_readable<Traits, Bits>) {
-                        using block_type = std::remove_cvref_t<decltype(Traits::block(c, 0UZ))>;
-                        constexpr auto digits = static_cast<std::size_t>(std::numeric_limits<block_type>::digits);
-                        constexpr auto left_bit = digits - 1UZ;
-
-                        auto index = i / digits;
-                        auto const offset = i % digits;
-
-                        // Shifted up rather than masked, so the bit at offset lands on the top
-                        // one and countl_zero measures the distance back down. At offset ==
-                        // left_bit that is a shift by zero, the identity, so the boundary needs
-                        // no arm of its own -- the mirror of next_inclusive's missing guard.
-                        if (auto const block = static_cast<block_type>(Traits::block(c, index) << (left_bit - offset)); block != block_type{}) {
-                                return i - detail::bits::countl_zero(block);
+                        auto const i = n < size ? n : size;
+                        if (i == 0UZ) {
+                                return size;
                         }
-                        // Only where a lower block can exist: at one block the walk is
-                        // unreachable code carrying an untakeable branch.
-                        if constexpr (static_block_count<Traits, block_type>() != 1UZ) {
-                                while (index-- != 0UZ) {
-                                        if (auto const block = Traits::block(c, index); block != block_type{}) {
-                                                return (digits * index) + left_bit - detail::bits::countl_zero(block);
-                                        }
-                                }
+                        if constexpr (block_readable<Traits, Bits>) {
+                                return prev_by_block(c, i - 1UZ);
+                        } else {
+                                return prev_by_element(c, i - 1UZ);
                         }
-                } else if constexpr (Traits::extent == 1UZ) {
-                        // A single position: the descent below would have nowhere to step from,
-                        // so it is written as the one test it reduces to rather than as a loop
-                        // whose exit arm no instantiation could take.
-                        if (Traits::at(c, i)) {
-                                return i;
-                        }
-                } else {
-                        for (;;) {
-                                if (Traits::at(c, i)) {
-                                        return i;
-                                }
-                                if (i == 0UZ) {
-                                        break;
-                                }
-                                --i;
-                        }
-                }
-                return size;
                 }
         }
 
@@ -212,59 +275,37 @@ struct bit_scan
                 if constexpr (Traits::extent == 0UZ) {
                         return size;
                 } else {
-                if (n >= size) {
-                        return size;
-                }
-                if constexpr (block_readable<Traits, Bits>) {
-                        using block_type = std::remove_cvref_t<decltype(Traits::block(c, 0UZ))>;
-                        constexpr auto digits = static_cast<std::size_t>(std::numeric_limits<block_type>::digits);
-
-                        auto const blocks = Traits::num_blocks(c);
-                        auto index = n / digits;
-                        auto const offset = n % digits;
-
-                        // No offset != 0 guard: >> 0 is the identity, so the boundary case needs
-                        // no arm of its own. #88 measured the guard as pure cost.
-                        if (auto const block = static_cast<block_type>(Traits::block(c, index) >> offset); block != block_type{}) {
-                                return n + detail::bits::countr_zero(block);
+                        if (n >= size) {
+                                return size;
                         }
-                        // The mirror of prev's guard: at one block there is no later block to
-                        // walk to, so the loop would be an arm no instantiation can take.
-                        if constexpr (static_block_count<Traits, block_type>() != 1UZ) {
-                                for (++index; index < blocks; ++index) {
-                                        if (auto const block = Traits::block(c, index); block != block_type{}) {
-                                                return (digits * index) + detail::bits::countr_zero(block);
-                                        }
-                                }
+                        if constexpr (block_readable<Traits, Bits>) {
+                                return next_by_block(c, n);
+                        } else {
+                                return next_by_element(c, n);
                         }
-                } else {
-                        for (auto i = n; i < size; ++i) {
-                                if (Traits::at(c, i)) {
-                                        return i;
-                                }
-                        }
-                }
-                return size;
                 }
         }
 
         // The set ordering: the positions in increasing order, compared lexicographically, which
-        // is what std::set's <=> means. Deliberately not the magnitude ordering boost::dynamic_bitset
-        // gives its own operator<, and that divergence is documented rather than reconciled.
+        // is what std::set's <=> means. Deliberately not the magnitude ordering
+        // boost::dynamic_bitset gives its own operator<, and that divergence is documented rather
+        // than reconciled.
         template<class Bits>
         [[nodiscard]] static constexpr auto lexicographical_three_way(Bits const& x, Bits const& y) noexcept
                 -> std::strong_ordering
         {
+                auto const nx = Traits::size(x);
+                auto const ny = Traits::size(y);
                 auto i = first(x);
                 auto j = first(y);
-                for (auto const nx = Traits::size(x), ny = Traits::size(y); i != nx and j != ny; i = next(x, i), j = next(y, j)) {
+                for (; i != nx and j != ny; i = next(x, i), j = next(y, j)) {
                         if (auto const cmp = i <=> j; cmp != 0) {
                                 return cmp;
                         }
                 }
                 // One ran out: the shorter sequence of positions is the smaller set, and both
                 // running out together makes them equal.
-                return (i != Traits::size(x)) <=> (j != Traits::size(y));
+                return (i != nx) <=> (j != ny);
         }
 };
 

--- a/include/xstd/bits/bit_traits.hpp
+++ b/include/xstd/bits/bit_traits.hpp
@@ -92,19 +92,23 @@ private:
                 constexpr auto digits = static_cast<std::size_t>(std::numeric_limits<block_type>::digits);
                 constexpr auto left_bit = digits - 1UZ;
 
-                auto index = i / digits;
+                auto const start = i / digits;
                 auto const offset = i % digits;
 
                 // Shifted up rather than masked, so the bit at offset lands on the top one and
                 // countl_zero measures the distance back down. At offset == left_bit that is a
                 // shift by zero, the identity, so the boundary needs no arm of its own -- the
                 // mirror of next_by_block's missing offset guard.
-                if (auto const block = static_cast<block_type>(Traits::block(c, index) << (left_bit - offset)); block != block_type{}) {
+                if (auto const block = static_cast<block_type>(Traits::block(c, start) << (left_bit - offset)); block != block_type{}) {
                         return i - detail::bits::countl_zero(block);
                 }
                 // Only where a lower block can exist: at one block this walk is unreachable code
-                // carrying a branch no instantiation could take.
+                // carrying a branch no instantiation could take. The cursor lives in here rather
+                // than beside start, because at one block the walk is discarded and a cursor
+                // declared outside would never be written -- which misc-const-correctness reads,
+                // correctly, as a variable that should have been const.
                 if constexpr (static_block_count<Traits, block_type>() != 1UZ) {
+                        auto index = start;
                         while (index-- != 0UZ) {
                                 if (auto const block = Traits::block(c, index); block != block_type{}) {
                                         return (digits * index) + left_bit - detail::bits::countl_zero(block);
@@ -145,18 +149,18 @@ private:
                 using block_type = std::remove_cvref_t<decltype(Traits::block(c, 0UZ))>;
                 constexpr auto digits = static_cast<std::size_t>(std::numeric_limits<block_type>::digits);
 
-                auto index = n / digits;
+                auto const start = n / digits;
                 auto const offset = n % digits;
 
                 // No offset != 0 guard: >> 0 is the identity, so the boundary case needs no arm
                 // of its own. #88 measured the guard as pure cost.
-                if (auto const block = static_cast<block_type>(Traits::block(c, index) >> offset); block != block_type{}) {
+                if (auto const block = static_cast<block_type>(Traits::block(c, start) >> offset); block != block_type{}) {
                         return n + detail::bits::countr_zero(block);
                 }
                 // The mirror of prev_by_block's guard: at one block there is no later block to
-                // walk to.
+                // walk to, and the cursor belongs to the walk for the same reason it does there.
                 if constexpr (static_block_count<Traits, block_type>() != 1UZ) {
-                        for (auto const blocks = Traits::num_blocks(c); ++index < blocks;) {
+                        for (auto index = start + 1UZ, blocks = Traits::num_blocks(c); index < blocks; ++index) {
                                 if (auto const block = Traits::block(c, index); block != block_type{}) {
                                         return (digits * index) + detail::bits::countr_zero(block);
                                 }

--- a/include/xstd/bits/bit_traits.hpp
+++ b/include/xstd/bits/bit_traits.hpp
@@ -8,9 +8,8 @@
 
 #include <xstd/bits/detail/intrin.hpp>             // countl_zero, countr_zero, popcount
 #include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer
-#include <cassert>                                 // assert
 #include <compare>                                 // strong_ordering
-#include <concepts>                                // convertible_to, same_as
+#include <concepts>                                // convertible_to
 #include <cstddef>                                 // size_t
 #include <limits>                                  // digits
 #include <span>                                    // dynamic_extent
@@ -86,22 +85,57 @@ struct bit_scan
                 return n >= size ? size : next_inclusive(c, n + 1UZ);
         }
 
-        // The last set position strictly below n. Unlike block_sequence::find_prev_exclusive
-        // this is total rather than precondition-guarded: that one can demand any() because
-        // reverse iteration supplies the guard, and a fallback synthesised for a foreign type
-        // has no such caller to lean on.
+        // The last set position strictly below n, or size() if there is none.
+        //
+        // Unlike block_sequence::find_prev_exclusive this is total rather than
+        // precondition-guarded: that one may demand any() because reverse iteration supplies
+        // the guard, and a fallback synthesised for a foreign type has no such caller to lean
+        // on.
+        //
+        // The block tier is not an optimization here so much as a complexity fix. Element-wise,
+        // one step is O(N) and a full reverse traversal is O(N^2) -- which is exactly what
+        // #80 measures boost::dynamic_bitset's missing find_prev to cost. A type that hands
+        // over its blocks does not pay it.
         template<class Bits>
         [[nodiscard]] static constexpr auto prev(Bits const& c, std::size_t n) noexcept
                 -> std::size_t
         {
                 auto const size = Traits::size(c);
-                if (auto i = n < size ? n : size; i != 0UZ) {
-                        do {
-                                --i;
+                auto i = n < size ? n : size;
+                if (i == 0UZ) {
+                        return size;
+                }
+                --i;
+                if constexpr (block_readable<Traits, Bits>) {
+                        using block_type = std::remove_cvref_t<decltype(Traits::block(c, 0UZ))>;
+                        constexpr auto digits = static_cast<std::size_t>(std::numeric_limits<block_type>::digits);
+                        constexpr auto left_bit = digits - 1UZ;
+
+                        auto index = i / digits;
+                        auto const offset = i % digits;
+
+                        // Shifted up rather than masked, so the bit at offset lands on the top
+                        // one and countl_zero measures the distance back down. At offset ==
+                        // left_bit that is a shift by zero, the identity, so the boundary needs
+                        // no arm of its own -- the mirror of next_inclusive's missing guard.
+                        if (auto const block = static_cast<block_type>(Traits::block(c, index) << (left_bit - offset)); block != block_type{}) {
+                                return i - detail::bits::countl_zero(block);
+                        }
+                        while (index-- != 0UZ) {
+                                if (auto const block = Traits::block(c, index); block != block_type{}) {
+                                        return (digits * index) + left_bit - detail::bits::countl_zero(block);
+                                }
+                        }
+                } else {
+                        for (;;) {
                                 if (Traits::at(c, i)) {
                                         return i;
                                 }
-                        } while (i != 0UZ);
+                                if (i == 0UZ) {
+                                        break;
+                                }
+                                --i;
+                        }
                 }
                 return size;
         }

--- a/include/xstd/bits/block_sequence.hpp
+++ b/include/xstd/bits/block_sequence.hpp
@@ -7,6 +7,7 @@
 #define XSTD_BITS_BLOCK_SEQUENCE_HPP
 
 #include <boost/hash2/hash_append_fwd.hpp>                     // hash_append, hash_append_tag
+#include <xstd/bits/bit_traits.hpp>                            // bit_scan, bit_traits
 #include <xstd/bits/detail/intrin.hpp>                         // countl_zero, countr_zero, popcount
 #include <xstd/bits/detail/pred.hpp>                           // intersects, is_subset_of, not_equal_to
 #include <xstd/ints/concepts/unsigned_integer.hpp>             // unsigned_integer
@@ -17,6 +18,7 @@
 #include <algorithm>                                           // all_of, any_of, equal, fill, fill_n, fold_left, max, shift_left, shift_right
 #include <array>                                               // array
 #include <cassert>                                             // assert
+#include <compare>                                             // strong_ordering
 #include <concepts>                                            // swap
 #include <cstddef>                                             // ptrdiff_t, size_t
 #include <functional>                                          // plus
@@ -860,6 +862,68 @@ using block_array = block_sequence<std::array<Block, num_blocks_v<Block, N>>, N>
 
 template<xstd::unsigned_integer Block = std::size_t, class Allocator = std::allocator<Block>>
 using block_vector = block_sequence<std::vector<Block, Allocator>>;
+
+// The one specialization that forwards and nothing more. block_sequence has every primitive
+// natively, which is the ceiling principle written as a trait: there is no tier to fall back to,
+// so bit_scan is called nowhere below except for the ordering, which is a reading rather than a
+// primitive and has no native spelling here to prefer.
+//
+// It needs no friendship. The 14 forwarding hidden friends this fold retires belong to the three
+// containers that hold a block_sequence privately; block_sequence's own vocabulary is public, so
+// the door reaches it directly.
+template<class Blocks, std::size_t N>
+struct bit_traits<block_sequence<Blocks, N>>
+{
+        using bits_type = block_sequence<Blocks, N>;
+
+        static constexpr std::size_t extent = N;
+
+        [[nodiscard]] static constexpr auto size(bits_type const& c) noexcept -> std::size_t { return c.size(); }
+        [[nodiscard]] static constexpr auto at(bits_type const& c, std::size_t n) noexcept -> bool { return c[n]; }
+
+        // set(n) and reset(n) rather than a set(n, value) block_sequence does not have. Both
+        // assert is_valid(n), so the position is a precondition here as it is everywhere below.
+        static constexpr void assign(bits_type& c, std::size_t n, bool value) noexcept
+        {
+                if (value) {
+                        c.set(n);
+                } else {
+                        c.reset(n);
+                }
+        }
+
+        [[nodiscard]] static constexpr auto count(bits_type const& c) noexcept -> std::size_t { return c.count(); }
+
+        [[nodiscard]] static constexpr auto num_blocks(bits_type const& c) noexcept -> std::size_t { return c.num_blocks(); }
+        [[nodiscard]] static constexpr auto block(bits_type const& c, std::size_t i) noexcept { return c.block(i); }
+
+        [[nodiscard]] static constexpr auto find_first(bits_type const& c) noexcept -> std::size_t { return c.find_first(); }
+        [[nodiscard]] static constexpr auto find_last (bits_type const& c) noexcept -> std::size_t { return c.find_last();  }
+
+        // The two scans keep the contracts block_sequence gives them rather than widening to the
+        // total ones bit_scan's fallbacks happen to provide. That is the ceiling principle again:
+        // the door's contract is the most efficient form, and #88 measured find_prev_exclusive's
+        // non-totality as three instructions at every width. A fallback synthesised for a foreign
+        // type may be more generous than the contract; it may not be less.
+        //
+        // So find_next requires is_valid(n), and find_prev requires a set position strictly below
+        // n -- which any() does not establish, a container whose set positions all lie above n
+        // having none below it. Reverse iteration supplies exactly that guard, rend() being
+        // make_reverse_iterator(begin()), which is why block_sequence can omit it and why the
+        // guard belongs to the container above rather than here. #86 settled the same division
+        // one layer down: totality is the container's contract, not the sequence's.
+        [[nodiscard]] static constexpr auto find_next(bits_type const& c, std::size_t n) noexcept -> std::size_t { return c.find_next_exclusive(n); }
+        [[nodiscard]] static constexpr auto find_prev(bits_type const& c, std::size_t n) noexcept -> std::size_t { return c.find_prev_exclusive(n); }
+
+        // The set ordering has no native spelling here to prefer: block_sequence compares as
+        // storage, and ascending-positions-lexicographically is a reading of it. The fallback is
+        // the definition, so it is what this calls.
+        [[nodiscard]] static constexpr auto lexicographical_three_way(bits_type const& x, bits_type const& y) noexcept
+                -> std::strong_ordering
+        {
+                return bit_scan<bit_traits>::lexicographical_three_way(x, y);
+        }
+};
 
 }       // namespace xstd
 

--- a/test/src/bits/bit_traits.cpp
+++ b/test/src/bits/bit_traits.cpp
@@ -1,0 +1,186 @@
+//          Copyright Rein Halbersma 2014-2026.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/test/unit_test.hpp>      // BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL
+#include <test/block_types.hpp>          // graded_extents
+#include <xstd/bits/bit_traits.hpp>      // bit_scan, bit_storage, bit_traits, block_readable, static_bit_extent
+#include <xstd/bits/block_sequence.hpp>  // block_array
+#include <compare>                       // strong_ordering
+#include <cstddef>                       // size_t
+#include <set>                           // set
+
+// Two adapters over identical storage, differing only in whether they hand their blocks over.
+// That is the whole design of this file: bit_scan picks its tier on block_readable, so the only
+// way to test the choice is to hold the bits fixed and vary nothing else. Every check below then
+// runs twice, and the two answers must agree with each other as well as with std::set.
+namespace {
+
+// The floor and nothing more: a width and an indexed read.
+template<std::size_t N, class Block>
+struct element_bits
+{
+        xstd::block_array<Block, N> bits{};
+};
+
+// The same bits, with block access as well.
+template<std::size_t N, class Block>
+struct block_bits
+{
+        xstd::block_array<Block, N> bits{};
+};
+
+}       // namespace
+
+namespace xstd {
+
+template<std::size_t N, class Block>
+struct bit_traits<element_bits<N, Block>>
+{
+        static constexpr std::size_t extent = N;
+
+        [[nodiscard]] static constexpr auto size(element_bits<N, Block> const&) noexcept -> std::size_t { return N; }
+        [[nodiscard]] static constexpr auto at(element_bits<N, Block> const& c, std::size_t n) noexcept -> bool { return c.bits[n]; }
+};
+
+template<std::size_t N, class Block>
+struct bit_traits<block_bits<N, Block>>
+{
+        static constexpr std::size_t extent = N;
+
+        [[nodiscard]] static constexpr auto size(block_bits<N, Block> const&) noexcept -> std::size_t { return N; }
+        [[nodiscard]] static constexpr auto at(block_bits<N, Block> const& c, std::size_t n) noexcept -> bool { return c.bits[n]; }
+
+        [[nodiscard]] static constexpr auto num_blocks(block_bits<N, Block> const& c) noexcept -> std::size_t { return c.bits.num_blocks(); }
+        [[nodiscard]] static constexpr auto block(block_bits<N, Block> const& c, std::size_t i) noexcept -> Block { return c.bits.block(i); }
+};
+
+}       // namespace xstd
+
+namespace {
+
+template<class T>
+using scan = xstd::bit_scan<xstd::bit_traits<T>>;
+
+template<class T>
+inline constexpr auto extent_of = xstd::bit_traits<T>::extent;
+
+// The model and the container, built from one description so they cannot drift.
+template<class T>
+[[nodiscard]] auto make(std::set<std::size_t> const& model) -> T
+{
+        auto c = T();
+        for (auto const p : model) {
+                c.bits.set(p);
+        }
+        return c;
+}
+
+// Every scan, at every argument its domain admits, against std::set answering the same question.
+template<class T>
+auto check_scans(std::set<std::size_t> const& model) -> void
+{
+        auto const c = make<T>(model);
+        constexpr auto N = extent_of<T>;
+
+        BOOST_CHECK_EQUAL(scan<T>::count(c), model.size());
+        BOOST_CHECK_EQUAL(scan<T>::last(c), N);
+        BOOST_CHECK_EQUAL(scan<T>::first(c), model.empty() ? N : *model.begin());
+
+        // One past the width too: every scan here is total, so the argument past the end is a
+        // question with an answer rather than a precondition violation.
+        for (auto n = 0UZ; n <= N + 1UZ; ++n) {
+                auto const above = model.upper_bound(n);
+                BOOST_CHECK_EQUAL(scan<T>::next(c, n), above == model.end() ? N : *above);
+
+                auto const at_or_above = model.lower_bound(n);
+                BOOST_CHECK_EQUAL(scan<T>::next_inclusive(c, n), at_or_above == model.end() ? N : *at_or_above);
+
+                auto const below = model.lower_bound(n < N ? n : N);
+                BOOST_CHECK_EQUAL(scan<T>::prev(c, n), below == model.begin() ? N : *std::prev(below));
+        }
+}
+
+// Patterns rather than every subset, since the graded extents run to 128 positions: the empty
+// and full sets, every singleton, and every adjacent pair, which is what puts a set bit on both
+// sides of every block boundary the width has.
+template<class T>
+auto check_every_pattern() -> void
+{
+        constexpr auto N = extent_of<T>;
+
+        check_scans<T>({});
+
+        auto full = std::set<std::size_t>();
+        for (auto i = 0UZ; i < N; ++i) {
+                full.insert(i);
+        }
+        check_scans<T>(full);
+
+        for (auto i = 0UZ; i < N; ++i) {
+                check_scans<T>({ i });
+                if (i + 1UZ < N) {
+                        check_scans<T>({ i, i + 1UZ });
+                }
+        }
+}
+
+}       // namespace
+
+BOOST_AUTO_TEST_SUITE(BitTraits)
+
+using ElementTypes = test::graded_extents<element_bits>;
+using BlockTypes   = test::graded_extents<block_bits>;
+
+// The floor is a width and an indexed read; nothing above it is required to satisfy bit_storage.
+BOOST_AUTO_TEST_CASE_TEMPLATE(TheFloorIsAWidthAndAnIndexedRead, T, ElementTypes)
+{
+        static_assert(xstd::bit_storage<T>);
+        static_assert(xstd::static_bit_extent<T>);
+}
+
+// The tier split is what the two adapters exist to pin down: identical storage, one answering
+// block_readable and one not, so neither branch of the if constexpr can go unexercised.
+BOOST_AUTO_TEST_CASE_TEMPLATE(BlockAccessIsWhatSeparatesTheTiers, T, ElementTypes)
+{
+        static_assert(not xstd::block_readable<xstd::bit_traits<T>, T>);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(BlockAccessIsDetectedWhereOffered, T, BlockTypes)
+{
+        static_assert(xstd::block_readable<xstd::bit_traits<T>, T>);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(ElementWiseScansAgreeWithStdSet, T, ElementTypes)
+{
+        check_every_pattern<T>();
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(BlockWiseScansAgreeWithStdSet, T, BlockTypes)
+{
+        check_every_pattern<T>();
+}
+
+// The set ordering: positions ascending, compared lexicographically, which is what std::set's
+// own <=> means. Exhaustive over every pair of subsets at the narrowest width, so the answer is
+// checked against the standard library rather than against a reading of it.
+BOOST_AUTO_TEST_CASE(OrderingAgreesWithStdSet)
+{
+        using T = element_bits<test::digits_v<unsigned char>, unsigned char>;
+        constexpr auto N = extent_of<T>;
+
+        for (auto a = 0UZ; a < (1UZ << N); ++a) {
+                for (auto b = 0UZ; b < (1UZ << N); ++b) {
+                        auto x = std::set<std::size_t>();
+                        auto y = std::set<std::size_t>();
+                        for (auto i = 0UZ; i < N; ++i) {
+                                if ((a >> i & 1UZ) != 0UZ) { x.insert(i); }
+                                if ((b >> i & 1UZ) != 0UZ) { y.insert(i); }
+                        }
+                        BOOST_CHECK((scan<T>::lexicographical_three_way(make<T>(x), make<T>(y)) == (x <=> y)));
+                }
+        }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/bits/block_sequence.cpp
+++ b/test/src/bits/block_sequence.cpp
@@ -481,8 +481,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(TheDoorForwardsToTheStorage, T, test::graded_exten
         BOOST_CHECK_EQUAL(traits::count(c), 0UZ);
         BOOST_CHECK_EQUAL(traits::num_blocks(c), c.num_blocks());
 
+        // BOOST_CHECK rather than BOOST_CHECK_EQUAL: the latter prints its operands on
+        // failure, and graded_extents includes xstd::uint128, for which libc++ has no
+        // operator<< -- an ambiguity libstdc++ does not have and so does not report.
         for (auto k = 0UZ; k < c.num_blocks(); ++k) {
-                BOOST_CHECK_EQUAL(traits::block(c, k), c.block(k));
+                BOOST_CHECK(traits::block(c, k) == c.block(k));
         }
 
         // One position at a time, set and then cleared again: assign's two arms are the point,

--- a/test/src/bits/block_sequence.cpp
+++ b/test/src/bits/block_sequence.cpp
@@ -5,12 +5,14 @@
 
 #include <boost/test/unit_test.hpp>    // BOOST_CHECK_EQUAL, BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
 #include <test/block_types.hpp>        // graded_extents, word_types
+#include <xstd/bits/bit_traits.hpp>    // bit_storage, bit_traits, block_readable, static_bit_extent
 #include <xstd/bits/block_sequence.hpp> // block_array, block_sequence, block_storage, block_vector
 #include <algorithm>                   // count
 #include <array>                       // array
 #include <cstddef>                     // size_t
 #include <cstdint>                     // uint8_t, uint64_t
 #include <ranges>                      // iota
+#include <set>                         // set
 #include <vector>                      // vector
 
 BOOST_AUTO_TEST_SUITE(BitBlocks)
@@ -455,6 +457,70 @@ BOOST_AUTO_TEST_CASE(ADefaultConstructedRunTimeWidthIsZeroWidthWithOneBlock)
         BOOST_CHECK_EQUAL(b.size(), 0UZ);
         BOOST_CHECK_EQUAL(b.num_blocks(), 1UZ);
         BOOST_CHECK(b == xstd::block_vector<std::uint8_t>(0));
+}
+
+// bit_traits over our own storage forwards and nothing more, so what these check is that each
+// entry reaches the member it names and that the contracts survive the trip. The scans keep
+// block_sequence's own preconditions rather than widening to the total ones bit_scan's fallbacks
+// happen to provide -- find_next wants a valid position, find_prev a set position strictly below
+// n -- so every call below stays inside them.
+BOOST_AUTO_TEST_CASE_TEMPLATE(TheDoorForwardsToTheStorage, T, test::graded_extents<graded_block_array>)
+{
+        using traits = xstd::bit_traits<T>;
+        constexpr auto N = traits::extent;
+
+        static_assert(xstd::bit_storage<T>);
+        static_assert(xstd::static_bit_extent<T>);
+        static_assert(xstd::block_readable<traits, T>);
+
+        auto c = T();
+
+        BOOST_CHECK_EQUAL(traits::size(c), N);
+        BOOST_CHECK_EQUAL(traits::find_last(c), N);
+        BOOST_CHECK_EQUAL(traits::find_first(c), N);
+        BOOST_CHECK_EQUAL(traits::count(c), 0UZ);
+        BOOST_CHECK_EQUAL(traits::num_blocks(c), c.num_blocks());
+
+        for (auto k = 0UZ; k < c.num_blocks(); ++k) {
+                BOOST_CHECK_EQUAL(traits::block(c, k), c.block(k));
+        }
+
+        // One position at a time, set and then cleared again: assign's two arms are the point,
+        // and a single set position makes every scan's answer something the loop already knows.
+        for (auto i = 0UZ; i < N; ++i) {
+                traits::assign(c, i, true);
+                BOOST_CHECK(traits::at(c, i));
+                BOOST_CHECK_EQUAL(traits::count(c), 1UZ);
+                BOOST_CHECK_EQUAL(traits::find_first(c), i);
+                BOOST_CHECK_EQUAL(traits::find_prev(c, i + 1UZ), i);
+                BOOST_CHECK_EQUAL(traits::find_next(c, i), N);
+
+                traits::assign(c, i, false);
+                BOOST_CHECK(not traits::at(c, i));
+                BOOST_CHECK_EQUAL(traits::count(c), 0UZ);
+        }
+}
+
+// The ordering is the one entry with no native spelling to forward to: block_sequence compares as
+// storage, while this is the set reading of it. Checked against std::set, which is the definition.
+BOOST_AUTO_TEST_CASE(TheDoorOrdersAsStdSetDoes)
+{
+        using T = xstd::block_array<std::uint8_t, 8>;
+        using traits = xstd::bit_traits<T>;
+
+        for (auto a = 0UZ; a < 256UZ; ++a) {
+                for (auto b = 0UZ; b < 256UZ; ++b) {
+                        auto x = T();
+                        auto y = T();
+                        auto sx = std::set<std::size_t>();
+                        auto sy = std::set<std::size_t>();
+                        for (auto i = 0UZ; i < 8UZ; ++i) {
+                                if ((a >> i & 1UZ) != 0UZ) { x.set(i); sx.insert(i); }
+                                if ((b >> i & 1UZ) != 0UZ) { y.set(i); sy.insert(i); }
+                        }
+                        BOOST_CHECK((traits::lexicographical_three_way(x, y) == (sx <=> sy)));
+                }
+        }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/bits/block_sequence.cpp
+++ b/test/src/bits/block_sequence.cpp
@@ -524,6 +524,14 @@ BOOST_AUTO_TEST_CASE(TheDoorOrdersAsStdSetDoes)
                         BOOST_CHECK((traits::lexicographical_three_way(x, y) == (sx <=> sy)));
                 }
         }
+
+        // The ordering reaches bit_scan's forward scan only from inside its loop, where the
+        // position is always below the width, so the past-the-end arm has to be asked for
+        // directly. Each instantiation carries its own branch slots and covers them or does not:
+        // that another Traits exercises this one elsewhere does not count for this one.
+        auto const empty = T();
+        BOOST_CHECK_EQUAL(xstd::bit_scan<traits>::next(empty, traits::extent), traits::extent);
+        BOOST_CHECK_EQUAL(xstd::bit_scan<traits>::first(empty), traits::extent);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Step 3a of #80. The door and the one specialization that proves it, with nothing routed through it yet.

`bit_traits<Bits>` is declared and never defined — adaptation is opt-in, never guessed. Around it: `bit_storage` (the floor: `extent`, `size`, `at`), `block_readable` (the block tier), `static_bit_extent`, and `bit_scan<Traits>` carrying the generic walks a foreign type may need synthesised. `bit_traits<block_sequence<Blocks, N>>` is the first specialization, pure forwarding — `block_sequence`'s vocabulary is already public, so it needs no friendship.

**No behaviour change.** Every existing test passes unchanged, because nothing calls into the new header yet except its own tests. The four old primaries (`block_access`, `set_find`, `sequence_find`, `set_compare`) are still live and still doing the work.

## Two design revisions against #80 as written

**No `default_bit_traits`, and no base class.** A partial specialization cannot serve as the default: `bit_traits<block_sequence<Blocks, N>>` matches `block_sequence` and nothing else, so `std::bitset` and `boost::dynamic_bitset` cannot reach it. A CRTP base *would* work — a spike across three toolchains confirms it, and an earlier claim of mine that a base cannot call the derived specialization's `block()` is wrong; that is true of a plain base, not a CRTP one. It is simply not worth it at this scale: three hand-written specializations in total, one of which needs no fallbacks. The cost would be losing the property that each specialization's chosen tier is visible at its own definition, which is what a reader checks when asking why a container is slower than expected.

So the fallbacks take the trait as a template argument and reach the *complete* specialization. Which tier a type takes is a visible `if constexpr` in the specialization that owns the decision, rather than an inference from overload resolution against a base.

**The fallbacks are static members, not free functions.** This one is load-bearing. Since C++20 ([temp.names]/3, P0846) an unqualified `scan_first<Traits>(c)` parses its `<` as a template argument list and then performs **ADL with the explicit template arguments included** — so `std` and `boost`, the associated namespaces of the very types being adapted, join the overload set. `[namespace.std]` bars *users* from adding to `std` but not implementations, and boost is under no such constraint. Qualifying every call would close it, but then the safety lives in remembering a prefix at every site, and one omission is silent. Member lookup through a qualified-id never consults associated namespaces, so `bit_scan<bit_traits>::first(c)` has no unqualified call to hijack.

It is also the shape `block_access`, `set_find` and `sequence_find` already have, so the fold keeps one idiom rather than adding a second.

Both revisions are recorded on #80 (5548059281, 5548164711); the retraction of the CRTP claim and the scale argument are in 5550619153.

## Also here

- **`next_inclusive` is the primitive** both forward scans derive from, as in `block_sequence`. Forward is inclusive and reverse is exclusive, so both derivations are `+ 1` and never `− 1` — which is what lets `first()` name its own extreme without `size_t` wrapping at zero. #88's anti-diagonal, one layer up.
- **No `offset != 0` guard** on the general block path; #88 measured it as pure cost.
- **`extent` sits inside the `bit_storage` floor** rather than beside it, so `static_bit_extent`'s second operand can read it without first proving it exists. That retires the `bit_extent` variable template: the width comes through the one door like everything else.
- **`bit_scan::prev` is total**, unlike `block_sequence::find_prev_exclusive`. That one may demand `any()` because reverse iteration supplies the guard; a fallback synthesised for a foreign type has no such caller to lean on. Totality is the container's contract, not the sequence's — the same ruling as #86.
- **`static_block_count` is derived, not declared.** The extent is already in the floor and `block_readable`'s contract fixes the layout, so a trait entry would be a second source of truth. It exists to give the degenerate widths their own `if constexpr` arm, which is what the coverage gate needs: gcovr does not merge template instantiations, so a one-block instantiation must take *different code*, not merely a different branch.

## Test plan

- [x] Two adapters over identical `block_array` storage — one element-wise, one with block access — driven off `test::graded_extents` and cross-checked against `std::set`: `count`, `first`, `last`, `next`, `next_inclusive` and `prev` agree with the model at every `n` in `[0, extent]`, plus the zero-width case.
- [x] `block_readable` pinned by `static_assert` to hold for one adapter and not the other, so both arms of every `if constexpr` are provably exercised.
- [x] `lexicographical_three_way` matches `std::set`'s own `<=>` over all 256 × 256 pairs at N = 8, including #80's documented case `{0,1} < {1}`.
- [x] `bit_traits<block_sequence<Blocks, N>>` forwards to the storage, and orders as `std::set` does, over `test::graded_extents`.
- [x] 100% line and 100% branch on the new header, at the CI gate's own thresholds.
- [x] Green under ASan + UBSan; clean under the repo's gcc `-Werror` and clang `-Weverything` sets and its clang-tidy config.
- [x] Installed-header closure: `bit_traits.hpp` is in `FILE_SET HEADERS`, and the installed set is closed under its own `xstd/bits` includes.
- [x] All 86 CI checks.

## Follow-on, deliberately not here

Step 3b converts **three** adapters and routes `set_view` and `sequence_view` through the door in the same commit, since otherwise the old primaries stay live and the new specializations are dead code:

- `std::bitset<N>` and `boost::dynamic_bitset<Block, Allocator>`, under `ext/`;
- `xstd::bitset<N, Block>`, whose four specializations live in `bitset.hpp` itself (lines 363, 366, 406, 415), **not** under `ext/`. Temporary — it dies at step 6 when `xstd::bitset` becomes an alias of `basic_bitset` — but worth converting, since today's `set_find::first` is a `find_if` over `views::iota` while the class exposes `block_count`/`block_at` as hidden friends.

`ext/xstd/bitset.hpp` is *not* an adapter — it holds only the eight range-access free functions that make `xstd::bitset` iterable by ADL — so it is untouched. Every call site is enumerated on #80 (5550636734).

The behaviour changes step 3 carries are held for 3b as well: `_Getword`-guarded block access for `std::bitset`, boost's `npos` normalised to `size()`, and the block tier for `xstd::bitset`. A reviewer sees them alone rather than buried in a restructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gfTqPbkbmFo2yfGSCDRpU