### PR TITLE
Align block_sequence's vocabulary with the door it now serves

### DIFF
--- a/include/xstd/bits/bit_array.hpp
+++ b/include/xstd/bits/bit_array.hpp
@@ -64,7 +64,7 @@ struct bit_array
 
         [[nodiscard]] friend constexpr auto find_first(const bit_array&)                  noexcept -> std::size_t { return 0UZ;         }
         [[nodiscard]] friend constexpr auto find_last (const bit_array&)                  noexcept -> std::size_t { return N;           }
-        [[nodiscard]] friend constexpr auto find_at   (const bit_array& c, std::size_t n) noexcept -> std::size_t { return c.m_bits[n]; }
+        [[nodiscard]] friend constexpr auto find_at   (const bit_array& c, std::size_t n) noexcept -> std::size_t { return c.m_bits.test(n); }
         friend constexpr void assign_at(bit_array& c, std::size_t n, bool value) noexcept { if (value) { c.m_bits.set(n); } else { c.m_bits.reset(n); } }
 
         // types

--- a/include/xstd/bits/bit_finite_set.hpp
+++ b/include/xstd/bits/bit_finite_set.hpp
@@ -72,8 +72,8 @@ class bit_finite_set
 
         [[nodiscard]] friend constexpr auto find_first(const bit_finite_set& c)                noexcept -> std::size_t { return c.m_bits.find_first(); }
         [[nodiscard]] friend constexpr auto find_last (const bit_finite_set& c)                noexcept -> std::size_t { return c.m_bits.find_last();  }
-        [[nodiscard]] friend constexpr auto find_next (const bit_finite_set& c, std::size_t n) noexcept -> std::size_t { return c.m_bits.find_next_exclusive(n); }
-        [[nodiscard]] friend constexpr auto find_prev (const bit_finite_set& c, std::size_t n) noexcept -> std::size_t { return c.m_bits.find_prev_exclusive(n); }
+        [[nodiscard]] friend constexpr auto find_next (const bit_finite_set& c, std::size_t n) noexcept -> std::size_t { return c.m_bits.exclusive_find_next(n); }
+        [[nodiscard]] friend constexpr auto find_prev (const bit_finite_set& c, std::size_t n) noexcept -> std::size_t { return c.m_bits.exclusive_find_prev(n); }
 
         template<class Provider, class Hash, class Flavor>
         friend constexpr void tag_invoke(boost::hash2::hash_append_tag const&, Provider const&, Hash& h, Flavor const& f, bit_finite_set const* v) noexcept
@@ -265,7 +265,7 @@ public:
         // block_sequence asserts is_valid on every position it accepts and offers no total
         // spelling of any of these -- that is the layering working, not a gap in it. The
         // precondition is the sequence's, the guard is the container's.
-        [[nodiscard]] constexpr auto contains(const key_type& x) const noexcept -> bool      { return x < N and m_bits[x]; }
+        [[nodiscard]] constexpr auto contains(const key_type& x) const noexcept -> bool      { return x < N and m_bits.test(x); }
         [[nodiscard]] constexpr auto count   (const key_type& x) const noexcept -> size_type { return contains(x);         }
 
         [[nodiscard]] constexpr auto find(this auto&& self, const key_type& x) noexcept -> iterator
@@ -275,12 +275,12 @@ public:
                 }
                 return self.end();
         }
-        // The bound is find_next_inclusive at x, and its exclusive twin one past it. The x ? :
+        // The bound is inclusive_find_next at x, and its exclusive twin one past it. The x ? :
         // that used to stand here was find_next's exclusivity showing through: x - 1 wraps at
         // 0, so the 0 case had to be spelled separately. An inclusive primitive has no such
         // seam, so the two bounds now differ by the + 1 that actually separates them.
-        [[nodiscard]] constexpr auto lower_bound(this auto&& self, const key_type& x) noexcept -> iterator                      { return { &self, x < N ? self.m_bits.find_next_inclusive(x    ) : N }; }
-        [[nodiscard]] constexpr auto upper_bound(this auto&& self, const key_type& x) noexcept -> iterator                      { return { &self, x < N ? self.m_bits.find_next_inclusive(x + 1) : N }; }
+        [[nodiscard]] constexpr auto lower_bound(this auto&& self, const key_type& x) noexcept -> iterator                      { return { &self, x < N ? self.m_bits.inclusive_find_next(x    ) : N }; }
+        [[nodiscard]] constexpr auto upper_bound(this auto&& self, const key_type& x) noexcept -> iterator                      { return { &self, x < N ? self.m_bits.inclusive_find_next(x + 1) : N }; }
         [[nodiscard]] constexpr auto equal_range(this auto&& self, const key_type& x) noexcept -> std::pair<iterator, iterator> { return { self.lower_bound(x), self.upper_bound(x) };               }
 
         [[nodiscard]] constexpr auto is_subset_of       (const bit_finite_set& other) const noexcept -> bool { return this->m_bits.is_subset_of       (other.m_bits); }

--- a/include/xstd/bits/bit_traits.hpp
+++ b/include/xstd/bits/bit_traits.hpp
@@ -190,7 +190,7 @@ public:
         [[nodiscard]] static constexpr auto first(Bits const& c) noexcept
                 -> std::size_t
         {
-                return next_inclusive(c, 0UZ);
+                return inclusive_next(c, 0UZ);
         }
 
         // One past the last position, which for every reading is the width: the end iterator's
@@ -203,19 +203,19 @@ public:
                 return Traits::size(c);
         }
 
-        // The first set position strictly above n, mirroring block_sequence::find_next_exclusive
+        // The first set position strictly above n, mirroring block_sequence::exclusive_find_next
         // and boost's find_next. Total in n: a position at or past the width has nothing above it.
         template<class Bits>
         [[nodiscard]] static constexpr auto next(Bits const& c, std::size_t n) noexcept
                 -> std::size_t
         {
                 auto const size = Traits::size(c);
-                return n >= size ? size : next_inclusive(c, n + 1UZ);
+                return n >= size ? size : inclusive_next(c, n + 1UZ);
         }
 
         // The last set position strictly below n, or size() if there is none.
         //
-        // Unlike block_sequence::find_prev_exclusive this is total rather than
+        // Unlike block_sequence::exclusive_find_prev this is total rather than
         // precondition-guarded: that one may demand any() because reverse iteration supplies the
         // guard, and a fallback synthesised for a foreign type has no such caller to lean on.
         //
@@ -269,10 +269,10 @@ public:
         }
 
         // The first set position at or above n: the primitive the two forward scans derive from,
-        // exactly as block_sequence's find_next_inclusive is. Both derivations are + 1 and never
+        // exactly as block_sequence's inclusive_find_next is. Both derivations are + 1 and never
         // - 1, which is what lets first() name its own extreme without size_t wrapping at zero.
         template<class Bits>
-        [[nodiscard]] static constexpr auto next_inclusive(Bits const& c, std::size_t n) noexcept
+        [[nodiscard]] static constexpr auto inclusive_next(Bits const& c, std::size_t n) noexcept
                 -> std::size_t
         {
                 auto const size = Traits::size(c);

--- a/include/xstd/bits/bitset.hpp
+++ b/include/xstd/bits/bitset.hpp
@@ -125,12 +125,12 @@ public:
 
                 [[nodiscard]] constexpr explicit(false) operator bool() const noexcept  // NOLINT(misc-explicit-constructor)
                 {
-                        return m_ptr->m_bits[m_idx];
+                        return m_ptr->m_bits.test(m_idx);
                 }
 
                 [[nodiscard]] constexpr auto operator~() const noexcept -> bool
                 {
-                        return not m_ptr->m_bits[m_idx];
+                        return not m_ptr->m_bits.test(m_idx);
                 }
 
                 friend constexpr void swap(reference x, reference y) noexcept { bool const t = x; x = y; y = t; }
@@ -273,7 +273,7 @@ public:
         [[nodiscard]] constexpr auto operator[](std::size_t pos) const noexcept
                 -> bool
         {
-                return m_bits[pos];
+                return m_bits.test(pos);
         }
 
         [[nodiscard]] constexpr auto operator[](std::size_t pos) noexcept
@@ -297,7 +297,7 @@ public:
                 // which is what bitset<0>::to_string() returns.
                 auto str = std::basic_string<charT, traits, Allocator>(N, zero);  // NOLINT(bugprone-string-constructor)
                 for (auto const i : std::views::iota(0UZ, N)) {
-                        if (m_bits[N - 1 - i]) {
+                        if (m_bits.test(N - 1 - i)) {
                                 str[i] = one;
                         }
                 }
@@ -314,7 +314,7 @@ public:
                 -> bool
         {
                 if (pos < N) {
-                        return m_bits[pos];
+                        return m_bits.test(pos);
                 }
                 throw out_of_range(pos);
         }

--- a/include/xstd/bits/block_sequence.hpp
+++ b/include/xstd/bits/block_sequence.hpp
@@ -233,17 +233,17 @@ public:
                 }
         }
 
-        // Its own 0. Now that find_next_inclusive carries the 2-block case too, this emits the same
+        // Its own 0. Now that inclusive_find_next carries the 2-block case too, this emits the same
         // instruction sequence the hand-written version did -- verified, not assumed -- so the
         // duplication goes without costing the unrolling. libstdc++ writes both scans out and
         // repeats the word loop and the ctz-plus-index arithmetic between them; boost factors
-        // the shared tail into m_do_find_from, but only at block granularity, so find_next_exclusive still
+        // the shared tail into m_do_find_from, but only at block granularity, so exclusive_find_next still
         // needs its own prologue for a mid-block start. Factoring at bit granularity subsumes
         // both: a block-aligned start is just offset == 0.
         [[nodiscard]] constexpr auto find_first() const noexcept
                 -> std::size_t
         {
-                return find_next_inclusive(0UZ);
+                return inclusive_find_next(0UZ);
         }
 
         [[nodiscard]] constexpr auto find_last() const noexcept
@@ -263,10 +263,10 @@ public:
         // The inclusive form is the primitive and the exclusive one is derived, because the
         // reverse does not close:
         //
-        //     find_next_exclusive(n) == find_next_inclusive(n + 1)     for every n
-        //     find_first()           == find_next_inclusive(0)
+        //     exclusive_find_next(n) == inclusive_find_next(n + 1)     for every n
+        //     find_first()           == inclusive_find_next(0)
         //
-        // Exclusive-first would need find_first() == find_next_exclusive(-1), and size_t has no
+        // Exclusive-first would need find_first() == exclusive_find_next(-1), and size_t has no
         // such value -- which is exactly why the container used to branch on x == 0. boost's
         // find_next and libstdc++'s _M_do_find_next are both the exclusive form, correctly: their
         // iteration idiom is find_first() then find_next(i), which never needs the inclusive one.
@@ -274,8 +274,8 @@ public:
         // n == size() rather than n >= size(): the precondition is n <= size(), asserted just
         // below, so size() is the only value the scan cannot start from. is_valid does not say
         // this -- it is n < size() -- and size() is a legitimate argument here, meaning "no such
-        // position", exactly as it is for find_prev_exclusive.
-        [[nodiscard]] constexpr auto find_next_inclusive(std::size_t n) const noexcept
+        // position", exactly as it is for exclusive_find_prev.
+        [[nodiscard]] constexpr auto inclusive_find_next(std::size_t n) const noexcept
                 -> std::size_t
         {
                 assert(n <= size());
@@ -330,14 +330,14 @@ public:
                 return size();
         }
 
-        [[nodiscard]] constexpr auto find_next_exclusive(std::size_t n) const noexcept
+        [[nodiscard]] constexpr auto exclusive_find_next(std::size_t n) const noexcept
                 -> std::size_t
         {
                 assert(is_valid(n));
-                return find_next_inclusive(n + 1);
+                return inclusive_find_next(n + 1);
         }
 
-        // The last set position below n. Deliberately NOT total: where find_next_inclusive
+        // The last set position below n. Deliberately NOT total: where inclusive_find_next
         // answers size() for "nothing at or above", this one has a precondition instead, and
         // that is the whole of why it is three instructions cheaper at every width -- it never
         // materializes a not-found value.
@@ -348,10 +348,10 @@ public:
         // the forward idiom terminates itself against size(), the reverse one runs off the
         // bottom. Totality is the container's contract to keep, per #86 -- not this layer's to
         // absorb.
-        [[nodiscard]] constexpr auto find_prev_exclusive(std::size_t n) const noexcept
+        [[nodiscard]] constexpr auto exclusive_find_prev(std::size_t n) const noexcept
                 -> std::size_t
         {
-                // The mirror of find_next_exclusive's assert(is_valid(n)): each says the position actually
+                // The mirror of exclusive_find_next's assert(is_valid(n)): each says the position actually
                 // scanned from is one this container has. n - 1 is that position here, and the
                 // wraparound does the work at the bottom -- 0 - 1 is SIZE_MAX, which no width
                 // admits -- so this states 1 <= n <= size() without a second predicate. is_valid
@@ -362,7 +362,7 @@ public:
                 if constexpr (has_static_size and static_num_blocks == 1) {
                         return n - detail::bits::countl_zero(static_cast<block_type>(m_blocks[0] << (left_bit - n)));
                 } else if constexpr (has_static_size and static_num_blocks == 2) {
-                        // The mirror of find_next_inclusive's two-block case, and simpler than the general
+                        // The mirror of inclusive_find_next's two-block case, and simpler than the general
                         // path below because the fallback is one named block rather than a scan.
                         //
                         // No reverse_offset != 0 guard is needed here. Below, that guard is not
@@ -407,7 +407,7 @@ public:
                 }
         }
 
-        constexpr void operator&=(block_sequence const& other [[maybe_unused]]) noexcept
+        constexpr auto operator&=(block_sequence const& other [[maybe_unused]]) noexcept -> block_sequence&
         {
                 assert(this->size() == other.size());
                 if constexpr (has_static_size and N > 0 and static_num_blocks == 1) {
@@ -420,9 +420,10 @@ public:
                                 this->m_blocks[i] &= other.m_blocks[i];
                         }
                 }
+                return *this;
         }
 
-        constexpr void operator|=(block_sequence const& other [[maybe_unused]]) noexcept
+        constexpr auto operator|=(block_sequence const& other [[maybe_unused]]) noexcept -> block_sequence&
         {
                 assert(this->size() == other.size());
                 if constexpr (has_static_size and N > 0 and static_num_blocks == 1) {
@@ -435,9 +436,10 @@ public:
                                 this->m_blocks[i] |= other.m_blocks[i];
                         }
                 }
+                return *this;
         }
 
-        constexpr void operator^=(block_sequence const& other [[maybe_unused]]) noexcept
+        constexpr auto operator^=(block_sequence const& other [[maybe_unused]]) noexcept -> block_sequence&
         {
                 assert(this->size() == other.size());
                 if constexpr (has_static_size and N > 0 and static_num_blocks == 1) {
@@ -450,9 +452,10 @@ public:
                                 this->m_blocks[i] ^= other.m_blocks[i];
                         }
                 }
+                return *this;
         }
 
-        constexpr void operator-=(block_sequence const& other [[maybe_unused]]) noexcept
+        constexpr auto operator-=(block_sequence const& other [[maybe_unused]]) noexcept -> block_sequence&
         {
                 assert(this->size() == other.size());
                 if constexpr (has_static_size and N > 0 and static_num_blocks == 1) {
@@ -465,9 +468,10 @@ public:
                                 this->m_blocks[i] &= static_cast<block_type>(~other.m_blocks[i]);
                         }
                 }
+                return *this;
         }
 
-        constexpr void operator<<=(std::size_t n [[maybe_unused]]) noexcept
+        constexpr auto operator<<=(std::size_t n [[maybe_unused]]) noexcept -> block_sequence&
         {
                 assert(is_valid(n));
                 if constexpr (has_static_size and static_num_blocks == 1) {
@@ -494,9 +498,10 @@ public:
                         std::ranges::fill_n(std::ranges::begin(m_blocks), static_cast<std::ptrdiff_t>(n_blocks), zero);
                 }
                 erase_unused();
+                return *this;
         }
 
-        constexpr void operator>>=(std::size_t n [[maybe_unused]]) noexcept
+        constexpr auto operator>>=(std::size_t n [[maybe_unused]]) noexcept -> block_sequence&
         {
                 assert(is_valid(n));
                 if constexpr (has_static_size and static_num_blocks == 1) {
@@ -517,9 +522,10 @@ public:
                         }
                         std::ranges::fill_n(std::ranges::prev(std::ranges::end(m_blocks), static_cast<std::ptrdiff_t>(n_blocks)), static_cast<std::ptrdiff_t>(n_blocks), zero);
                 }
+                return *this;
         }
 
-        constexpr void set() noexcept
+        constexpr auto set() noexcept -> block_sequence&
         {
                 if constexpr (has_static_size and static_has_unused_bits) {
                         std::ranges::fill_n(std::ranges::begin(m_blocks), static_cast<std::ptrdiff_t>(static_last_block), ones);
@@ -533,15 +539,17 @@ public:
                         m_blocks[last_block()] = used_bits();
                 }
                 assert(all());
+                return *this;
         }
 
-        constexpr void reset() noexcept
+        constexpr auto reset() noexcept -> block_sequence&
         {
                 std::ranges::fill(m_blocks, zero);
                 assert(none());
+                return *this;
         }
 
-        constexpr void flip() noexcept
+        constexpr auto flip() noexcept -> block_sequence&
         {
                 if constexpr (has_static_size and N > 0 and static_num_blocks == 1) {
                         m_blocks[0] = static_cast<block_type>(~m_blocks[0]);
@@ -554,6 +562,7 @@ public:
                         }
                 }
                 erase_unused();
+                return *this;
         }
 
         constexpr void swap(block_sequence& other) noexcept(std::is_nothrow_swappable_v<Blocks>)
@@ -563,12 +572,13 @@ public:
                 std::ranges::swap(this->m_size,   other.m_size);
         }
 
-        constexpr void set(std::size_t n) noexcept
+        constexpr auto set(std::size_t n) noexcept -> block_sequence&
         {
                 assert(is_valid(n));
                 auto&& [ block, mask ] = block_mask(n);
                 block |= mask;
-                assert((*this)[n]);
+                assert(test(n));
+                return *this;
         }
 
         [[nodiscard]] constexpr auto insert(std::size_t n) noexcept
@@ -578,16 +588,17 @@ public:
                 auto&& [ block, mask ] = block_mask(n);
                 auto const inserted = not detail::bits::intersects(block, mask);
                 block |= mask;
-                assert((*this)[n]);
+                assert(test(n));
                 return inserted;
         }
 
-        constexpr void reset(std::size_t n) noexcept
+        constexpr auto reset(std::size_t n) noexcept -> block_sequence&
         {
                 assert(is_valid(n));
                 auto&& [ block, mask ] = block_mask(n);
                 block &= static_cast<block_type>(~mask);
-                assert(not (*this)[n]);
+                assert(not test(n));
+                return *this;
         }
 
         [[nodiscard]] constexpr auto erase(std::size_t n) noexcept
@@ -597,18 +608,25 @@ public:
                 auto&& [ block, mask ] = block_mask(n);
                 auto const erased = detail::bits::intersects(block, mask);
                 block &= static_cast<block_type>(~mask);
-                assert(not (*this)[n]);
+                assert(not test(n));
                 return erased;
         }
 
-        constexpr void flip(std::size_t n) noexcept
+        constexpr auto flip(std::size_t n) noexcept -> block_sequence&
         {
                 assert(is_valid(n));
                 auto&& [ block, mask ] = block_mask(n);
                 block ^= mask;
+                return *this;
         }
 
-        [[nodiscard]] constexpr auto operator[](std::size_t n) const noexcept
+        // test rather than operator[], because this reads and cannot be written through:
+        // std::bitset's operator[] returns an assignable proxy and this returns bool, so the
+        // subscript spelling would promise an assignment that does not compile. The writable
+        // proxy belongs to the containers above, which is also where the checked reading lives
+        // -- std::bitset::test throws where this asserts, a difference the door states as
+        // unchecked_test rather than one this name should try to carry.
+        [[nodiscard]] constexpr auto test(std::size_t n) const noexcept
                 -> bool
         {
                 assert(is_valid(n));
@@ -788,7 +806,7 @@ private:
                 return std::ranges::all_of(first, first + static_cast<std::ptrdiff_t>(last_block()), [](auto block) { return block == ones; });
         }
 
-        // The top bit of the last block, padding included. find_back and find_prev_exclusive count
+        // The top bit of the last block, padding included. find_back and exclusive_find_prev count
         // down from it and both assert any(), so the zero-width case never reaches here.
         [[nodiscard]] constexpr auto last_bit() const noexcept
                 -> std::size_t
@@ -879,7 +897,7 @@ struct bit_traits<block_sequence<Blocks, N>>
         static constexpr std::size_t extent = N;
 
         [[nodiscard]] static constexpr auto size(bits_type const& c) noexcept -> std::size_t { return c.size(); }
-        [[nodiscard]] static constexpr auto at(bits_type const& c, std::size_t n) noexcept -> bool { return c[n]; }
+        [[nodiscard]] static constexpr auto at(bits_type const& c, std::size_t n) noexcept -> bool { return c.test(n); }
 
         // set(n) and reset(n) rather than a set(n, value) block_sequence does not have. Both
         // assert is_valid(n), so the position is a precondition here as it is everywhere below.
@@ -902,7 +920,7 @@ struct bit_traits<block_sequence<Blocks, N>>
 
         // The two scans keep the contracts block_sequence gives them rather than widening to the
         // total ones bit_scan's fallbacks happen to provide. That is the ceiling principle again:
-        // the door's contract is the most efficient form, and #88 measured find_prev_exclusive's
+        // the door's contract is the most efficient form, and #88 measured exclusive_find_prev's
         // non-totality as three instructions at every width. A fallback synthesised for a foreign
         // type may be more generous than the contract; it may not be less.
         //
@@ -912,8 +930,8 @@ struct bit_traits<block_sequence<Blocks, N>>
         // make_reverse_iterator(begin()), which is why block_sequence can omit it and why the
         // guard belongs to the container above rather than here. #86 settled the same division
         // one layer down: totality is the container's contract, not the sequence's.
-        [[nodiscard]] static constexpr auto find_next(bits_type const& c, std::size_t n) noexcept -> std::size_t { return c.find_next_exclusive(n); }
-        [[nodiscard]] static constexpr auto find_prev(bits_type const& c, std::size_t n) noexcept -> std::size_t { return c.find_prev_exclusive(n); }
+        [[nodiscard]] static constexpr auto find_next(bits_type const& c, std::size_t n) noexcept -> std::size_t { return c.exclusive_find_next(n); }
+        [[nodiscard]] static constexpr auto find_prev(bits_type const& c, std::size_t n) noexcept -> std::size_t { return c.exclusive_find_prev(n); }
 
         // The set ordering has no native spelling here to prefer: block_sequence compares as
         // storage, and ascending-positions-lexicographically is a reading of it. The fallback is

--- a/test/src/bits/bit_traits.cpp
+++ b/test/src/bits/bit_traits.cpp
@@ -41,7 +41,7 @@ struct bit_traits<element_bits<N, Block>>
         static constexpr std::size_t extent = N;
 
         [[nodiscard]] static constexpr auto size(element_bits<N, Block> const&) noexcept -> std::size_t { return N; }
-        [[nodiscard]] static constexpr auto at(element_bits<N, Block> const& c, std::size_t n) noexcept -> bool { return c.bits[n]; }
+        [[nodiscard]] static constexpr auto at(element_bits<N, Block> const& c, std::size_t n) noexcept -> bool { return c.bits.test(n); }
 };
 
 template<std::size_t N, class Block>
@@ -50,7 +50,7 @@ struct bit_traits<block_bits<N, Block>>
         static constexpr std::size_t extent = N;
 
         [[nodiscard]] static constexpr auto size(block_bits<N, Block> const&) noexcept -> std::size_t { return N; }
-        [[nodiscard]] static constexpr auto at(block_bits<N, Block> const& c, std::size_t n) noexcept -> bool { return c.bits[n]; }
+        [[nodiscard]] static constexpr auto at(block_bits<N, Block> const& c, std::size_t n) noexcept -> bool { return c.bits.test(n); }
 
         [[nodiscard]] static constexpr auto num_blocks(block_bits<N, Block> const& c) noexcept -> std::size_t { return c.bits.num_blocks(); }
         [[nodiscard]] static constexpr auto block(block_bits<N, Block> const& c, std::size_t i) noexcept -> Block { return c.bits.block(i); }
@@ -95,7 +95,7 @@ auto check_scans(std::set<std::size_t> const& model) -> void
                 BOOST_CHECK_EQUAL(scan<T>::next(c, n), above == model.end() ? N : *above);
 
                 auto const at_or_above = model.lower_bound(n);
-                BOOST_CHECK_EQUAL(scan<T>::next_inclusive(c, n), at_or_above == model.end() ? N : *at_or_above);
+                BOOST_CHECK_EQUAL(scan<T>::inclusive_next(c, n), at_or_above == model.end() ? N : *at_or_above);
 
                 auto const below = model.lower_bound(n < N ? n : N);
                 BOOST_CHECK_EQUAL(scan<T>::prev(c, n), below == model.begin() ? N : *std::prev(below));

--- a/test/src/bits/block_sequence.cpp
+++ b/test/src/bits/block_sequence.cpp
@@ -28,7 +28,7 @@ auto reference(BB const& b) -> model
 {
         auto m = model(b.size());
         for (auto i = 0UZ; i < b.size(); ++i) {
-                m[i] = b[i];
+                m[i] = b.test(i);
         }
         return m;
 }
@@ -92,7 +92,7 @@ class checker
         auto same(model const& m, BB const& got) -> void
         {
                 for (auto i = 0UZ; i < m_n; ++i) {
-                        disagree(got[i], m[i]);
+                        disagree(got.test(i), m[i]);
                 }
         }
 
@@ -126,7 +126,7 @@ public:
                         while (not m_mx[back]) { --back; }
                         unequal(m_x.find_front(), front);
                         unequal(m_x.find_back(),  back);
-                        unequal(m_x.find_prev_exclusive(m_n), back);
+                        unequal(m_x.exclusive_find_prev(m_n), back);
                 }
 
                 auto first = 0UZ;
@@ -137,22 +137,22 @@ public:
                 for (auto i = 0UZ; i < m_n; ++i) {
                         auto next = i + 1;
                         while (next < m_n and not m_mx[next]) { ++next; }
-                        unequal(m_x.find_next_exclusive(i), next);
+                        unequal(m_x.exclusive_find_next(i), next);
                 }
 
-                // find_next_inclusive is the primitive; find_first is its 0 and find_next_exclusive its n + 1. Check
+                // inclusive_find_next is the primitive; find_first is its 0 and exclusive_find_next its n + 1. Check
                 // it directly over its whole precondition domain -- n == size() included, which is
                 // the one value the scan cannot start from and the reason the guard is == at all.
                 for (auto i = 0UZ; i <= m_n; ++i) {
                         auto bound = i;
                         while (bound < m_n and not m_mx[bound]) { ++bound; }
-                        unequal(m_x.find_next_inclusive(i), bound);
+                        unequal(m_x.inclusive_find_next(i), bound);
                 }
                 for (auto i = 1UZ; i <= m_n and m_cardinality != 0; ++i) {
                         auto j = i;
                         while (j-- > 0) {
                                 if (m_mx[j]) {
-                                        unequal(m_x.find_prev_exclusive(i), j);
+                                        unequal(m_x.exclusive_find_prev(i), j);
                                         break;
                                 }
                         }
@@ -219,7 +219,7 @@ public:
                 a.flip();
                 unequal(a.count(), m_n - m_cardinality);
                 for (auto const i : std::views::iota(0UZ, m_n)) {
-                        disagree(a[i], not m_mx[i]);
+                        disagree(a.test(i), not m_mx[i]);
                 }
         }
 
@@ -236,11 +236,11 @@ public:
         auto positions() -> void
         {
                 for (auto i = 0UZ; i < m_n; ++i) {
-                        { auto& a = fresh_x(); a.set(i);   disagree(a[i], true);  }
-                        { auto& a = fresh_x(); a.reset(i); disagree(a[i], false); }
-                        { auto& a = fresh_x(); a.flip(i);  disagree(a[i], not m_mx[i]); }
-                        { auto& a = fresh_x(); disagree(a.insert(i), not m_mx[i]); disagree(a[i], true);  }
-                        { auto& a = fresh_x(); disagree(a.erase(i),      m_mx[i]); disagree(a[i], false); }
+                        { auto& a = fresh_x(); a.set(i);   disagree(a.test(i), true);  }
+                        { auto& a = fresh_x(); a.reset(i); disagree(a.test(i), false); }
+                        { auto& a = fresh_x(); a.flip(i);  disagree(a.test(i), not m_mx[i]); }
+                        { auto& a = fresh_x(); disagree(a.insert(i), not m_mx[i]); disagree(a.test(i), true);  }
+                        { auto& a = fresh_x(); disagree(a.erase(i),      m_mx[i]); disagree(a.test(i), false); }
                 }
         }
 


### PR DESCRIPTION
Three renames of #80, no behaviour change, landing together because they touch overlapping members. Sequenced **before** step 3b deliberately: 3b writes the `bit_traits` specializations, and the `block_sequence` one already reads `find_next -> c.find_next_exclusive(n)`. Doing 3b first would mean writing those call sites and renaming them in the next commit.

## Mutators return `*this` rather than `void`

Step 6 will require the shared bitset vocabulary through a `has_bitops` concept rather than restate it as trait entries — `bit_traits` reconciles what differs, a concept requires what doesn't (#80 5550802155). That concept can only be tight, `same_as<Bits&>`, if every backend agrees on the return type. `std::bitset` and `boost::dynamic_bitset` already do; this makes the third agree.

**Measured free**, not assumed. A patched header returning `block_sequence&` from all six `operator@=`, against a TU covering one-block, two-block, general static, narrow-block and dynamic widths plus a hot loop and a `[[gnu::noinline]]` callee where the epilogue cannot be inlined away:

| | gcc 14 | clang 18 |
|---|---|---|
| `-O1` / `-O2` / `-O3` | **0 differing instructions** | **0 differing instructions** |
| `-Os` | differs; `fN` 9→6 bytes, `loopN` 60→45 | differs; no function larger |

Byte-identical normalised disassembly at every optimisation level a release build uses. `this` arrives in `rdi` and the ABI returns it in `rax`, so the move is dead before instruction selection.

`insert` and `erase` keep returning `bool` — that is information the caller cannot cheaply recompute, and `*this` never is.

## `operator[]` becomes `test()`

It was const-only and returned `bool`, where `std::bitset::operator[]` returns an assignable proxy — so the subscript spelling promised an assignment that does not compile. The writable proxy belongs to the containers above (`bitset.hpp:318`), and gets factored out in step 4.

`test()` is unchecked here and throwing on `std::bitset`. That difference is stated at the door as `unchecked_test`, exactly as `operator<<=` is handled, rather than being something this name should try to carry.

## Qualifier suffixes become prefixes

Matching the `checked_`/`unchecked_` convention the trait uses for the same kind of contract qualifier:

| | |
|---|---|
| `find_next_inclusive` | `inclusive_find_next` |
| `find_next_exclusive` | `exclusive_find_next` |
| `find_prev_exclusive` | `exclusive_find_prev` |
| `bit_scan::next_inclusive` | `bit_scan::inclusive_next` |

Comment prose is renamed with the identifiers, since several comments state the algebra between them (`exclusive_find_next(n) == inclusive_find_next(n + 1)`).

## Verification

- [x] **Full suite: 28/28 buildable tests pass.** Four do not build locally and fail **identically on unmodified `origin/main`** — `std_set/o1` and `o2` need `std::set(from_range, ...)` which gcc 14's libstdc++ lacks, and both `sieve.cpp` need `fmt`, which is not installed here. Verified against a clean worktree at `fb27fff` rather than assumed.
- [x] gcc `-Werror` with the repo's own flag set: 0 across all five affected tests.
- [x] clang `-Weverything` with the repo's own flag set: 0 across all five.
- [x] ASan + UBSan: 5/5 affected tests pass, 519 test cases.
- [x] clang-tidy findings all sit on lines **outside this diff** — `sequence_view.hpp:79` in a file this branch does not touch at all (and reproduced on the baseline), the regions around `bit_finite_set.hpp:175/177` and `bitset.hpp:112` byte-identical to `origin/main`, and the rest inside the `xstd-ints` dependency.

Building rather than trusting the rename sweep caught four call sites the greps missed: `bit_traits.cpp:44` and `:53`, and three subscripts in `block_sequence.cpp`'s `positions()`.

Source-breaking for direct users of `block_sequence`, which is expected while #80 is in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gfTqPbkbmFo2yfGSCDRpU

---
_Generated by [Claude Code](https://claude.ai/code/session_016gfTqPbkbmFo2yfGSCDRpU)_