### PR TITLE
Flatten the door, and move the long comments to design.md

### DIFF
--- a/design.md
+++ b/design.md
@@ -210,11 +210,19 @@ std::lexicographical_compare_three_way(a.begin(), a.end(), b.begin(), b.end()) =
 which is stated on the **reading**, never on the storage: `block_sequence` has no `begin()`/`end()`, and
 `boost::dynamic_bitset` has no public iterators, so it cannot be written against a backend at all.
 
-Two things follow. `basic_bitset` has no `operator<=>` because it does not iterate — the existing "no
-iteration and no `<=>` here by design" is a consequence rather than a separate rule. And magnitude ordering
-(boost's `operator<`, a top-down block walk) is the lexicographic order of *reverse* iteration, so no
-forward-iterating container obeying the invariant can have it; boost escapes only by having no iterators to
-be constrained by.
+`basic_bitset` therefore has no `operator<=>`, because it does not iterate — the existing "no iteration and
+no `<=>` here by design" is a consequence rather than a separate rule.
+
+`boost::dynamic_bitset::operator<` is a **third** reading, not an unreachable one. It pairs *a*'s highest bit
+with *b*'s highest, second with second, then breaks a tie on width — which is that same standard algorithm
+over **reverse** iterators. Verified over 1,046,529 pairs spanning every width 0-9 against every other: zero
+mismatches against reverse-lex, 223,893 against numeric order. It is *not* magnitude ordering, though it
+coincides with one at equal width, which is the only case our operators admit: `"1"` and `"01"` are both the
+number 1, and boost orders them strictly.
+
+So it stays out of `operator<=>` because that is defined by *forward* iteration, not because nothing could
+reach it — and should a dynamic bitset ever want boost's exact ordering, it costs no new algorithm, being
+`sequence_three_way` over `rbegin`/`rend`.
 
 Where a specialization offers nothing faster, the default is that standard algorithm over the reading's own
 iterators — so the default cannot disagree with the specification, and only an optimization can.
@@ -296,3 +304,145 @@ one this name should try to carry.
 Contract qualifiers are prefixes, not suffixes — `inclusive_find_next`, `exclusive_find_prev`,
 `unchecked_test`, `checked_shift_left` — so that the contract reads before the operation and the cheaper
 form cannot be called by mistake.
+
+## Test harness
+
+### scratch-objects
+
+`checker` holds two scratch objects, reset before each mutating check, rather than taking a fresh copy per
+check. Same-width assignment reuses the storage, so this is two allocations for the whole checker instead of
+one per operation — of which `positions()` alone did five per bit.
+
+It is faster, and it leaves the optimizer one object to follow rather than thousands of construct/destroy
+pairs. **Three GCC versions have each mis-analysed the copying shape in a different way** —
+`-Wfree-nonheap-object` on 15, `-Wrestrict` on 17-SVN — and moving the copies around only moved the
+diagnostic. The whole-container mutators get one method apiece for the same reason: at `-O3` GCC 15 inlines
+a combined sweep into a single function and then reports `-Wfree-nonheap-object` on the vector copies, which
+ASan, LSan and UBSan all say is not there.
+
+The scratch objects are held **by reference**, owned by `check_ops`: by value they would be the only members
+narrower than a pointer, and `-Wpadded` reports the tail padding that leaves.
+
+### counted-not-asserted
+
+Disagreements are counted rather than asserted per bit. A passing assertion per bit says no more than one,
+and a failing one drowns the log. Two helpers turn the comparison into a count, so the cast
+`readability-implicit-bool-conversion` asks for has two sites rather than thirty.
+
+### seven-patterns
+
+The sweep uses seven patterns, chosen so every pair lands on both sides of each branch: all clear and all set
+for the whole-container shortcuts, the strided ones for partial blocks, and the endpoint ones for the first
+and last block specifically.
+
+The last pattern fills every block but the last, which is the only way to reach the right operand of `all()`'s
+short circuit with a `false`: every other pattern either fails a block below the last, or fills the last one
+too. It compares block indices rather than a precomputed bit count, so that a single-block width — for which
+it selects nothing — does not fold into an unsigned comparison against zero.
+
+### width-zero-comparisons
+
+An unsigned comparison against zero is a diagnostic on both major compilers: `-Wtype-limits` on GCC, and C4296
+on MSVC, which is what `is_valid()` carries its own note about. At a width of zero, `i < n` with `n` folding to
+a constant is exactly that, so the sweeps use `views::iota` instead.
+
+The same folding is why lambdas capture by reference throughout rather than naming what they use: under a
+static width the compiler folds those to constants, and naming something usable in a constant expression is
+what `-Wunused-lambda-capture` reports.
+
+## Views and containers
+
+### asking-is-total
+
+Asking is total whatever the extent: a position past the width is a key the set does not hold, which is an
+answer and not a precondition violation. That is what `[set]` gives `contains` and `find` — `s.find(k)`
+returns `end()` for any `k` it does not hold, never refuses the question — and it is the difference between
+the set reading and the sequence reading, where `sequence_view::operator[]` indexes and out of range is out
+of bounds.
+
+`insert` carries no `noexcept`, for the reason `std::set::insert` carries none: growing a dynamic extent
+allocates. It is the one operation a set can be unable to satisfy, and only a **static** extent ever is — a
+fixed capacity cannot come to hold a position outside it, so that is the precondition violation. A dynamic
+extent grows to hold it, `[set]` giving `insert` no way to fail. Growing has a limit of its own: `n + 1` must
+be a width the container can address, and `dynamic_bitset::max_size()` being `SIZE_MAX`, the one position
+ruled out is the one whose successor wraps to zero.
+
+Erasing stays total like `contains`: removing what is not there is the no-op returning zero that
+`std::set::erase` is.
+
+### unchecked-writes-in-views
+
+Reads and writes inside a view go through the **subscript**, not through `test()`, `set(n)` or `reset(n)`.
+The position is already in range by then, and those are the checked accessors whose throw would escape a
+`noexcept` — which `bugprone-exception-escape` is right to report. Every type in the vocabulary hands out a
+proxy that writes without checking.
+
+### the-proxy-recursion-trap
+
+`sequence_view` refuses the `operator[]` fallback for a type without `set(n, value)`. Were such a type's
+`operator[]` to return our own proxy, that proxy's assignment would land back in the fallback and **recurse
+until the stack is gone**.
+
+Where `set(n, value)` does exist the type is a concrete bitset, and its subscript is the unchecked way in —
+which is the one to take, the position being a precondition asserted just below, where `std::bitset::set` and
+`xstd::bitset::set` would check it again and throw out of a `noexcept`.
+
+### total-lookups-on-the-container
+
+Every `bit_finite_set` lookup is total over `key_type`, because `std::set`'s is: a key outside `[0, N)` names
+no element, so it answers *absent* rather than reaching the bit. `block_sequence` asserts `is_valid` on every
+position it accepts and offers no total spelling of any of these — that is the layering working, not a gap in
+it. **The precondition is the sequence's; the guard is the container's.**
+
+One of those guards stops a *write* rather than a read: without it an out-of-range key clears a bit in
+whatever follows the blocks.
+
+Two findings from running the suite against the unguarded header are worth keeping, because they are why it
+sweeps every width rather than one convenient one. **No single width exposed all six operations and no single
+key did either** — at N = 8 over `uint8_t` every one of them was clean for `key == N`, so a narrow
+single-block set proves nothing on its own. And `erase` was an out-of-bounds *write*, while `upper_bound`
+failed on its returned value rather than on memory at all: `find_next`'s `++n` wrapped before it could test
+the bound, so it answered with a real element where `end()` was due. That second one is why this stays a gate
+on the jobs that build without sanitizers.
+
+## Platform and tooling, continued
+
+### uint128-support
+
+`xstd::uint128` names a type on every compiler the matrix runs, but the library can only carry it where
+`<bit>` will: `detail::bits::intrin` forwards `countl_zero`, `countr_zero` and `popcount` straight through,
+and those take `std::unsigned_integral` alone. That is three separate facts.
+
+GCC and Clang have the built-in. libstdc++ and libc++ hand it the `numeric_limits` specialization that carries
+it into the concept **only outside `__STRICT_ANSI__`**, which is why the matrix compiles as `gnu++23`. And the
+Microsoft STL's `std::_Unsigned128` is a class type, so `<bit>` declines it whatever the mode — that block
+waits on an `xstd::countl_zero`, not on anything here.
+
+The condition worth testing is the concept, which no `#if` can spell, so the assert holds the macro to it in
+both directions. The day that seam grows its own implementation, or a new pairing lands on the matrix, the
+build says so there rather than at fifteen instantiation lists or, worse, nowhere.
+
+### exception-escape-nolints
+
+Nine primitives in `test/include/test/bitset/primitives.hpp` carry `NOLINT(bugprone-exception-escape)` on a
+`noexcept operator()`. Each guards on `pos < self.size()` and calls a member the standard specifies as
+throwing outside that width — `set`, `reset`, `flip`, `test`, `at` — checking in the other arm that it does
+throw.
+
+The check reads the callee's signature and cannot read the guard, so it reports every instantiation: 104 of
+them across the two `std_bitset` units. The `noexcept` is the claim being made — that a primitive answering
+about a position inside the bitset never throws — and it is what would fail the suite loudly were the guard
+ever wrong.
+
+### clang-tidy-false-positives
+
+Four findings are suppressed because the checker cannot see what makes them right:
+
+- `bugprone-unhandled-self-assignment` on the bitset proxy's `operator=`, which owns no storage: `b[i] = b[i]`
+  reads the bit and writes it back.
+- `bugprone-string-constructor` on `to_string`, which sees the `N == 0` instantiation where the string is
+  empty — which is what `bitset<0>::to_string()` returns.
+- `misc-const-correctness` on a variable assigned inside an `if constexpr (N > 0)` that the `N == 0`
+  instantiation discards; it sees only that one and asks for a `const` that would stop every other
+  instantiation compiling.
+- `misc-redundant-expression` on a reflexivity check, which cannot be written without naming the object twice.

--- a/design.md
+++ b/design.md
@@ -1,0 +1,298 @@
+# Design notes
+
+Why the code is shaped the way it is. The headers carry one line each; the reasoning lives here, and a
+one-line comment ending in `[design.md#anchor]` points at the section that explains it.
+
+Decisions still in flight are recorded on [#80](https://github.com/rhalbersma/xstd-bits/issues/80); this
+file holds what has landed.
+
+## Storage and containers
+
+### block-storage
+
+`block_storage` asks whether a range **is** blocks: a contiguous, sized range of unsigned integers.
+`std::array` and `std::vector` both qualify, and so does `std::inplace_vector` — a runtime width over
+static capacity, for free.
+
+`xstd::ranges::block_range` is the other side of the same word, and asks whether a bit container will
+**hand its blocks over**. Nothing models both, and no scope sees both unqualified.
+
+### the-one-vehicle
+
+`block_sequence<Blocks, N>` is the single storage vehicle. `N` is the width when that is a constant and
+`std::dynamic_extent` when the width is carried at run time.
+
+It owns the **unused-tail invariant** — every bit at or above `size()` reads zero — which is what makes
+whole-block comparison, popcount and the block-at-a-time scans mean anything at all.
+
+It has no iterators and no proxies. Those are readings, and a reading here would be picking one; it would
+also make `std::ranges` see a sequence of blocks rather than of bits.
+
+The hand-unrolled one- and two-block cases are where the static performance lives, so they stay
+compile-time branches. The general path they fall through to is written over `m_blocks` as a range, and
+therefore serves the dynamic width unchanged.
+
+### padding
+
+`static_used_bits` is the mask of the last block that is not padding. `num_bits` is `align_up(N)`, so
+`num_bits - N` lies in `[0, bits_per_block)` and the shift is always in range.
+
+Width zero is the one case that form cannot express — there is nothing to align up, so it reports no
+padding where in truth the sole block is all of it — and it gets a selection instead.
+
+**Naming zero rather than computing it matters on MSVC**, which constant-folds both arms of a `?:` and
+answers C4293, *shift count too big*, on the arm it discards. `used_bits()` is the same two cases at a
+run-time width.
+
+### default-construction
+
+A defaulted default constructor plus an NSDMI, rather than two constructors constrained on the extent:
+`std::vector` default-constructs empty, and the at-least-one-block invariant has to hold from the start.
+
+## Scans
+
+### inclusive-is-the-primitive
+
+Inclusive and exclusive name the only thing separating the two forward scans: whether `n` itself is a
+candidate. That is a property of the scan rather than of a reading, which is why this is not called
+`lower_bound` — that is the set reading's word, and this layer serves the sequence reading equally.
+`bit_finite_set::lower_bound` is where the set name belongs, and it maps here one for one.
+
+The inclusive form is the primitive and the exclusive one is derived, because the reverse does not close:
+
+```
+exclusive_find_next(n) == inclusive_find_next(n + 1)     for every n
+find_first()           == inclusive_find_next(0)
+```
+
+Exclusive-first would need `find_first() == exclusive_find_next(-1)`, and `size_t` has no such value —
+which is exactly why the container used to branch on `x == 0`. **Both derivations are `+ 1` and never
+`− 1`**, so nothing wraps at zero. Boost's `find_next` and libstdc++'s `_M_do_find_next` are both the
+exclusive form, correctly: their iteration idiom is `find_first()` then `find_next(i)`, which never needs
+the inclusive one.
+
+`n == size()` rather than `n >= size()`: the precondition is `n <= size()`, so `size()` is the only value
+the scan cannot start from. `is_valid` does not say this — it is `n < size()` — and `size()` is a
+legitimate argument, meaning "no such position".
+
+### offset-guards
+
+Neither forward scan guards on `offset != 0`. `>> 0` is the identity, so the masked test is correct at a
+block boundary too, and advancing past that block afterwards is right either way. Neither reference
+implementation guards it — boost shifts by `ind` then falls to `m_do_find_from(blk + 1)`, libstdc++ masks
+by `~0 << whichbit` then does `__i++` — and the guard skips no work: at offset 0 it merely moves the same
+test into the loop's first iteration. [#88](https://github.com/rhalbersma/xstd-bits/issues/88) measured it
+as pure cost.
+
+The reverse scan's `reverse_offset != 0` guard is a different question, and is not about the shift:
+`left_bit - offset` is in `[0, left_bit]`, so shifting is always in range and by zero is the identity. It
+is about which block the range scan must start at — at `index` when the whole block is in range, below it
+when the masked block came up empty. Naming the fallback block outright, as the two-block case does, makes
+that distinction disappear.
+
+### two-block-case
+
+At two blocks the tail is one named block rather than a range: the general walk costs more than the whole
+scan is worth at this width. `index` is a run-time value — `n` is — but the block count is not, so the
+second half is a test and not a loop.
+
+**Indexed rather than branched**: `m_blocks[index]`, not an `if` on `index`, so the common path is one
+computed load. Only when the starting block comes up empty does it matter which block we started in, and
+then only to decide whether block 1 is still ahead. Writing this as a branch instead cost **10 instructions
+at `-O3 -march=native`**.
+
+### index-walks
+
+A plain index walk rather than `drop` + `find_if`, and a descending one rather than `reverse` + `drop` +
+`find_if`. The iterator forms had to recover the block's position with `distance()`; the index *is* that
+position, so it never needed recovering. The reverse form composed two adaptors only to have `distance()`
+undo them.
+
+## Contracts
+
+### total-versus-precondition
+
+`block_sequence::exclusive_find_prev` is deliberately **not** total. Where `inclusive_find_next` answers
+`size()` for "nothing at or above", this one has a precondition instead, and that is the whole of why it is
+three instructions cheaper at every width: it never materializes a not-found value.
+
+It is safe because **reverse iteration supplies the guard the function does not**. `rend()` is
+`make_reverse_iterator(begin())`, and `std::reverse_iterator` stops there, so `operator--` is never applied
+at `begin()`. A hand-written loop gets no such help: the forward idiom terminates itself against `size()`,
+the reverse one runs off the bottom.
+
+Totality is the **container's** contract to keep, not this layer's to absorb —
+[#86](https://github.com/rhalbersma/xstd-bits/issues/86) settled the same division one layer down.
+
+### the-wraparound-assert
+
+`exclusive_find_prev` asserts `is_valid(n - 1)`, mirroring `exclusive_find_next`'s `is_valid(n)`: each says
+the position actually scanned from is one this container has.
+
+`n - 1` is that position here, and **the wraparound does the work at the bottom** — `0 - 1` is `SIZE_MAX`,
+which no width admits — so this states `1 <= n <= size()` without a second predicate. `is_valid` alone
+would be wrong: `size()` is a legitimate argument, meaning "from the end".
+
+### the-ceiling-principle
+
+The door's contract is the most efficient form, so `bit_traits<block_sequence<...>>` keeps the contracts
+`block_sequence` gives it rather than widening to the total ones the synthesised walks happen to provide.
+
+**A fallback synthesised for a foreign type may be more generous than the contract; it may not be less.**
+
+So `find_next` requires `is_valid(n)`, and `find_prev` requires a set position strictly below `n` — which
+`any()` does not establish, a container whose set positions all lie above `n` having none below it.
+
+## The door
+
+### opt-in
+
+`bit_traits` is declared and never defined. Adaptation is opt-in rather than guessed, so a type nobody has
+adapted is a compile error naming an incomplete type, rather than a silent fallback onto whatever members
+happened to answer. That is the failure per-operation member probing walks into, and the door's reason for
+existing.
+
+`bit_storage` gates the adaptors on the floor rather than on `bit_traits<Bits>` being complete, which turns
+*incomplete type* into *constraint not satisfied* — the error that names the real problem.
+
+### detection-by-absence
+
+`block_readable` is meaningful **only because nothing supplies a default**: a specialization that does not
+spell `block()` genuinely has no block access, so absence is an answer rather than an oversight.
+
+That is also why the walks are free functions and not a base class to inherit from. A base would satisfy
+the concept for every type, and the tier choice would collapse silently — and the same applies to the
+`requires` probes for `checked_test` and `checked_shift_left`, which read a missing entry as "this backend
+has none".
+
+### why-nested
+
+The walks live in `xstd::detail::bits` rather than in `xstd`, and the nesting is load-bearing.
+
+Since C++20 ([temp.names]/3, P0846) an unqualified `scan_first<Traits>(c)` parses its `<` as a template
+argument list and then performs ADL **with the explicit template arguments included** — so `std` and
+`boost`, the associated namespaces of the very types being adapted, would join the overload set.
+`[namespace.std]` bars *users* from adding to `std` but not implementations, and boost is under no such
+constraint.
+
+Down here nothing is visible unqualified from `xstd`, so the qualification is enforced by **scoping** rather
+than by remembering a prefix at every call site — which is what a class was previously substituting for.
+
+### block-writes
+
+`set_block` is the write side of `block()`, and deliberately not a trait entry: block writes are only ever
+needed on storage we control, and the unused tail is `block_sequence`'s to keep.
+
+## Orderings
+
+### two-readings-disagree
+
+"Lexicographic" is underspecified below the reading layer. Both readings are lexicographic; they order over
+different sequences, and **they disagree**:
+
+| `{0,1}` against `{1}` | compared as | result |
+|---|---|---|
+| set reading | ascending positions, `[0,1]` against `[1]` | `{0,1} < {1}` |
+| sequence reading | bools from index 0, `[1,1,0…]` against `[0,1,0…]` | `{0,1} > {1}` |
+
+A door serving three readings cannot hold one of their orderings without choosing for its callers, so it
+holds neither under that name. `set_three_way` and `sequence_three_way` are each owned by the view whose
+reading defines them.
+
+### the-ordering-invariant
+
+Every ordering in the library satisfies
+
+```cpp
+std::lexicographical_compare_three_way(a.begin(), a.end(), b.begin(), b.end()) == (a <=> b)
+```
+
+which is stated on the **reading**, never on the storage: `block_sequence` has no `begin()`/`end()`, and
+`boost::dynamic_bitset` has no public iterators, so it cannot be written against a backend at all.
+
+Two things follow. `basic_bitset` has no `operator<=>` because it does not iterate — the existing "no
+iteration and no `<=>` here by design" is a consequence rather than a separate rule. And magnitude ordering
+(boost's `operator<`, a top-down block walk) is the lexicographic order of *reverse* iteration, so no
+forward-iterating container obeying the invariant can have it; boost escapes only by having no iterators to
+be constrained by.
+
+Where a specialization offers nothing faster, the default is that standard algorithm over the reading's own
+iterators — so the default cannot disagree with the specification, and only an optimization can.
+
+## Coverage
+
+### per-instantiation-slots
+
+gcovr counts branch slots **per template instantiation and never merges them**. A loop that a one-block
+instantiation can never enter is a branch never taken, whatever every other instantiation does.
+
+So a degenerate width does not get an unreachable loop; it gets **different code**, via `if constexpr` on
+`static_num_blocks == 1` and `== 2` in `block_sequence`, and on `static_block_count` and `extent == 0` in
+the walks. `static_block_count` is derived from `extent` rather than declared for exactly this reason:
+nothing new has to be supplied to know it, since `block_readable`'s contract already fixes the layout.
+
+The same gate is why a cursor lives inside the walk it belongs to rather than beside the block index: at one
+block the walk is discarded, and a cursor declared outside would never be written — which
+`misc-const-correctness` reads, correctly, as a variable that should have been `const`.
+
+### while-not-for
+
+Two descending walks are shaped as a `while` rather than a `for` with a fall-through, deliberately. The
+precondition guarantees a set bit at or below, so a loop that could run out would carry an exit branch no
+test can take — exactly what the coverage gate catches, and what `find_if` hid by keeping that branch inside
+the standard library. Written as a `while`, both branches of the condition are exercised: empty blocks are
+skipped, a non-empty one ends it.
+
+### one-function-per-tier
+
+Each tier of each scan is its own function. `readability-function-cognitive-complexity` counts `if constexpr`
+like any other branch, and the guards that satisfy the coverage gate put both scans over the threshold when
+the tier choice shares the body. The tier was the seam anyway.
+
+## Platform workarounds
+
+### libcxx-views-take
+
+`all_but_last_are_ones` uses an iterator pair rather than `views::take`.
+
+libc++ 18 — Xcode 16.4 on the matrix — writes the return type of `views::take`'s `iota_view` fast path as
+`decltype(iota_view(*begin(rng), ...))`, so forming the adaptor's `operator|` over a range of 128-bit blocks
+instantiates an `iota_view` over that block type, however unlike an `iota_view` a `std::vector` is. That
+trips libc++'s *bigger than integer-like type* `static_assert`, which is a hard error rather than a
+substitution failure.
+
+`views::drop`, `views::reverse`, `views::transform` and `views::zip` are all clear. Only `take` carries it,
+and only until Xcode 16.4 leaves the matrix.
+
+### gcc-array-bounds
+
+The shift operators assert `n_blocks <= last_block()`, which is implied by the `is_valid(n)` above it. It is
+stated again because GCC does not carry the range through `xstd::div`'s aggregate return: without it,
+`-Warray-bounds` reports the memmove inside `shift_right` at `-O1` and `-O2` whenever asserts are live.
+
+No CMake build type is that combination — Debug is `-O0`, and the optimized ones carry `NDEBUG` — but
+`-O2 -g` is one command away, and the bound is worth saying in any case.
+
+### uint128-printing
+
+Never `BOOST_CHECK_EQUAL` on a block-typed value. It prints its operands on failure, and no standard library
+defines `operator<<` for `__int128`, so a `graded_extents` sweep that includes `xstd::uint128` fails to
+compile on libc++ where it happens to compile on libstdc++. `BOOST_CHECK` compares without printing.
+
+## Naming
+
+### test-not-subscript
+
+`block_sequence::test` rather than `operator[]`: this reads and cannot be written through. `std::bitset`'s
+`operator[]` returns an assignable proxy and this returns `bool`, so the subscript spelling would promise an
+assignment that does not compile.
+
+The writable proxy belongs to the containers above, which is also where the checked reading lives —
+`std::bitset::test` throws where this asserts, a difference the door states as `unchecked_test` rather than
+one this name should try to carry.
+
+### qualifier-prefixes
+
+Contract qualifiers are prefixes, not suffixes — `inclusive_find_next`, `exclusive_find_prev`,
+`unchecked_test`, `checked_shift_left` — so that the contract reads before the operation and the cheaper
+form cannot be called by mistake.

--- a/include/xstd/bits/bit_finite_set.hpp
+++ b/include/xstd/bits/bit_finite_set.hpp
@@ -213,8 +213,7 @@ public:
         constexpr auto erase(const key_type& x) noexcept
                 -> size_type
         {
-                // The one guard here that stops a write rather than a read: without it an
-                // out-of-range key clears a bit in whatever follows the blocks.
+                // The one guard stopping a write: without it an out-of-range key clears a foreign bit. [design.md#total-lookups-on-the-container]
                 return x < N and m_bits.erase(x);
         }
 
@@ -259,12 +258,7 @@ public:
         [[nodiscard]] constexpr auto   key_comp() const noexcept -> key_compare   { return {}; }
         [[nodiscard]] constexpr auto value_comp() const noexcept -> value_compare { return {}; }
 
-        // set operations
-        // Every lookup below is total over key_type, because std::set's is: a key outside
-        // [0, N) names no element, so it answers "absent" rather than reaching the bit.
-        // block_sequence asserts is_valid on every position it accepts and offers no total
-        // spelling of any of these -- that is the layering working, not a gap in it. The
-        // precondition is the sequence's, the guard is the container's.
+        // set operations, every one total over key_type as std::set's are. [design.md#total-lookups-on-the-container]
         [[nodiscard]] constexpr auto contains(const key_type& x) const noexcept -> bool      { return x < N and m_bits.test(x); }
         [[nodiscard]] constexpr auto count   (const key_type& x) const noexcept -> size_type { return contains(x);         }
 
@@ -275,10 +269,7 @@ public:
                 }
                 return self.end();
         }
-        // The bound is inclusive_find_next at x, and its exclusive twin one past it. The x ? :
-        // that used to stand here was find_next's exclusivity showing through: x - 1 wraps at
-        // 0, so the 0 case had to be spelled separately. An inclusive primitive has no such
-        // seam, so the two bounds now differ by the + 1 that actually separates them.
+        // The two bounds differ by the + 1 that separates them, an inclusive primitive having no seam at 0.
         [[nodiscard]] constexpr auto lower_bound(this auto&& self, const key_type& x) noexcept -> iterator                      { return { &self, x < N ? self.m_bits.inclusive_find_next(x    ) : N }; }
         [[nodiscard]] constexpr auto upper_bound(this auto&& self, const key_type& x) noexcept -> iterator                      { return { &self, x < N ? self.m_bits.inclusive_find_next(x + 1) : N }; }
         [[nodiscard]] constexpr auto equal_range(this auto&& self, const key_type& x) noexcept -> std::pair<iterator, iterator> { return { self.lower_bound(x), self.upper_bound(x) };               }

--- a/include/xstd/bits/bit_traits.hpp
+++ b/include/xstd/bits/bit_traits.hpp
@@ -14,26 +14,14 @@
 #include <span>                                    // dynamic_extent
 #include <type_traits>                             // remove_cvref_t
 
-// The one door between a bit container and the readings built on it. Everything above this
-// header asks bit_traits<Bits> and never the type itself, which is what lets a std::bitset, a
-// boost::dynamic_bitset and our own block_sequence wear the same three readings without any of
-// them knowing the others exist.
+// The one door: everything above asks bit_traits<Bits> and never the type itself. [design.md#the-door]
 namespace xstd {
 
-// Declared, never defined: adaptation is opt-in, never guessed. A type nobody has adapted is a
-// compile error naming an incomplete type rather than a silent fallback onto whatever members
-// happened to answer -- which is the failure that per-operation member probing walks into, and
-// this file's reason for existing. See bit_storage below for the error that reads better.
+// Declared, never defined: an unadapted type is an error, not a silent fallback. [design.md#opt-in]
 template<class Bits>
 struct bit_traits;
 
-// Whether a trait offers block access at all. std::bitset on libc++ and boost::dynamic_bitset
-// do not, so their scans take the element-wise tier; ours and libstdc++'s std::bitset do.
-//
-// Meaningful only because nothing supplies a default: a specialization that does not spell
-// block() genuinely has no block access, so absence is an answer rather than an oversight. That
-// is why the fallbacks below are free functions and not a base class -- a base would satisfy
-// this concept for every type, and the tier choice would collapse.
+// Whether the trait offers block access; libc++'s std::bitset and boost do not. [design.md#detection-by-absence]
 template<class Traits, class Bits>
 concept block_readable =
         requires (Bits const& c, std::size_t i)
@@ -45,29 +33,10 @@ concept block_readable =
 
 } // namespace xstd
 
-// The walks a specialization calls for whatever it has no native spelling of, so adapting a type
-// is never all-or-nothing. Free functions in the namespace that already holds countl_zero,
-// countr_zero and popcount -- the intrinsics these are written in terms of -- rather than members
-// of a scan class or a base to inherit from. Flat, and one public name above: bit_traits.
-//
-// The nesting is load-bearing rather than decorative. Since C++20 an unqualified
-// scan_first<Traits>(c) parses its '<' as a template argument list and then goes through ADL,
-// explicit arguments included -- so std and boost, the associated namespaces of the very types
-// being adapted, would join the overload set. [namespace.std] bars users from adding to std but
-// not implementations, and boost is under no such constraint. Down here that cannot arise: these
-// names are not visible unqualified from xstd, so every call site must write the qualification
-// out and the hazard is closed by scoping rather than by remembering a prefix.
+// Free functions so block_readable stays answerable, nested so no unqualified call reaches ADL. [design.md#why-nested]
 namespace xstd::detail::bits {
 
-// How many blocks a trait's storage has, when the type settles it. Derived rather than declared:
-// extent is already in the floor, and block access's contract fixes the layout -- block i holds
-// [i * digits, (i + 1) * digits) -- so nothing new has to be supplied to know this.
-//
-// It exists for the coverage gate rather than for speed. gcovr counts branch slots per template
-// instantiation and does not merge them, so a loop that a one-block instantiation can never enter
-// is a branch never taken, whatever every other instantiation does. block_sequence answers the
-// same gate the same way, with if constexpr on static_num_blocks == 1 and == 2: the degenerate
-// case does not get an unreachable loop, it gets different code.
+// Derived, not declared; here so a degenerate width gets different code. [design.md#per-instantiation-slots]
 template<class Traits, class Block>
 [[nodiscard]] consteval auto static_block_count() noexcept
         -> std::size_t
@@ -80,10 +49,7 @@ template<class Traits, class Block>
         }
 }
 
-// Each tier of each scan gets its own function. Not decomposition for its own sake:
-// readability-function-cognitive-complexity counts if constexpr like any other branch, and the
-// guards that satisfy the coverage gate put both scans over the threshold when the tier choice
-// sits in the same body. The tier is where the seam was anyway.
+// One function per tier: a shared body exceeds the complexity threshold. [design.md#one-function-per-tier]
 
 // The last set position at or below i, block at a time.
 template<class Traits, class Bits>
@@ -97,18 +63,11 @@ template<class Traits, class Bits>
         auto const start = i / digits;
         auto const offset = i % digits;
 
-        // Shifted up rather than masked, so the bit at offset lands on the top one and
-        // countl_zero measures the distance back down. At offset == left_bit that is a
-        // shift by zero, the identity, so the boundary needs no arm of its own -- the
-        // mirror of scan_next_by_block's missing offset guard.
+        // Shifted up rather than masked so countl_zero measures back down; at left_bit that shift is zero.
         if (auto const block = static_cast<block_type>(Traits::block(c, start) << (left_bit - offset)); block != block_type{}) {
                 return i - detail::bits::countl_zero(block);
         }
-        // Only where a lower block can exist: at one block this walk is unreachable code
-        // carrying a branch no instantiation could take. The cursor lives in here rather
-        // than beside start, because at one block the walk is discarded and a cursor
-        // declared outside would never be written -- which misc-const-correctness reads,
-        // correctly, as a variable that should have been const.
+        // Guarded, cursor inside: one block makes both unreachable. [design.md#per-instantiation-slots]
         if constexpr (static_block_count<Traits, block_type>() != 1UZ) {
                 auto index = start;
                 while (index-- != 0UZ) {
@@ -125,10 +84,8 @@ template<class Traits, class Bits>
 [[nodiscard]] constexpr auto scan_prev_by_element(Bits const& c, std::size_t i) noexcept
         -> std::size_t
 {
+        // One test, not a loop: a loop's exit arm is untakeable here. [design.md#per-instantiation-slots]
         if constexpr (Traits::extent == 1UZ) {
-                // A single position: the descent below would have nowhere to step from,
-                // so it is written as the one test it reduces to rather than as a loop
-                // whose exit arm no instantiation could take.
                 return Traits::at(c, i) ? i : Traits::size(c);
         } else {
                 for (;;) {
@@ -154,13 +111,11 @@ template<class Traits, class Bits>
         auto const start = n / digits;
         auto const offset = n % digits;
 
-        // No offset != 0 guard: >> 0 is the identity, so the boundary case needs no arm
-        // of its own. #88 measured the guard as pure cost.
+        // No offset != 0 guard: >> 0 is the identity, and #88 measured it as pure cost. [design.md#offset-guards]
         if (auto const block = static_cast<block_type>(Traits::block(c, start) >> offset); block != block_type{}) {
                 return n + detail::bits::countr_zero(block);
         }
-        // The mirror of scan_prev_by_block's guard: at one block there is no later block to
-        // walk to, and the cursor belongs to the walk for the same reason it does there.
+        // The mirror of scan_prev_by_block's guard, cursor included, for the same two reasons.
         if constexpr (static_block_count<Traits, block_type>() != 1UZ) {
                 for (auto index = start + 1UZ, blocks = Traits::num_blocks(c); index < blocks; ++index) {
                         if (auto const block = Traits::block(c, index); block != block_type{}) {
@@ -185,9 +140,7 @@ template<class Traits, class Bits>
         return size;
 }
 
-// The first set position at or above n: the primitive the two forward scans derive from,
-// exactly as block_sequence's inclusive_find_next is. Both derivations are + 1 and never
-// - 1, which is what lets scan_first name its own extreme without size_t wrapping at zero.
+// The primitive both forward scans derive from, by + 1 and never - 1. [design.md#inclusive-is-the-primitive]
 template<class Traits, class Bits>
 [[nodiscard]] constexpr auto scan_inclusive_next(Bits const& c, std::size_t n) noexcept
         -> std::size_t
@@ -207,8 +160,7 @@ template<class Traits, class Bits>
         }
 }
 
-// The first set position, or size() if there is none. Total, like every scan here: this
-// is the layer that answers, not the layer with preconditions.
+// The first set position, or size(). Total, like every scan here. [design.md#total-versus-precondition]
 template<class Traits, class Bits>
 [[nodiscard]] constexpr auto scan_first(Bits const& c) noexcept
         -> std::size_t
@@ -216,9 +168,7 @@ template<class Traits, class Bits>
         return scan_inclusive_next<Traits>(c, 0UZ);
 }
 
-// One past the last position, which for every reading is the width: the end iterator's
-// position, not a scan at all. Named alongside the scans because callers ask for it in
-// the same breath.
+// One past the last position, which for every reading is the width: not a scan, but asked for alongside them.
 template<class Traits, class Bits>
 [[nodiscard]] constexpr auto scan_last(Bits const& c) noexcept
         -> std::size_t
@@ -226,8 +176,7 @@ template<class Traits, class Bits>
         return Traits::size(c);
 }
 
-// The first set position strictly above n, mirroring block_sequence::exclusive_find_next
-// and boost's find_next. Total in n: a position at or past the width has nothing above it.
+// Strictly above n, and total where block_sequence's twin is not. [design.md#total-versus-precondition]
 template<class Traits, class Bits>
 [[nodiscard]] constexpr auto scan_next(Bits const& c, std::size_t n) noexcept
         -> std::size_t
@@ -236,23 +185,13 @@ template<class Traits, class Bits>
         return n >= size ? size : scan_inclusive_next<Traits>(c, n + 1UZ);
 }
 
-// The last set position strictly below n, or size() if there is none.
-//
-// Unlike block_sequence::exclusive_find_prev this is total rather than precondition-guarded:
-// that one may demand any() because reverse iteration supplies the guard, and a fallback
-// synthesised for a foreign type has no such caller to lean on.
-//
-// The block tier is not an optimization here so much as a complexity fix. Element-wise, one
-// step is O(N) and a full reverse traversal is O(N^2) -- which is exactly what #80 measures
-// boost::dynamic_bitset's missing find_prev to cost. A type that hands over its blocks does
-// not pay it.
+// The last set position below n, total: a fallback has no reverse iteration to guard it. [design.md#total-versus-precondition]
 template<class Traits, class Bits>
 [[nodiscard]] constexpr auto scan_prev(Bits const& c, std::size_t n) noexcept
         -> std::size_t
 {
         auto const size = Traits::size(c);
-        // A width fixed at zero holds nothing below anything, and saying so here rather
-        // than at run time leaves the scans with no arm that cannot be reached.
+        // A zero width holds nothing below anything, said here to leave no unreachable arm. [design.md#per-instantiation-slots]
         if constexpr (Traits::extent == 0UZ) {
                 return size;
         } else {
@@ -260,6 +199,7 @@ template<class Traits, class Bits>
                 if (i == 0UZ) {
                         return size;
                 }
+                // The tier is a complexity fix, not an optimization: element-wise reverse traversal is O(N^2).
                 if constexpr (block_readable<Traits, Bits>) {
                         return scan_prev_by_block<Traits>(c, i - 1UZ);
                 } else {
@@ -268,8 +208,7 @@ template<class Traits, class Bits>
         }
 }
 
-// How many positions are set. The block tier is the whole point: popcount per word
-// rather than a test per bit.
+// How many positions are set; the block tier is the whole point, popcount per word rather than a test per bit.
 template<class Traits, class Bits>
 [[nodiscard]] constexpr auto scan_count(Bits const& c) noexcept
         -> std::size_t
@@ -295,27 +234,19 @@ template<class Traits, class Bits>
 
 namespace xstd {
 
-// The floor for wrappability: a width, and an indexed read. Everything else -- blocks, native
-// scans, a native ordering -- is an optimization tier a specialization may or may not supply.
-//
-// Gating the adaptors on this rather than on bit_traits<Bits> being complete is what turns
-// "incomplete type" into "constraint not satisfied", which names the actual problem.
+// The floor, gated as a concept so an unadapted type reads "constraint not satisfied". [design.md#opt-in]
 template<class Bits>
 concept bit_storage =
         requires (Bits const& c, std::size_t n)
         {
-                // extent is part of the floor rather than an extra: every adapter states its
-                // width policy, dynamic_extent included, which is what lets static_bit_extent
-                // below read it without first proving it exists.
+                // Inside the floor, not beside it, so static_bit_extent can read it without proving it exists.
                 { bit_traits<Bits>::extent   } -> std::convertible_to<std::size_t>;
                 { bit_traits<Bits>::size(c)  } -> std::convertible_to<std::size_t>;
                 { bit_traits<Bits>::at(c, n) } -> std::convertible_to<bool>;
         }
 ;
 
-// How many positions a bit sequence has when the type settles it, so a static width reaches the
-// readings as a constant expression. Replaces the bit_extent variable template: one door, and
-// the extent comes through it like everything else.
+// A static width reaching the readings as a constant expression; replaces the bit_extent variable template.
 template<class Bits>
 concept static_bit_extent = bit_storage<Bits> and bit_traits<Bits>::extent != std::dynamic_extent;
 

--- a/include/xstd/bits/bit_traits.hpp
+++ b/include/xstd/bits/bit_traits.hpp
@@ -8,7 +8,6 @@
 
 #include <xstd/bits/detail/intrin.hpp>             // countl_zero, countr_zero, popcount
 #include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer
-#include <compare>                                 // strong_ordering
 #include <concepts>                                // convertible_to
 #include <cstddef>                                 // size_t
 #include <limits>                                  // digits
@@ -30,6 +29,11 @@ struct bit_traits;
 
 // Whether a trait offers block access at all. std::bitset on libc++ and boost::dynamic_bitset
 // do not, so their scans take the element-wise tier; ours and libstdc++'s std::bitset do.
+//
+// Meaningful only because nothing supplies a default: a specialization that does not spell
+// block() genuinely has no block access, so absence is an answer rather than an oversight. That
+// is why the fallbacks below are free functions and not a base class -- a base would satisfy
+// this concept for every type, and the tier choice would collapse.
 template<class Traits, class Bits>
 concept block_readable =
         requires (Bits const& c, std::size_t i)
@@ -39,8 +43,24 @@ concept block_readable =
         }
 ;
 
+} // namespace xstd
+
+// The walks a specialization calls for whatever it has no native spelling of, so adapting a type
+// is never all-or-nothing. Free functions in the namespace that already holds countl_zero,
+// countr_zero and popcount -- the intrinsics these are written in terms of -- rather than members
+// of a scan class or a base to inherit from. Flat, and one public name above: bit_traits.
+//
+// The nesting is load-bearing rather than decorative. Since C++20 an unqualified
+// scan_first<Traits>(c) parses its '<' as a template argument list and then goes through ADL,
+// explicit arguments included -- so std and boost, the associated namespaces of the very types
+// being adapted, would join the overload set. [namespace.std] bars users from adding to std but
+// not implementations, and boost is under no such constraint. Down here that cannot arise: these
+// names are not visible unqualified from xstd, so every call site must write the qualification
+// out and the hazard is closed by scoping rather than by remembering a prefix.
+namespace xstd::detail::bits {
+
 // How many blocks a trait's storage has, when the type settles it. Derived rather than declared:
-// extent is already in the floor, and block_access's contract fixes the layout -- block i holds
+// extent is already in the floor, and block access's contract fixes the layout -- block i holds
 // [i * digits, (i + 1) * digits) -- so nothing new has to be supplied to know this.
 //
 // It exists for the coverage gate rather than for speed. gcovr counts branch slots per template
@@ -60,258 +80,220 @@ template<class Traits, class Block>
         }
 }
 
-// The fallbacks a specialization calls for whatever it has no native spelling of, so adapting a
-// type is never all-or-nothing.
-//
-// Static members of a class template rather than free functions, and that is load-bearing.
-// Since C++20 an unqualified scan_first<Traits>(c) parses its '<' as a template argument list
-// and then goes through ADL, explicit arguments included -- so std and boost, the associated
-// namespaces of the very types being adapted, would join the overload set. [namespace.std] bars
-// users from adding to std but not implementations, and boost is under no such constraint.
-// Qualifying every call would close it, but the safety would live in remembering a prefix at
-// every site. Member lookup through a qualified-id never consults associated namespaces, so
-// there is no unqualified call here to hijack in the first place.
-//
-// It is also the shape block_access, set_find and sequence_find already had, so the fold keeps
-// one idiom rather than introducing free functions as a second.
-template<class Traits>
-struct bit_scan
+// Each tier of each scan gets its own function. Not decomposition for its own sake:
+// readability-function-cognitive-complexity counts if constexpr like any other branch, and the
+// guards that satisfy the coverage gate put both scans over the threshold when the tier choice
+// sits in the same body. The tier is where the seam was anyway.
+
+// The last set position at or below i, block at a time.
+template<class Traits, class Bits>
+[[nodiscard]] constexpr auto scan_prev_by_block(Bits const& c, std::size_t i) noexcept
+        -> std::size_t
 {
-private:
-        // Each tier of each scan gets its own function. Not decomposition for its own sake:
-        // readability-function-cognitive-complexity counts if constexpr like any other branch,
-        // and the guards that satisfy the coverage gate put both scans over the threshold when
-        // the tier choice sits in the same body. The tier is where the seam was anyway.
+        using block_type = std::remove_cvref_t<decltype(Traits::block(c, 0UZ))>;
+        constexpr auto digits = static_cast<std::size_t>(std::numeric_limits<block_type>::digits);
+        constexpr auto left_bit = digits - 1UZ;
 
-        // The last set position at or below i, block at a time.
-        template<class Bits>
-        [[nodiscard]] static constexpr auto prev_by_block(Bits const& c, std::size_t i) noexcept
-                -> std::size_t
-        {
-                using block_type = std::remove_cvref_t<decltype(Traits::block(c, 0UZ))>;
-                constexpr auto digits = static_cast<std::size_t>(std::numeric_limits<block_type>::digits);
-                constexpr auto left_bit = digits - 1UZ;
+        auto const start = i / digits;
+        auto const offset = i % digits;
 
-                auto const start = i / digits;
-                auto const offset = i % digits;
-
-                // Shifted up rather than masked, so the bit at offset lands on the top one and
-                // countl_zero measures the distance back down. At offset == left_bit that is a
-                // shift by zero, the identity, so the boundary needs no arm of its own -- the
-                // mirror of next_by_block's missing offset guard.
-                if (auto const block = static_cast<block_type>(Traits::block(c, start) << (left_bit - offset)); block != block_type{}) {
-                        return i - detail::bits::countl_zero(block);
-                }
-                // Only where a lower block can exist: at one block this walk is unreachable code
-                // carrying a branch no instantiation could take. The cursor lives in here rather
-                // than beside start, because at one block the walk is discarded and a cursor
-                // declared outside would never be written -- which misc-const-correctness reads,
-                // correctly, as a variable that should have been const.
-                if constexpr (static_block_count<Traits, block_type>() != 1UZ) {
-                        auto index = start;
-                        while (index-- != 0UZ) {
-                                if (auto const block = Traits::block(c, index); block != block_type{}) {
-                                        return (digits * index) + left_bit - detail::bits::countl_zero(block);
-                                }
-                        }
-                }
-                return Traits::size(c);
+        // Shifted up rather than masked, so the bit at offset lands on the top one and
+        // countl_zero measures the distance back down. At offset == left_bit that is a
+        // shift by zero, the identity, so the boundary needs no arm of its own -- the
+        // mirror of scan_next_by_block's missing offset guard.
+        if (auto const block = static_cast<block_type>(Traits::block(c, start) << (left_bit - offset)); block != block_type{}) {
+                return i - detail::bits::countl_zero(block);
         }
-
-        // The same, one position at a time, for a type that keeps its blocks to itself.
-        template<class Bits>
-        [[nodiscard]] static constexpr auto prev_by_element(Bits const& c, std::size_t i) noexcept
-                -> std::size_t
-        {
-                if constexpr (Traits::extent == 1UZ) {
-                        // A single position: the descent below would have nowhere to step from,
-                        // so it is written as the one test it reduces to rather than as a loop
-                        // whose exit arm no instantiation could take.
-                        return Traits::at(c, i) ? i : Traits::size(c);
-                } else {
-                        for (;;) {
-                                if (Traits::at(c, i)) {
-                                        return i;
-                                }
-                                if (i == 0UZ) {
-                                        return Traits::size(c);
-                                }
-                                --i;
+        // Only where a lower block can exist: at one block this walk is unreachable code
+        // carrying a branch no instantiation could take. The cursor lives in here rather
+        // than beside start, because at one block the walk is discarded and a cursor
+        // declared outside would never be written -- which misc-const-correctness reads,
+        // correctly, as a variable that should have been const.
+        if constexpr (static_block_count<Traits, block_type>() != 1UZ) {
+                auto index = start;
+                while (index-- != 0UZ) {
+                        if (auto const block = Traits::block(c, index); block != block_type{}) {
+                                return (digits * index) + left_bit - detail::bits::countl_zero(block);
                         }
                 }
         }
+        return Traits::size(c);
+}
 
-        // The first set position at or above n, block at a time.
-        template<class Bits>
-        [[nodiscard]] static constexpr auto next_by_block(Bits const& c, std::size_t n) noexcept
-                -> std::size_t
-        {
-                using block_type = std::remove_cvref_t<decltype(Traits::block(c, 0UZ))>;
-                constexpr auto digits = static_cast<std::size_t>(std::numeric_limits<block_type>::digits);
-
-                auto const start = n / digits;
-                auto const offset = n % digits;
-
-                // No offset != 0 guard: >> 0 is the identity, so the boundary case needs no arm
-                // of its own. #88 measured the guard as pure cost.
-                if (auto const block = static_cast<block_type>(Traits::block(c, start) >> offset); block != block_type{}) {
-                        return n + detail::bits::countr_zero(block);
-                }
-                // The mirror of prev_by_block's guard: at one block there is no later block to
-                // walk to, and the cursor belongs to the walk for the same reason it does there.
-                if constexpr (static_block_count<Traits, block_type>() != 1UZ) {
-                        for (auto index = start + 1UZ, blocks = Traits::num_blocks(c); index < blocks; ++index) {
-                                if (auto const block = Traits::block(c, index); block != block_type{}) {
-                                        return (digits * index) + detail::bits::countr_zero(block);
-                                }
-                        }
-                }
-                return Traits::size(c);
-        }
-
-        // The same, one position at a time.
-        template<class Bits>
-        [[nodiscard]] static constexpr auto next_by_element(Bits const& c, std::size_t n) noexcept
-                -> std::size_t
-        {
-                auto const size = Traits::size(c);
-                for (auto i = n; i < size; ++i) {
+// The same, one position at a time, for a type that keeps its blocks to itself.
+template<class Traits, class Bits>
+[[nodiscard]] constexpr auto scan_prev_by_element(Bits const& c, std::size_t i) noexcept
+        -> std::size_t
+{
+        if constexpr (Traits::extent == 1UZ) {
+                // A single position: the descent below would have nowhere to step from,
+                // so it is written as the one test it reduces to rather than as a loop
+                // whose exit arm no instantiation could take.
+                return Traits::at(c, i) ? i : Traits::size(c);
+        } else {
+                for (;;) {
                         if (Traits::at(c, i)) {
                                 return i;
                         }
-                }
-                return size;
-        }
-
-public:
-        // The first set position, or size() if there is none. Total, like every scan here: this
-        // is the layer that answers, not the layer with preconditions.
-        template<class Bits>
-        [[nodiscard]] static constexpr auto first(Bits const& c) noexcept
-                -> std::size_t
-        {
-                return inclusive_next(c, 0UZ);
-        }
-
-        // One past the last position, which for every reading is the width: the end iterator's
-        // position, not a scan at all. Named alongside the scans because callers ask for it in
-        // the same breath.
-        template<class Bits>
-        [[nodiscard]] static constexpr auto last(Bits const& c) noexcept
-                -> std::size_t
-        {
-                return Traits::size(c);
-        }
-
-        // The first set position strictly above n, mirroring block_sequence::exclusive_find_next
-        // and boost's find_next. Total in n: a position at or past the width has nothing above it.
-        template<class Bits>
-        [[nodiscard]] static constexpr auto next(Bits const& c, std::size_t n) noexcept
-                -> std::size_t
-        {
-                auto const size = Traits::size(c);
-                return n >= size ? size : inclusive_next(c, n + 1UZ);
-        }
-
-        // The last set position strictly below n, or size() if there is none.
-        //
-        // Unlike block_sequence::exclusive_find_prev this is total rather than
-        // precondition-guarded: that one may demand any() because reverse iteration supplies the
-        // guard, and a fallback synthesised for a foreign type has no such caller to lean on.
-        //
-        // The block tier is not an optimization here so much as a complexity fix. Element-wise,
-        // one step is O(N) and a full reverse traversal is O(N^2) -- which is exactly what #80
-        // measures boost::dynamic_bitset's missing find_prev to cost. A type that hands over its
-        // blocks does not pay it.
-        template<class Bits>
-        [[nodiscard]] static constexpr auto prev(Bits const& c, std::size_t n) noexcept
-                -> std::size_t
-        {
-                auto const size = Traits::size(c);
-                // A width fixed at zero holds nothing below anything, and saying so here rather
-                // than at run time leaves the scans with no arm that cannot be reached.
-                if constexpr (Traits::extent == 0UZ) {
-                        return size;
-                } else {
-                        auto const i = n < size ? n : size;
                         if (i == 0UZ) {
-                                return size;
+                                return Traits::size(c);
                         }
-                        if constexpr (block_readable<Traits, Bits>) {
-                                return prev_by_block(c, i - 1UZ);
-                        } else {
-                                return prev_by_element(c, i - 1UZ);
+                        --i;
+                }
+        }
+}
+
+// The first set position at or above n, block at a time.
+template<class Traits, class Bits>
+[[nodiscard]] constexpr auto scan_next_by_block(Bits const& c, std::size_t n) noexcept
+        -> std::size_t
+{
+        using block_type = std::remove_cvref_t<decltype(Traits::block(c, 0UZ))>;
+        constexpr auto digits = static_cast<std::size_t>(std::numeric_limits<block_type>::digits);
+
+        auto const start = n / digits;
+        auto const offset = n % digits;
+
+        // No offset != 0 guard: >> 0 is the identity, so the boundary case needs no arm
+        // of its own. #88 measured the guard as pure cost.
+        if (auto const block = static_cast<block_type>(Traits::block(c, start) >> offset); block != block_type{}) {
+                return n + detail::bits::countr_zero(block);
+        }
+        // The mirror of scan_prev_by_block's guard: at one block there is no later block to
+        // walk to, and the cursor belongs to the walk for the same reason it does there.
+        if constexpr (static_block_count<Traits, block_type>() != 1UZ) {
+                for (auto index = start + 1UZ, blocks = Traits::num_blocks(c); index < blocks; ++index) {
+                        if (auto const block = Traits::block(c, index); block != block_type{}) {
+                                return (digits * index) + detail::bits::countr_zero(block);
                         }
                 }
         }
+        return Traits::size(c);
+}
 
-        // How many positions are set. The block tier is the whole point: popcount per word
-        // rather than a test per bit.
-        template<class Bits>
-        [[nodiscard]] static constexpr auto count(Bits const& c) noexcept
-                -> std::size_t
-        {
-                if constexpr (Traits::extent == 0UZ) {
-                        return 0UZ;
-                } else if constexpr (block_readable<Traits, Bits>) {
-                        auto n = 0UZ;
-                        for (auto i = 0UZ, blocks = Traits::num_blocks(c); i < blocks; ++i) {
-                                n += detail::bits::popcount(Traits::block(c, i));
-                        }
-                        return n;
-                } else {
-                        auto n = 0UZ;
-                        for (auto i = 0UZ, size = Traits::size(c); i < size; ++i) {
-                                n += Traits::at(c, i) ? 1UZ : 0UZ;
-                        }
-                        return n;
+// The same, one position at a time.
+template<class Traits, class Bits>
+[[nodiscard]] constexpr auto scan_next_by_element(Bits const& c, std::size_t n) noexcept
+        -> std::size_t
+{
+        auto const size = Traits::size(c);
+        for (auto i = n; i < size; ++i) {
+                if (Traits::at(c, i)) {
+                        return i;
                 }
         }
+        return size;
+}
 
-        // The first set position at or above n: the primitive the two forward scans derive from,
-        // exactly as block_sequence's inclusive_find_next is. Both derivations are + 1 and never
-        // - 1, which is what lets first() name its own extreme without size_t wrapping at zero.
-        template<class Bits>
-        [[nodiscard]] static constexpr auto inclusive_next(Bits const& c, std::size_t n) noexcept
-                -> std::size_t
-        {
-                auto const size = Traits::size(c);
-                if constexpr (Traits::extent == 0UZ) {
+// The first set position at or above n: the primitive the two forward scans derive from,
+// exactly as block_sequence's inclusive_find_next is. Both derivations are + 1 and never
+// - 1, which is what lets scan_first name its own extreme without size_t wrapping at zero.
+template<class Traits, class Bits>
+[[nodiscard]] constexpr auto scan_inclusive_next(Bits const& c, std::size_t n) noexcept
+        -> std::size_t
+{
+        auto const size = Traits::size(c);
+        if constexpr (Traits::extent == 0UZ) {
+                return size;
+        } else {
+                if (n >= size) {
                         return size;
+                }
+                if constexpr (block_readable<Traits, Bits>) {
+                        return scan_next_by_block<Traits>(c, n);
                 } else {
-                        if (n >= size) {
-                                return size;
-                        }
-                        if constexpr (block_readable<Traits, Bits>) {
-                                return next_by_block(c, n);
-                        } else {
-                                return next_by_element(c, n);
-                        }
+                        return scan_next_by_element<Traits>(c, n);
                 }
         }
+}
 
-        // The set ordering: the positions in increasing order, compared lexicographically, which
-        // is what std::set's <=> means. Deliberately not the magnitude ordering
-        // boost::dynamic_bitset gives its own operator<, and that divergence is documented rather
-        // than reconciled.
-        template<class Bits>
-        [[nodiscard]] static constexpr auto lexicographical_three_way(Bits const& x, Bits const& y) noexcept
-                -> std::strong_ordering
-        {
-                auto const nx = Traits::size(x);
-                auto const ny = Traits::size(y);
-                auto i = first(x);
-                auto j = first(y);
-                for (; i != nx and j != ny; i = next(x, i), j = next(y, j)) {
-                        if (auto const cmp = i <=> j; cmp != 0) {
-                                return cmp;
-                        }
+// The first set position, or size() if there is none. Total, like every scan here: this
+// is the layer that answers, not the layer with preconditions.
+template<class Traits, class Bits>
+[[nodiscard]] constexpr auto scan_first(Bits const& c) noexcept
+        -> std::size_t
+{
+        return scan_inclusive_next<Traits>(c, 0UZ);
+}
+
+// One past the last position, which for every reading is the width: the end iterator's
+// position, not a scan at all. Named alongside the scans because callers ask for it in
+// the same breath.
+template<class Traits, class Bits>
+[[nodiscard]] constexpr auto scan_last(Bits const& c) noexcept
+        -> std::size_t
+{
+        return Traits::size(c);
+}
+
+// The first set position strictly above n, mirroring block_sequence::exclusive_find_next
+// and boost's find_next. Total in n: a position at or past the width has nothing above it.
+template<class Traits, class Bits>
+[[nodiscard]] constexpr auto scan_next(Bits const& c, std::size_t n) noexcept
+        -> std::size_t
+{
+        auto const size = Traits::size(c);
+        return n >= size ? size : scan_inclusive_next<Traits>(c, n + 1UZ);
+}
+
+// The last set position strictly below n, or size() if there is none.
+//
+// Unlike block_sequence::exclusive_find_prev this is total rather than precondition-guarded:
+// that one may demand any() because reverse iteration supplies the guard, and a fallback
+// synthesised for a foreign type has no such caller to lean on.
+//
+// The block tier is not an optimization here so much as a complexity fix. Element-wise, one
+// step is O(N) and a full reverse traversal is O(N^2) -- which is exactly what #80 measures
+// boost::dynamic_bitset's missing find_prev to cost. A type that hands over its blocks does
+// not pay it.
+template<class Traits, class Bits>
+[[nodiscard]] constexpr auto scan_prev(Bits const& c, std::size_t n) noexcept
+        -> std::size_t
+{
+        auto const size = Traits::size(c);
+        // A width fixed at zero holds nothing below anything, and saying so here rather
+        // than at run time leaves the scans with no arm that cannot be reached.
+        if constexpr (Traits::extent == 0UZ) {
+                return size;
+        } else {
+                auto const i = n < size ? n : size;
+                if (i == 0UZ) {
+                        return size;
                 }
-                // One ran out: the shorter sequence of positions is the smaller set, and both
-                // running out together makes them equal.
-                return (i != nx) <=> (j != ny);
+                if constexpr (block_readable<Traits, Bits>) {
+                        return scan_prev_by_block<Traits>(c, i - 1UZ);
+                } else {
+                        return scan_prev_by_element<Traits>(c, i - 1UZ);
+                }
         }
-};
+}
+
+// How many positions are set. The block tier is the whole point: popcount per word
+// rather than a test per bit.
+template<class Traits, class Bits>
+[[nodiscard]] constexpr auto scan_count(Bits const& c) noexcept
+        -> std::size_t
+{
+        if constexpr (Traits::extent == 0UZ) {
+                return 0UZ;
+        } else if constexpr (block_readable<Traits, Bits>) {
+                auto n = 0UZ;
+                for (auto i = 0UZ, blocks = Traits::num_blocks(c); i < blocks; ++i) {
+                        n += detail::bits::popcount(Traits::block(c, i));
+                }
+                return n;
+        } else {
+                auto n = 0UZ;
+                for (auto i = 0UZ, size = Traits::size(c); i < size; ++i) {
+                        n += Traits::at(c, i) ? 1UZ : 0UZ;
+                }
+                return n;
+        }
+}
+
+} // namespace xstd::detail::bits
+
+namespace xstd {
 
 // The floor for wrappability: a width, and an indexed read. Everything else -- blocks, native
 // scans, a native ordering -- is an optimization tier a specialization may or may not supply.

--- a/include/xstd/bits/bitset.hpp
+++ b/include/xstd/bits/bitset.hpp
@@ -72,14 +72,10 @@ class bitset
 public:
         using block_type = Block;
 
-        // sequence_view's proxy, ported to the member [bitset.refs] asks for: the bits and a position,
-        // handed out by operator[] and reaching them only when read or written. Every such reach
-        // goes through xstd::block_sequence, whose set, reset, flip and operator[] are noexcept and
-        // asserted, so the proxy never takes the checked set(pos, val) beside it that throws.
+        // sequence_view's proxy as [bitset.refs] asks for it, reaching the bits only through the unchecked way in. [design.md#unchecked-writes-in-views]
         class reference
         {
-                // A pointer, not the reference sequence_view's proxy holds, so that the copy
-                // constructor below can stay defaulted as [bitset.refs] declares it.
+                // A pointer, not a reference, so the copy constructor stays defaulted as [bitset.refs] declares it.
                 bitset* m_ptr{};
                 std::size_t m_idx{};
 
@@ -101,12 +97,7 @@ public:
                         return *this;
                 }
 
-                // Assigns the bit and not the proxy: b[i] = b[j] is what [bitset.refs] gives this
-                // signature, and the swap below reads b[i] = b[j] too, so rebinding would leave
-                // both positions holding whatever the second one did.
-                //
-                // bugprone-unhandled-self-assignment wants the &other == this guard a class owning
-                // storage needs. This one owns none: b[i] = b[i] reads the bit and writes it back.
+                // Assigns the bit, not the proxy: rebinding would break the swap below. [design.md#clang-tidy-false-positives]
                 constexpr auto operator=(const reference& x) noexcept -> reference&  // NOLINT(bugprone-unhandled-self-assignment)
                 {
                         return *this = static_cast<bool>(x);
@@ -293,8 +284,7 @@ public:
         [[nodiscard]] constexpr auto to_string(charT zero = charT('0'), charT one = charT('1')) const
                 -> std::basic_string<charT, traits, Allocator>
         {
-                // bugprone-string-constructor sees the N == 0 instantiation, where this is empty --
-                // which is what bitset<0>::to_string() returns.
+                // The finding is the N == 0 instantiation, where empty is the answer. [design.md#clang-tidy-false-positives]
                 auto str = std::basic_string<charT, traits, Allocator>(N, zero);  // NOLINT(bugprone-string-constructor)
                 for (auto const i : std::views::iota(0UZ, N)) {
                         if (m_bits.test(N - 1 - i)) {
@@ -457,9 +447,7 @@ auto operator>>(std::basic_istream<charT, traits>& is, bitset<N, Block>& x)
         -> std::basic_istream<charT, traits>&
 {
         auto str = std::basic_string<charT, traits>(N, is.widen('0'));  // NOLINT(bugprone-string-constructor)
-        // state is assigned below, inside an if constexpr (N > 0) that the N == 0 instantiation
-        // discards; misc-const-correctness sees only that one and asks for a const that would
-        // stop every other instantiation from compiling.
+        // Assigned inside an if constexpr the N == 0 instantiation discards. [design.md#clang-tidy-false-positives]
         auto state = std::ios_base::goodbit;  // NOLINT(misc-const-correctness)
         charT ch;
         auto i = 0UZ;

--- a/include/xstd/bits/block_sequence.hpp
+++ b/include/xstd/bits/block_sequence.hpp
@@ -32,13 +32,7 @@
 
 namespace xstd {
 
-// What block_sequence packs bits into: a contiguous, sized range of unsigned integers.
-// std::array and std::vector both qualify, and so does std::inplace_vector -- runtime
-// width over static capacity, for free.
-//
-// Storage, not container: xstd::ranges::block_range is the other side of the same word,
-// and asks whether a bit container will hand its blocks over. This one asks whether a
-// range is blocks. Nothing models both, and no scope sees both unqualified.
+// Whether a range IS blocks; block_range asks if a container hands its blocks over. [design.md#block-storage]
 template<class R>
 concept block_storage =
         std::ranges::contiguous_range<R> and
@@ -46,9 +40,7 @@ concept block_storage =
         xstd::unsigned_integer<std::ranges::range_value_t<R>>
 ;
 
-// The block count a width of N bits needs, floored at one so that even a zero-width
-// block_sequence has a block to name. Free rather than a member, because block_array below
-// has to spell it inside block_sequence's own template argument list.
+// Floored at one so a zero width still names a block. [design.md#the-one-vehicle]
 template<xstd::unsigned_integer Block, std::size_t N>
 inline constexpr auto num_blocks_v = std::ranges::max(
         align_up(N, static_cast<std::size_t>(xstd::numeric_limits<Block>::digits)) /
@@ -56,19 +48,7 @@ inline constexpr auto num_blocks_v = std::ranges::max(
         1UZ
 );
 
-// The one storage vehicle. N is the width when that is a constant, and
-// std::dynamic_extent when the width is carried at run time instead.
-//
-// It owns the unused-tail invariant -- every bit at or above size() reads zero, which is
-// what makes whole-block comparison, popcount and the block-at-a-time scans mean
-// anything -- and the whole primitive vocabulary over it.
-//
-// No iterators and no proxies: those are readings, and a reading here would be picking
-// one. It would also make std::ranges see a sequence of blocks.
-//
-// The hand-unrolled one- and two-block cases below are where the static performance
-// lives, so they stay compile-time branches; the general path they fall through to is
-// written over m_blocks as a range and therefore serves the dynamic width unchanged.
+// The one vehicle: it owns the unused-tail invariant, and has no iterators. [design.md#the-one-vehicle]
 template<block_storage Blocks, std::size_t N = std::dynamic_extent>
 class block_sequence
 {
@@ -88,22 +68,13 @@ private:
         static constexpr auto zero     = static_cast<block_type>( 0);
         static constexpr auto ones     = static_cast<block_type>(-1);
 
-        // The padding above the width, and the mask of the last block that is not padding.
-        //
-        // num_bits is align_up(N), so num_bits - N is in [0, bits_per_block) and the shift
-        // is always in range. Width zero is the one case that form cannot express -- there
-        // is nothing to align up, so it reports no padding where in truth the sole block is
-        // all of it -- and it gets the selection instead. Naming zero rather than computing
-        // it matters on MSVC, which constant-folds both arms of a ?: and answers C4293,
-        // shift count too big, on the one it discards.
+        // Width zero named, not computed: MSVC folds both ?: arms and answers C4293. [design.md#padding]
         static constexpr auto static_num_unused_bits = has_static_size ? static_num_bits - N : 0UZ;
         static constexpr auto static_used_bits       = has_static_size and N == 0 ? zero : static_cast<block_type>(ones >> static_num_unused_bits);
         static constexpr auto static_unused_bits     = static_cast<block_type>(~static_used_bits);
         static constexpr auto static_has_unused_bits = has_static_size and static_used_bits != ones;
 
-        // A defaulted default constructor plus an NSDMI, rather than two constructors
-        // constrained on the extent: std::vector default-constructs empty, and the
-        // at-least-one-block invariant has to hold from the start.
+        // An NSDMI, not extent-constrained constructors: vector starts empty. [design.md#default-construction]
         [[nodiscard]] static constexpr auto make_blocks(std::size_t n) -> Blocks
         {
                 if constexpr (has_static_size) {
@@ -115,8 +86,7 @@ private:
 
         Blocks m_blocks = make_blocks(0UZ);
 
-        // Present only for a dynamic width; empty_type<size_tag> otherwise, and the tag is
-        // what keeps it distinct from any other absent member in an enclosing layout.
+        // Dynamic widths only; the tag keeps the absent member distinct from any other in an enclosing layout.
         [[XSTD_NO_UNIQUE_ADDRESS]]
         conditional_data_member_t<not has_static_size, std::size_t, struct size_tag> m_size{};
 
@@ -159,8 +129,7 @@ public:
                 return m_blocks[i];
         }
 
-        // The write side of block(). Not a bit_traits entry: block writes are only ever
-        // needed on storage we control, and the unused tail is this class's to keep.
+        // The write side of block(), and no trait entry. [design.md#block-writes]
         constexpr void set_block(std::size_t i, block_type value) noexcept
         {
                 assert(i < num_blocks());
@@ -197,11 +166,7 @@ public:
                 } else if constexpr (has_static_size and static_num_blocks == 2) {
                         return m_blocks[0] != zero ? detail::bits::countr_zero(m_blocks[0]) : detail::bits::countr_zero(m_blocks[1]) + bits_per_block;
                 } else {
-                        // A while rather than a for: any() guarantees a non-empty block exists, so
-                        // a loop that could run out would carry an exit branch no test can take.
-                        // Both branches of this condition are exercised instead -- empty blocks are
-                        // skipped, a non-empty one ends it -- and the index is the block's position
-                        // rather than something distance() has to recover.
+                        // A while, not a for: any() makes a for's exit untestable. [design.md#while-not-for]
                         auto i = 0UZ;
                         while (m_blocks[i] == zero) {
                                 assert(i != last_block());
@@ -220,9 +185,7 @@ public:
                 } else if constexpr (has_static_size and static_num_blocks == 2) {
                         return m_blocks[1] != zero ? last_bit() - detail::bits::countl_zero(m_blocks[1]) : left_bit - detail::bits::countl_zero(m_blocks[0]);
                 } else {
-                        // The mirror of find_front, and the last reverse view in the file. Counting
-                        // up from block i's own base rather than down from last_bit() drops the
-                        // last_block() - i term the reversed range needed.
+                        // The mirror of find_front, counting up from block i's base to drop the reversed range's term.
                         auto i = last_block();
                         while (m_blocks[i] == zero) {
                                 assert(i != 0);
@@ -232,13 +195,7 @@ public:
                 }
         }
 
-        // Its own 0. Now that inclusive_find_next carries the 2-block case too, this emits the same
-        // instruction sequence the hand-written version did -- verified, not assumed -- so the
-        // duplication goes without costing the unrolling. libstdc++ writes both scans out and
-        // repeats the word loop and the ctz-plus-index arithmetic between them; boost factors
-        // the shared tail into m_do_find_from, but only at block granularity, so exclusive_find_next still
-        // needs its own prologue for a mid-block start. Factoring at bit granularity subsumes
-        // both: a block-aligned start is just offset == 0.
+        // Its own 0, and the same instructions the hand-written version emitted. [design.md#inclusive-is-the-primitive]
         [[nodiscard]] constexpr auto find_first() const noexcept
                 -> std::size_t
         {
@@ -251,29 +208,7 @@ public:
                 return size();
         }
 
-        // The first set position at or above n, or size() if there is none.
-        //
-        // Inclusive and exclusive name the only thing that separates the two scans: whether n
-        // itself is a candidate. That is a property of the scan, not of a reading, which is why
-        // this is not called lower_bound -- that is the set reading's word for it, and this layer
-        // serves the sequence reading equally. bit_finite_set::lower_bound is where the set name
-        // belongs, and it maps here one for one.
-        //
-        // The inclusive form is the primitive and the exclusive one is derived, because the
-        // reverse does not close:
-        //
-        //     exclusive_find_next(n) == inclusive_find_next(n + 1)     for every n
-        //     find_first()           == inclusive_find_next(0)
-        //
-        // Exclusive-first would need find_first() == exclusive_find_next(-1), and size_t has no
-        // such value -- which is exactly why the container used to branch on x == 0. boost's
-        // find_next and libstdc++'s _M_do_find_next are both the exclusive form, correctly: their
-        // iteration idiom is find_first() then find_next(i), which never needs the inclusive one.
-        //
-        // n == size() rather than n >= size(): the precondition is n <= size(), asserted just
-        // below, so size() is the only value the scan cannot start from. is_valid does not say
-        // this -- it is n < size() -- and size() is a legitimate argument here, meaning "no such
-        // position", exactly as it is for exclusive_find_prev.
+        // The primitive: inclusive, so both derivations are + 1 and nothing wraps. [design.md#inclusive-is-the-primitive]
         [[nodiscard]] constexpr auto inclusive_find_next(std::size_t n) const noexcept
                 -> std::size_t
         {
@@ -286,16 +221,7 @@ public:
                                 return n + detail::bits::countr_zero(block);
                         }
                 } else if constexpr (has_static_size and static_num_blocks == 2) {
-                        // Two blocks, so the tail is one named block rather than a range: the walk
-                        // below costs more than the whole scan is worth at this width. index is a
-                        // run-time value -- n is -- but the block count is not, so the second half
-                        // is a test and not a loop.
-                        //
-                        // Indexed rather than branched: m_blocks[index], not an if on index, so the
-                        // common path is one computed load. Only when the starting block comes up
-                        // empty does it matter which block we started in, and then only to decide
-                        // whether block 1 is still ahead of us. Writing this as a branch instead
-                        // cost 10 instructions at -O3 -march=native.
+                        // Indexed, not branched: an if cost 10 instructions at -O3. [design.md#two-block-case]
                         auto const [ index, offset ] = index_offset(n);
                         if (auto const block = static_cast<block_type>(m_blocks[index] >> offset); block != zero) {
                                 return n + detail::bits::countr_zero(block);
@@ -304,22 +230,14 @@ public:
                                 return bits_per_block + detail::bits::countr_zero(m_blocks[1]);
                         }
                 } else {
-                        // No offset != 0 guard: >> 0 is the identity, so the masked test is correct
-                        // at a block boundary too, and advancing past that block afterwards is
-                        // right either way. Neither reference implementation guards it -- boost
-                        // shifts by ind then falls to m_do_find_from(blk + 1), libstdc++ masks by
-                        // ~0 << whichbit then does __i++ -- and the guard skips no work: at offset
-                        // 0 it merely moves the same test into the loop's first iteration.
+                        // No offset != 0 guard: >> 0 is the identity. [design.md#offset-guards]
                         auto [ index, offset ] = index_offset(n);
                         if (auto const block = static_cast<block_type>(m_blocks[index] >> offset); block != zero) {
                                 return n + detail::bits::countr_zero(block);
                         }
                         ++index;
                         n += bits_per_block - offset;
-                        // A plain index walk rather than drop + find_if. The iterator form had to
-                        // recover the block's position with distance(); the index is that position,
-                        // so it never needed recovering. Both exits are exercised: falling out is
-                        // how "nothing at or above n" reaches the return below.
+                        // A plain index walk: drop + find_if made distance() recover the index. [design.md#index-walks]
                         for (auto i = index; i < num_blocks(); ++i) {
                                 if (auto const block = m_blocks[i]; block != zero) {
                                         return n + detail::bits::countr_zero(block) + (bits_per_block * (i - index));
@@ -336,46 +254,23 @@ public:
                 return inclusive_find_next(n + 1);
         }
 
-        // The last set position below n. Deliberately NOT total: where inclusive_find_next
-        // answers size() for "nothing at or above", this one has a precondition instead, and
-        // that is the whole of why it is three instructions cheaper at every width -- it never
-        // materializes a not-found value.
-        //
-        // Safe because reverse iteration supplies the guard the function does not.
-        // rend() is make_reverse_iterator(begin()), and std::reverse_iterator stops there, so
-        // operator-- is never applied at begin(). A hand-written loop gets no such help:
-        // the forward idiom terminates itself against size(), the reverse one runs off the
-        // bottom. Totality is the container's contract to keep, per #86 -- not this layer's to
-        // absorb.
+        // Deliberately NOT total: three instructions cheaper, and rend() supplies the guard. [design.md#total-versus-precondition]
         [[nodiscard]] constexpr auto exclusive_find_prev(std::size_t n) const noexcept
                 -> std::size_t
         {
-                // The mirror of exclusive_find_next's assert(is_valid(n)): each says the position actually
-                // scanned from is one this container has. n - 1 is that position here, and the
-                // wraparound does the work at the bottom -- 0 - 1 is SIZE_MAX, which no width
-                // admits -- so this states 1 <= n <= size() without a second predicate. is_valid
-                // alone would be wrong: size() is a legitimate argument, meaning "from the end".
+                // States 1 <= n <= size() in one predicate, 0 - 1 being SIZE_MAX. [design.md#the-wraparound-assert]
                 assert(is_valid(n - 1));
                 assert(any());
                 --n;
                 if constexpr (has_static_size and static_num_blocks == 1) {
                         return n - detail::bits::countl_zero(static_cast<block_type>(m_blocks[0] << (left_bit - n)));
                 } else if constexpr (has_static_size and static_num_blocks == 2) {
-                        // The mirror of inclusive_find_next's two-block case, and simpler than the general
-                        // path below because the fallback is one named block rather than a scan.
-                        //
-                        // No reverse_offset != 0 guard is needed here. Below, that guard is not
-                        // about the shift -- left_bit - offset is in [0, left_bit], so shifting is
-                        // always in range and by zero is the identity -- it is about which block
-                        // the range scan must start at: at index when the whole block is in range,
-                        // below it when the masked block came up empty. Naming the fallback block
-                        // outright makes that distinction disappear.
+                        // Naming the fallback block removes the general path's start-index guard. [design.md#offset-guards]
                         auto const [ index, offset ] = index_offset(n);
                         if (auto const block = static_cast<block_type>(m_blocks[index] << (left_bit - offset)); block != zero) {
                                 return n - detail::bits::countl_zero(block);
                         }
-                        // Reaching here with index 0 means no set bit at or below the caller's n,
-                        // which is the precondition the general path asserts as prev != end(rg).
+                        // Reaching here at index 0 would break the precondition the general path asserts instead.
                         assert(index == 1);
                         assert(m_blocks[0] != zero);
                         return left_bit - detail::bits::countl_zero(m_blocks[0]);
@@ -388,15 +283,7 @@ public:
                                 --index;
                                 n -= bits_per_block - reverse_offset;
                         }
-                        // A descending index walk rather than reverse + drop + find_if, which
-                        // composed two adaptors only to have distance() undo them.
-                        //
-                        // Shaped as a while rather than a for with a fall-through, deliberately.
-                        // The precondition guarantees a set bit at or below, so a loop that could
-                        // run out would carry an exit branch no test can take -- which is exactly
-                        // what the coverage gate would catch, and what find_if hid by keeping that
-                        // branch inside the standard library. Here both branches of the condition
-                        // are exercised: empty blocks are skipped, a non-empty one ends it.
+                        // A while, not a for: the precondition makes a for's exit untestable. [design.md#while-not-for]
                         auto i = index;
                         while (m_blocks[i] == zero) {
                                 assert(i != 0);
@@ -478,12 +365,7 @@ public:
                         m_blocks[0] = static_cast<block_type>(m_blocks[0] << n);
                 } else {
                         auto const [ n_blocks, L_shift ] = xstd::div(n, bits_per_block);
-                        // Implied by is_valid(n) above, and stated again because GCC does not
-                        // carry the range through xstd::div's aggregate return: without it,
-                        // -Warray-bounds reports the memmove inside shift_right at -O1 and -O2
-                        // whenever asserts are live. No CMake build type is that combination --
-                        // Debug is -O0 and the optimized ones carry NDEBUG -- but -O2 -g is one
-                        // command away, and the bound is worth saying in any case.
+                        // Restated because GCC drops the range through xstd::div. [design.md#gcc-array-bounds]
                         assert(n_blocks <= last_block());
                         if (L_shift == 0) {
                                 std::shift_right(std::ranges::begin(m_blocks), std::ranges::end(m_blocks), static_cast<std::ptrdiff_t>(n_blocks));
@@ -532,8 +414,7 @@ public:
                 } else if constexpr (has_static_size and N > 0) {
                         std::ranges::fill(m_blocks, ones);
                 } else if constexpr (not has_static_size) {
-                        // Uniform, because used_bits() is the whole block when the width divides
-                        // evenly and none of it at width zero, where the sole block is all padding.
+                        // Uniform: used_bits() is the whole block on an even division, and none of it at width zero.
                         std::ranges::fill_n(std::ranges::begin(m_blocks), static_cast<std::ptrdiff_t>(last_block()), ones);
                         m_blocks[last_block()] = used_bits();
                 }
@@ -619,12 +500,7 @@ public:
                 return *this;
         }
 
-        // test rather than operator[], because this reads and cannot be written through:
-        // std::bitset's operator[] returns an assignable proxy and this returns bool, so the
-        // subscript spelling would promise an assignment that does not compile. The writable
-        // proxy belongs to the containers above, which is also where the checked reading lives
-        // -- std::bitset::test throws where this asserts, a difference the door states as
-        // unchecked_test rather than one this name should try to carry.
+        // test, not operator[]: this returns bool, std::bitset's a proxy. [design.md#test-not-subscript]
         [[nodiscard]] constexpr auto test(std::size_t n) const noexcept
                 -> bool
         {
@@ -672,9 +548,7 @@ public:
                                 return std::ranges::all_of(m_blocks, [](auto block) { return block == ones; });
                         }
                 } else {
-                        // One shape for both, because used_bits() names the full block when the
-                        // width divides evenly; the static arms keep the split only to stay
-                        // compile-time branches.
+                        // One shape for both; the static arms keep the split only to stay compile-time branches.
                         return all_but_last_are_ones() and m_blocks[last_block()] == used_bits();
                 }
         }
@@ -788,16 +662,7 @@ private:
                 return num_blocks() - 1UZ;
         }
 
-        // Every block but the last, which is the half of all() that padding cannot reach.
-        //
-        // An iterator pair rather than views::take: libc++ 18 -- Xcode 16.4 on the matrix --
-        // writes the return type of views::take's iota_view fast path as
-        // decltype(iota_view(*begin(rng), ...)), so forming the adaptor's operator| over a
-        // range of 128-bit blocks instantiates an iota_view over that block type, however
-        // unlike an iota_view a std::vector is. That trips libc++'s "bigger than integer-like
-        // type" static_assert, which is a hard error rather than a substitution failure.
-        // views::drop, views::reverse, views::transform and views::zip are all clear; only
-        // take carries it, and only until Xcode 16.4 leaves the matrix.
+        // An iterator pair, not views::take, which libc++ 18 cannot form here. [design.md#libcxx-views-take]
         [[nodiscard]] constexpr auto all_but_last_are_ones() const noexcept
                 -> bool
         {
@@ -805,18 +670,14 @@ private:
                 return std::ranges::all_of(first, first + static_cast<std::ptrdiff_t>(last_block()), [](auto block) { return block == ones; });
         }
 
-        // The top bit of the last block, padding included. find_back and exclusive_find_prev count
-        // down from it and both assert any(), so the zero-width case never reaches here.
+        // The top bit of the last block; both callers assert any(), so width zero never reaches here.
         [[nodiscard]] constexpr auto last_bit() const noexcept
                 -> std::size_t
         {
                 return (num_blocks() * bits_per_block) - 1UZ;
         }
 
-        // static_used_bits at a run-time width, and the same two cases. Above width zero the
-        // padding is num_blocks() * bits_per_block - size(), which is in [0, bits_per_block)
-        // and so always a shift in range; at width zero the sole block is entirely padding,
-        // which that expression would report as none, so the selection answers instead.
+        // static_used_bits at a run-time width, width zero selected rather than computed. [design.md#padding]
         [[nodiscard]] constexpr auto used_bits() const noexcept
                 -> block_type
         {
@@ -867,26 +728,14 @@ private:
         }
 };
 
-// The two storage vehicles the library ships, each named and ordered after what it holds.
-// std::inplace_vector needs no alias of its own: it satisfies block_storage, so
-// block_sequence<std::inplace_vector<Block, K>> already gives a runtime width over static
-// capacity.
-//
-// Block leads in both, as it does in std::array and std::vector. N cannot be defaulted
-// behind it, but nothing wants to: the three containers pass their own N and Block on.
+// The two vehicles shipped; std::inplace_vector needs no alias, already satisfying block_storage.
 template<xstd::unsigned_integer Block, std::size_t N>
 using block_array = block_sequence<std::array<Block, num_blocks_v<Block, N>>, N>;
 
 template<xstd::unsigned_integer Block = std::size_t, class Allocator = std::allocator<Block>>
 using block_vector = block_sequence<std::vector<Block, Allocator>>;
 
-// The one specialization that forwards and nothing more. block_sequence has every primitive
-// natively, which is the ceiling principle written as a trait: there is no tier to fall back to,
-// so not one of xstd::detail::bits' walks is reached from here.
-//
-// It needs no friendship. The 14 forwarding hidden friends this fold retires belong to the three
-// containers that hold a block_sequence privately; block_sequence's own vocabulary is public, so
-// the door reaches it directly.
+// Forwards and nothing more, reaching none of the walks. [design.md#the-ceiling-principle]
 template<class Blocks, std::size_t N>
 struct bit_traits<block_sequence<Blocks, N>>
 {
@@ -897,8 +746,7 @@ struct bit_traits<block_sequence<Blocks, N>>
         [[nodiscard]] static constexpr auto size(bits_type const& c) noexcept -> std::size_t { return c.size(); }
         [[nodiscard]] static constexpr auto at(bits_type const& c, std::size_t n) noexcept -> bool { return c.test(n); }
 
-        // set(n) and reset(n) rather than a set(n, value) block_sequence does not have. Both
-        // assert is_valid(n), so the position is a precondition here as it is everywhere below.
+        // set(n)/reset(n), there being no set(n, value) here; both assert, so the position is a precondition.
         static constexpr void assign(bits_type& c, std::size_t n, bool value) noexcept
         {
                 if (value) {
@@ -916,27 +764,11 @@ struct bit_traits<block_sequence<Blocks, N>>
         [[nodiscard]] static constexpr auto find_first(bits_type const& c) noexcept -> std::size_t { return c.find_first(); }
         [[nodiscard]] static constexpr auto find_last (bits_type const& c) noexcept -> std::size_t { return c.find_last();  }
 
-        // The two scans keep the contracts block_sequence gives them rather than widening to the
-        // total ones the walks below xstd::detail::bits happen to provide. That is the ceiling principle again:
-        // the door's contract is the most efficient form, and #88 measured exclusive_find_prev's
-        // non-totality as three instructions at every width. A fallback synthesised for a foreign
-        // type may be more generous than the contract; it may not be less.
-        //
-        // So find_next requires is_valid(n), and find_prev requires a set position strictly below
-        // n -- which any() does not establish, a container whose set positions all lie above n
-        // having none below it. Reverse iteration supplies exactly that guard, rend() being
-        // make_reverse_iterator(begin()), which is why block_sequence can omit it and why the
-        // guard belongs to the container above rather than here. #86 settled the same division
-        // one layer down: totality is the container's contract, not the sequence's.
+        // The door keeps the cheaper contracts. [design.md#the-ceiling-principle]
         [[nodiscard]] static constexpr auto find_next(bits_type const& c, std::size_t n) noexcept -> std::size_t { return c.exclusive_find_next(n); }
         [[nodiscard]] static constexpr auto find_prev(bits_type const& c, std::size_t n) noexcept -> std::size_t { return c.exclusive_find_prev(n); }
 
-        // No ordering entry. "Lexicographic" is underspecified at this layer: the set reading
-        // compares ascending positions and the sequence reading compares bools from index 0, and
-        // they disagree -- {0,1} < {1} as sets, {0,1} > {1} as sequences. Naming one of them here
-        // would make the door pick a reading for its callers. The orderings belong with the
-        // readings that define them, and each is std::lexicographical_compare_three_way over that
-        // reading's own iterators unless a specialization offers something faster.
+        // No ordering entry: the two readings disagree, so the door cannot pick one. [design.md#two-readings-disagree]
 };
 
 }       // namespace xstd

--- a/include/xstd/bits/block_sequence.hpp
+++ b/include/xstd/bits/block_sequence.hpp
@@ -7,7 +7,7 @@
 #define XSTD_BITS_BLOCK_SEQUENCE_HPP
 
 #include <boost/hash2/hash_append_fwd.hpp>                     // hash_append, hash_append_tag
-#include <xstd/bits/bit_traits.hpp>                            // bit_scan, bit_traits
+#include <xstd/bits/bit_traits.hpp>                            // bit_traits
 #include <xstd/bits/detail/intrin.hpp>                         // countl_zero, countr_zero, popcount
 #include <xstd/bits/detail/pred.hpp>                           // intersects, is_subset_of, not_equal_to
 #include <xstd/ints/concepts/unsigned_integer.hpp>             // unsigned_integer
@@ -18,7 +18,6 @@
 #include <algorithm>                                           // all_of, any_of, equal, fill, fill_n, fold_left, max, shift_left, shift_right
 #include <array>                                               // array
 #include <cassert>                                             // assert
-#include <compare>                                             // strong_ordering
 #include <concepts>                                            // swap
 #include <cstddef>                                             // ptrdiff_t, size_t
 #include <functional>                                          // plus
@@ -883,8 +882,7 @@ using block_vector = block_sequence<std::vector<Block, Allocator>>;
 
 // The one specialization that forwards and nothing more. block_sequence has every primitive
 // natively, which is the ceiling principle written as a trait: there is no tier to fall back to,
-// so bit_scan is called nowhere below except for the ordering, which is a reading rather than a
-// primitive and has no native spelling here to prefer.
+// so not one of xstd::detail::bits' walks is reached from here.
 //
 // It needs no friendship. The 14 forwarding hidden friends this fold retires belong to the three
 // containers that hold a block_sequence privately; block_sequence's own vocabulary is public, so
@@ -919,7 +917,7 @@ struct bit_traits<block_sequence<Blocks, N>>
         [[nodiscard]] static constexpr auto find_last (bits_type const& c) noexcept -> std::size_t { return c.find_last();  }
 
         // The two scans keep the contracts block_sequence gives them rather than widening to the
-        // total ones bit_scan's fallbacks happen to provide. That is the ceiling principle again:
+        // total ones the walks below xstd::detail::bits happen to provide. That is the ceiling principle again:
         // the door's contract is the most efficient form, and #88 measured exclusive_find_prev's
         // non-totality as three instructions at every width. A fallback synthesised for a foreign
         // type may be more generous than the contract; it may not be less.
@@ -933,14 +931,12 @@ struct bit_traits<block_sequence<Blocks, N>>
         [[nodiscard]] static constexpr auto find_next(bits_type const& c, std::size_t n) noexcept -> std::size_t { return c.exclusive_find_next(n); }
         [[nodiscard]] static constexpr auto find_prev(bits_type const& c, std::size_t n) noexcept -> std::size_t { return c.exclusive_find_prev(n); }
 
-        // The set ordering has no native spelling here to prefer: block_sequence compares as
-        // storage, and ascending-positions-lexicographically is a reading of it. The fallback is
-        // the definition, so it is what this calls.
-        [[nodiscard]] static constexpr auto lexicographical_three_way(bits_type const& x, bits_type const& y) noexcept
-                -> std::strong_ordering
-        {
-                return bit_scan<bit_traits>::lexicographical_three_way(x, y);
-        }
+        // No ordering entry. "Lexicographic" is underspecified at this layer: the set reading
+        // compares ascending positions and the sequence reading compares bools from index 0, and
+        // they disagree -- {0,1} < {1} as sets, {0,1} > {1} as sequences. Naming one of them here
+        // would make the door pick a reading for its callers. The orderings belong with the
+        // readings that define them, and each is std::lexicographical_compare_three_way over that
+        // reading's own iterators unless a specialization offers something faster.
 };
 
 }       // namespace xstd

--- a/include/xstd/bits/ranges/sequence_view.hpp
+++ b/include/xstd/bits/ranges/sequence_view.hpp
@@ -64,13 +64,7 @@ struct sequence_ops
                 }
         }
 
-        // The operator[] fallback this class refuses is the one below, for a type without
-        // set(n, value): were its operator[] to return our own proxy, that proxy's assignment
-        // would land back here and recurse until the stack is gone. Where set(n, value) does
-        // exist the type is a concrete bitset, and its subscript is the unchecked way in --
-        // which is the one to take, the position being a precondition asserted just below,
-        // where std::bitset::set and xstd::bitset::set check it again and throw out of this
-        // noexcept.
+        // Refused for a type without set(n, value): its proxy's assignment would recurse to death here. [design.md#the-proxy-recursion-trap]
         static constexpr void assign(Bits& c, std::size_t n, bool value) noexcept
                 requires requires { c.set(n, value); }
         {

--- a/include/xstd/bits/ranges/set_view.hpp
+++ b/include/xstd/bits/ranges/set_view.hpp
@@ -92,15 +92,7 @@ struct set_ops
                 }
         }
 
-        // Asking is total, whatever the extent: a position past the width is a key the set does not
-        // hold, which is an answer and not a precondition violation. That is what [set] gives
-        // contains and find -- s.find(k) returns end() for any k it does not hold, never refuses the
-        // question -- and it is the difference between the set reading and the sequence reading,
-        // where sequence_view's operator[] indexes and out of range is out of bounds.
-        //
-        // The position is in range by the time the bitset is read, so the read goes through
-        // operator[] and not test(): the latter is the checked accessor whose throw would escape this
-        // noexcept, and bugprone-exception-escape is right to say so.
+        // Asking is total whatever the extent, and reads go through the subscript. [design.md#asking-is-total]
         [[nodiscard]] static constexpr auto contains(Bits const& c, std::size_t n) noexcept
                 -> bool
         {
@@ -114,17 +106,7 @@ struct set_ops
                 }
         }
 
-        // insert carries no noexcept, for the reason std::set::insert carries none: growing a
-        // dynamic extent allocates. It is the one operation a set can be unable to satisfy, and
-        // only a static extent ever is: a fixed capacity cannot come to hold a position outside it, so that is the
-        // precondition violation. A dynamic extent grows to hold it, [set] giving insert no way
-        // to fail. Erasing stays total like contains -- a position past the width is a key the
-        // set does not hold, and removing what is not there is the no-op returning zero that
-        // std::set::erase is.
-        //
-        // The write goes through the subscript rather than set(n) and reset(n), which check the
-        // position a second time and throw. Every type in the vocabulary hands out a proxy that
-        // writes without checking -- xstd::bitset's since its operator[] stopped being a TODO.
+        // insert alone can fail, and only at a static extent; writes go through the subscript. [design.md#asking-is-total]
         static constexpr void insert(Bits& c, std::size_t n)
         {
                 if constexpr (bitset_vocabulary<Bits>) {
@@ -132,11 +114,7 @@ struct set_ops
                                 // The assert is on its own line: the coverage job drops assert branches by matching the start of the line.
                                 assert(n < max_size(c));
                         } else if (n >= max_size(c)) {
-                                // Growing has a limit of its own, and n + 1 must be a width the
-                                // container can address: dynamic_bitset's max_size() is SIZE_MAX,
-                                // so the one position this rules out is the one whose successor
-                                // wraps to zero -- where resize would grow nothing and the write
-                                // below would land SIZE_MAX bits past the end.
+                                // n + 1 must be addressable: the ruled-out position is the one whose successor wraps to zero.
                                 assert(n < c.max_size());
                                 c.resize(n + 1UZ);
                         }
@@ -492,9 +470,7 @@ public:
         [[nodiscard]] constexpr auto upper_bound(key_type x) const noexcept
                 -> const_iterator
         {
-                // Total like the rest of the asking: past the width there is nothing above x
-                // either. set_find::next is the primitive that scans from a position the set
-                // has, and x + 1 is not one of those once x reaches the width.
+                // Total like the rest of the asking: past the width there is nothing above x either.
                 if (x >= max_size()) {
                         return end();
                 }

--- a/test/include/test/bitset/primitives.hpp
+++ b/test/include/test/bitset/primitives.hpp
@@ -19,13 +19,7 @@
 
 namespace test::bitset {
 
-// Nine of the primitives below carry NOLINT(bugprone-exception-escape) on a noexcept operator().
-// Each guards on pos < self.size() and calls a member the standard specifies as throwing outside
-// that width -- set, reset, flip, test, at -- checking in the other arm that it does throw. The
-// check reads the callee's signature and cannot read the guard, so it reports every instantiation:
-// 104 of them across the two std_bitset units. The noexcept is the claim being made, that a
-// primitive answering about a position inside the bitset never throws, and it is what would fail
-// the suite loudly were the guard ever wrong.
+// Nine primitives below NOLINT bugprone-exception-escape: the check reads the callee, not the guard. [design.md#exception-escape-nolints]
 
 // These checks are on xstd::bitset's basic_string_view overload: std::bitset has none, and dynamic_bitset answers to its own contract.
 template<class X>

--- a/test/include/test/uint128.hpp
+++ b/test/include/test/uint128.hpp
@@ -14,19 +14,7 @@
 #define TEST_HAS_UINT128
 #endif
 
-// xstd::uint128 names a type on every compiler the matrix runs, but the library can only
-// carry it where <bit> will: detail::bits::intrin forwards countl_zero, countr_zero and
-// popcount straight through, and those take std::unsigned_integral alone. That is three
-// separate facts, and the three terms above are them in order. GCC and Clang have the
-// built-in; libstdc++ and libc++ hand it the numeric_limits specialization that carries
-// it into the concept only outside __STRICT_ANSI__, which is why the matrix compiles as
-// gnu++23; and the Microsoft STL's std::_Unsigned128 is a class type, so <bit> declines
-// it whatever the mode -- that block waits on an xstd::countl_zero, not on anything here.
-//
-// The condition worth testing is the concept, which no #if can spell, so the assert below
-// holds the macro to it in both directions. The day that seam grows its own implementation,
-// or a new pairing lands on the matrix, the build says so here rather than at fifteen
-// instantiation lists or, worse, nowhere.
+// Three terms for three facts, and the assert below holds the macro to the concept no #if can spell. [design.md#uint128-support]
 namespace test {
 
 #ifdef TEST_HAS_UINT128

--- a/test/src/bits/bit_finite_set.cpp
+++ b/test/src/bits/bit_finite_set.cpp
@@ -50,19 +50,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(IsABitSet, T, Types)
         static_assert(test::set::bit_set<T>);
 }
 
-// std::set's lookups are total over key_type, and so are these: a key naming no possible
-// element answers "absent" rather than reaching into the blocks. Kept out of the exhaustive
-// suite because that suite draws every key from [0, N), which is exactly why this went
-// unseen.
-//
-// Two findings from running this against the unguarded header are worth recording, because
-// they are why it sweeps the whole of Types rather than one convenient width. No single
-// width exposed all six operations and no single key did either -- at N = 8 over uint8_t
-// every one of them was clean for key == N, so a narrow single-block set proves nothing on
-// its own. And erase was an out-of-bounds *write*, while upper_bound failed on its returned
-// value rather than on memory at all: find_next's ++n wrapped before it could test the
-// bound, so it answered with a real element where end() was due. That second one is what
-// keeps this a gate on the jobs that build without sanitizers.
+// Total lookups, swept over every width because no single one exposed all six operations. [design.md#total-lookups-on-the-container]
 template<class X>
 auto check_key_outside_the_domain(X a, std::size_t x) -> void
 {

--- a/test/src/bits/bit_traits.cpp
+++ b/test/src/bits/bit_traits.cpp
@@ -5,14 +5,13 @@
 
 #include <boost/test/unit_test.hpp>      // BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL
 #include <test/block_types.hpp>          // graded_extents
-#include <xstd/bits/bit_traits.hpp>      // bit_scan, bit_storage, bit_traits, block_readable, static_bit_extent
+#include <xstd/bits/bit_traits.hpp>      // bit_storage, bit_traits, block_readable, scan_*, static_bit_extent
 #include <xstd/bits/block_sequence.hpp>  // block_array
-#include <compare>                       // strong_ordering
 #include <cstddef>                       // size_t
 #include <set>                           // set
 
 // Two adapters over identical storage, differing only in whether they hand their blocks over.
-// That is the whole design of this file: bit_scan picks its tier on block_readable, so the only
+// That is the whole design of this file: the walks pick their tier on block_readable, so the only
 // way to test the choice is to hold the bits fixed and vary nothing else. Every check below then
 // runs twice, and the two answers must agree with each other as well as with std::set.
 namespace {
@@ -60,8 +59,10 @@ struct bit_traits<block_bits<N, Block>>
 
 namespace {
 
+namespace bits = xstd::detail::bits;
+
 template<class T>
-using scan = xstd::bit_scan<xstd::bit_traits<T>>;
+using traits_of = xstd::bit_traits<T>;
 
 template<class T>
 inline constexpr auto extent_of = xstd::bit_traits<T>::extent;
@@ -84,21 +85,21 @@ auto check_scans(std::set<std::size_t> const& model) -> void
         auto const c = make<T>(model);
         constexpr auto N = extent_of<T>;
 
-        BOOST_CHECK_EQUAL(scan<T>::count(c), model.size());
-        BOOST_CHECK_EQUAL(scan<T>::last(c), N);
-        BOOST_CHECK_EQUAL(scan<T>::first(c), model.empty() ? N : *model.begin());
+        BOOST_CHECK_EQUAL(bits::scan_count<traits_of<T>>(c), model.size());
+        BOOST_CHECK_EQUAL(bits::scan_last<traits_of<T>>(c), N);
+        BOOST_CHECK_EQUAL(bits::scan_first<traits_of<T>>(c), model.empty() ? N : *model.begin());
 
         // One past the width too: every scan here is total, so the argument past the end is a
         // question with an answer rather than a precondition violation.
         for (auto n = 0UZ; n <= N + 1UZ; ++n) {
                 auto const above = model.upper_bound(n);
-                BOOST_CHECK_EQUAL(scan<T>::next(c, n), above == model.end() ? N : *above);
+                BOOST_CHECK_EQUAL(bits::scan_next<traits_of<T>>(c, n), above == model.end() ? N : *above);
 
                 auto const at_or_above = model.lower_bound(n);
-                BOOST_CHECK_EQUAL(scan<T>::inclusive_next(c, n), at_or_above == model.end() ? N : *at_or_above);
+                BOOST_CHECK_EQUAL(bits::scan_inclusive_next<traits_of<T>>(c, n), at_or_above == model.end() ? N : *at_or_above);
 
                 auto const below = model.lower_bound(n < N ? n : N);
-                BOOST_CHECK_EQUAL(scan<T>::prev(c, n), below == model.begin() ? N : *std::prev(below));
+                BOOST_CHECK_EQUAL(bits::scan_prev<traits_of<T>>(c, n), below == model.begin() ? N : *std::prev(below));
         }
 }
 
@@ -162,25 +163,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(BlockWiseScansAgreeWithStdSet, T, BlockTypes)
         check_every_pattern<T>();
 }
 
-// The set ordering: positions ascending, compared lexicographically, which is what std::set's
-// own <=> means. Exhaustive over every pair of subsets at the narrowest width, so the answer is
-// checked against the standard library rather than against a reading of it.
-BOOST_AUTO_TEST_CASE(OrderingAgreesWithStdSet)
-{
-        using T = element_bits<test::digits_v<unsigned char>, unsigned char>;
-        constexpr auto N = extent_of<T>;
-
-        for (auto a = 0UZ; a < (1UZ << N); ++a) {
-                for (auto b = 0UZ; b < (1UZ << N); ++b) {
-                        auto x = std::set<std::size_t>();
-                        auto y = std::set<std::size_t>();
-                        for (auto i = 0UZ; i < N; ++i) {
-                                if ((a >> i & 1UZ) != 0UZ) { x.insert(i); }
-                                if ((b >> i & 1UZ) != 0UZ) { y.insert(i); }
-                        }
-                        BOOST_CHECK((scan<T>::lexicographical_three_way(make<T>(x), make<T>(y)) == (x <=> y)));
-                }
-        }
-}
+// No ordering case here any more. The door carries no ordering: "lexicographic" names two
+// different comparisons at this layer -- ascending positions for the set reading, bools from
+// index 0 for the sequence reading -- and they disagree on {0,1} against {1}. Each ordering is
+// tested where it is defined, against std::lexicographical_compare_three_way over that reading's
+// own iterators.
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/bits/bit_traits.cpp
+++ b/test/src/bits/bit_traits.cpp
@@ -10,10 +10,7 @@
 #include <cstddef>                       // size_t
 #include <set>                           // set
 
-// Two adapters over identical storage, differing only in whether they hand their blocks over.
-// That is the whole design of this file: the walks pick their tier on block_readable, so the only
-// way to test the choice is to hold the bits fixed and vary nothing else. Every check below then
-// runs twice, and the two answers must agree with each other as well as with std::set.
+// Two adapters over identical storage, differing only in whether they hand their blocks over. [design.md#detection-by-absence]
 namespace {
 
 // The floor and nothing more: a width and an indexed read.
@@ -89,8 +86,7 @@ auto check_scans(std::set<std::size_t> const& model) -> void
         BOOST_CHECK_EQUAL(bits::scan_last<traits_of<T>>(c), N);
         BOOST_CHECK_EQUAL(bits::scan_first<traits_of<T>>(c), model.empty() ? N : *model.begin());
 
-        // One past the width too: every scan here is total, so the argument past the end is a
-        // question with an answer rather than a precondition violation.
+        // One past the width too, every scan here being total. [design.md#total-versus-precondition]
         for (auto n = 0UZ; n <= N + 1UZ; ++n) {
                 auto const above = model.upper_bound(n);
                 BOOST_CHECK_EQUAL(bits::scan_next<traits_of<T>>(c, n), above == model.end() ? N : *above);
@@ -103,9 +99,7 @@ auto check_scans(std::set<std::size_t> const& model) -> void
         }
 }
 
-// Patterns rather than every subset, since the graded extents run to 128 positions: the empty
-// and full sets, every singleton, and every adjacent pair, which is what puts a set bit on both
-// sides of every block boundary the width has.
+// Patterns rather than every subset: adjacent pairs put a set bit on both sides of every block boundary.
 template<class T>
 auto check_every_pattern() -> void
 {
@@ -141,8 +135,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(TheFloorIsAWidthAndAnIndexedRead, T, ElementTypes)
         static_assert(xstd::static_bit_extent<T>);
 }
 
-// The tier split is what the two adapters exist to pin down: identical storage, one answering
-// block_readable and one not, so neither branch of the if constexpr can go unexercised.
+// The tier split pinned down: one adapter answers block_readable, one does not. [design.md#detection-by-absence]
 BOOST_AUTO_TEST_CASE_TEMPLATE(BlockAccessIsWhatSeparatesTheTiers, T, ElementTypes)
 {
         static_assert(not xstd::block_readable<xstd::bit_traits<T>, T>);
@@ -163,10 +156,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(BlockWiseScansAgreeWithStdSet, T, BlockTypes)
         check_every_pattern<T>();
 }
 
-// No ordering case here any more. The door carries no ordering: "lexicographic" names two
-// different comparisons at this layer -- ascending positions for the set reading, bools from
-// index 0 for the sequence reading -- and they disagree on {0,1} against {1}. Each ordering is
-// tested where it is defined, against std::lexicographical_compare_three_way over that reading's
-// own iterators.
+// No ordering case: the door carries none, the two readings disagreeing. [design.md#two-readings-disagree]
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/bits/bitset.cpp
+++ b/test/src/bits/bitset.cpp
@@ -48,9 +48,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(IsTrivial, T, Types)
         static_assert(    std::is_trivially_move_assignable_v<T>);
 }
 
-// The proxy operator[] hands out, ported from sequence_view: assignment either way round, the
-// flipped reading, flip itself, and the three swaps. b[i] = b[j] is checked to move the bit
-// rather than the proxy, which is also what makes swap work.
+// The proxy from sequence_view: b[i] = b[j] must move the bit, not the proxy, or swap breaks.
 BOOST_AUTO_TEST_CASE(TheMutableSubscriptHandsOutAnAssignableProxy)
 {
         auto b = xstd::bitset<8>{};

--- a/test/src/bits/block_sequence.cpp
+++ b/test/src/bits/block_sequence.cpp
@@ -12,7 +12,6 @@
 #include <cstddef>                     // size_t
 #include <cstdint>                     // uint8_t, uint64_t
 #include <ranges>                      // iota
-#include <set>                         // set
 #include <vector>                      // vector
 
 BOOST_AUTO_TEST_SUITE(BitBlocks)
@@ -461,8 +460,8 @@ BOOST_AUTO_TEST_CASE(ADefaultConstructedRunTimeWidthIsZeroWidthWithOneBlock)
 
 // bit_traits over our own storage forwards and nothing more, so what these check is that each
 // entry reaches the member it names and that the contracts survive the trip. The scans keep
-// block_sequence's own preconditions rather than widening to the total ones bit_scan's fallbacks
-// happen to provide -- find_next wants a valid position, find_prev a set position strictly below
+// block_sequence's own preconditions rather than widening to the total ones the walks under
+// xstd::detail::bits provide -- find_next wants a valid position, find_prev a set position below
 // n -- so every call below stays inside them.
 BOOST_AUTO_TEST_CASE_TEMPLATE(TheDoorForwardsToTheStorage, T, test::graded_extents<graded_block_array>)
 {
@@ -504,34 +503,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(TheDoorForwardsToTheStorage, T, test::graded_exten
         }
 }
 
-// The ordering is the one entry with no native spelling to forward to: block_sequence compares as
-// storage, while this is the set reading of it. Checked against std::set, which is the definition.
-BOOST_AUTO_TEST_CASE(TheDoorOrdersAsStdSetDoes)
-{
-        using T = xstd::block_array<std::uint8_t, 8>;
-        using traits = xstd::bit_traits<T>;
-
-        for (auto a = 0UZ; a < 256UZ; ++a) {
-                for (auto b = 0UZ; b < 256UZ; ++b) {
-                        auto x = T();
-                        auto y = T();
-                        auto sx = std::set<std::size_t>();
-                        auto sy = std::set<std::size_t>();
-                        for (auto i = 0UZ; i < 8UZ; ++i) {
-                                if ((a >> i & 1UZ) != 0UZ) { x.set(i); sx.insert(i); }
-                                if ((b >> i & 1UZ) != 0UZ) { y.set(i); sy.insert(i); }
-                        }
-                        BOOST_CHECK((traits::lexicographical_three_way(x, y) == (sx <=> sy)));
-                }
-        }
-
-        // The ordering reaches bit_scan's forward scan only from inside its loop, where the
-        // position is always below the width, so the past-the-end arm has to be asked for
-        // directly. Each instantiation carries its own branch slots and covers them or does not:
-        // that another Traits exercises this one elsewhere does not count for this one.
-        auto const empty = T();
-        BOOST_CHECK_EQUAL(xstd::bit_scan<traits>::next(empty, traits::extent), traits::extent);
-        BOOST_CHECK_EQUAL(xstd::bit_scan<traits>::first(empty), traits::extent);
-}
+// No ordering case here. The door carries no ordering entry: "lexicographic" names two different
+// comparisons at this layer, and each belongs to the reading that defines it. And because every
+// entry above forwards to a native member, not one of xstd::detail::bits' walks is instantiated
+// for this Traits -- exercising them here would create an instantiation nothing else uses, whose
+// branch slots this file would then owe the coverage gate. They are covered in bit_traits.cpp,
+// against the two adapters built to drive both tiers.
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/bits/block_sequence.cpp
+++ b/test/src/bits/block_sequence.cpp
@@ -18,8 +18,7 @@ BOOST_AUTO_TEST_SUITE(BitBlocks)
 
 namespace {
 
-// std::vector<bool> is the reference reading: one bool per bit, no packing, no invariant
-// to get wrong. Every answer block_sequence gives is checked against what it says.
+// std::vector<bool> is the reference reading: one bool per bit, no packing, no invariant to get wrong.
 using model = std::vector<bool>;
 
 template<class BB>
@@ -32,13 +31,7 @@ auto reference(BB const& b) -> model
         return m;
 }
 
-// The pair under test, its model, and the running disagreement count, held together so
-// that each family of checks below reads as what it compares rather than as a parameter
-// list. One family per member, because all of them in one function is a cognitive
-// complexity clang-tidy rightly objects to.
-//
-// Disagreements are counted rather than asserted per bit: a passing assertion per bit
-// says no more than one, and a failing one drowns the log.
+// One family of checks per member, disagreements counted rather than asserted. [design.md#counted-not-asserted]
 template<class BB>
 class checker
 {
@@ -50,16 +43,7 @@ class checker
         std::size_t m_cardinality = static_cast<std::size_t>(std::ranges::count(m_mx, true));
         int& m_disagreements;
 
-        // Two scratch objects, reset before each mutating check, rather than a fresh copy
-        // per check. Same-width assignment reuses the storage, so this is two allocations
-        // for the whole checker instead of one per operation -- of which positions() alone
-        // did five per bit. It is faster, and it leaves the optimizer one object to follow
-        // rather than thousands of construct/destroy pairs: three GCC versions have each
-        // mis-analysed that shape in a different way (-Wfree-nonheap-object on 15,
-        // -Wrestrict on 17-SVN), and moving the copies around only moved the diagnostic.
-        //
-        // Held by reference, owned by check_ops: by value they would be the only members
-        // narrower than a pointer, and -Wpadded reports the tail padding that leaves.
+        // Two scratch objects by reference: copies per check trip three GCC diagnostics. [design.md#scratch-objects]
         BB& m_a;
         BB& m_b;
 
@@ -75,8 +59,7 @@ class checker
                 return m_b;
         }
 
-        // The two places a comparison becomes a count, so the cast that
-        // readability-implicit-bool-conversion asks for has two sites and not thirty.
+        // The two sites where a comparison becomes a count, so the cast is not thirty. [design.md#counted-not-asserted]
         auto disagree(bool ours, bool theirs) -> void
         {
                 m_disagreements += static_cast<int>(ours != theirs);
@@ -114,8 +97,7 @@ public:
                 disagree(m_x == m_y, m_mx == m_my);
         }
 
-        // find_front and find_back assert any(), so they answer only for a non-empty x;
-        // find_first and find_last are total and answer size() for an empty one.
+        // find_front/find_back assert any(); find_first/find_last are total and answer size().
         auto scans() -> void
         {
                 if (m_cardinality != 0) {
@@ -139,9 +121,7 @@ public:
                         unequal(m_x.exclusive_find_next(i), next);
                 }
 
-                // inclusive_find_next is the primitive; find_first is its 0 and exclusive_find_next its n + 1. Check
-                // it directly over its whole precondition domain -- n == size() included, which is
-                // the one value the scan cannot start from and the reason the guard is == at all.
+                // The primitive, checked over its whole domain, n == size() included. [design.md#inclusive-is-the-primitive]
                 for (auto i = 0UZ; i <= m_n; ++i) {
                         auto bound = i;
                         while (bound < m_n and not m_mx[bound]) { ++bound; }
@@ -174,8 +154,7 @@ public:
                 disagree(m_x.intersects(m_y),          meets);
         }
 
-        // On packed bits the set operation and the pointwise sequence operation are the
-        // same instruction, so one model answers for both readings.
+        // On packed bits the set and pointwise sequence operations are one instruction, so one model answers both.
         auto bitwise() -> void
         {
                 { auto& a = fresh_x(); a &= m_y; auto m = model(m_n); for (auto i = 0UZ; i < m_n; ++i) { m[i] = m_mx[i] and     m_my[i]; } same(m, a); }
@@ -192,10 +171,7 @@ public:
                 }
         }
 
-        // Each of these has to leave the unused tail zero. One method apiece rather than
-        // four scopes in one: at -O3 GCC 15 inlines the whole sweep into a single function
-        // and then reports -Wfree-nonheap-object on the vector copies, which ASan, LSan and
-        // UBSan all say is not there.
+        // One method apiece: combined, GCC 15 at -O3 reports a free-nonheap-object that is not there. [design.md#scratch-objects]
         auto whole_set() -> void
         {
                 auto& a = fresh_x();
@@ -243,8 +219,7 @@ public:
                 }
         }
 
-        // Writing every block back must be the identity, and writing all-ones must stop at
-        // size(), which is the unused-tail invariant itself.
+        // Writing blocks back is the identity, and all-ones must stop at size(): the unused-tail invariant.
         auto blocks() -> void
         {
                 disagree(m_x.num_blocks() * BB::bits_per_block >= m_n, true);
@@ -286,16 +261,7 @@ auto check_ops(BB const& x, BB const& y, int& disagreements) -> void
         c.blocks();
 }
 
-// Seven patterns, chosen so that every pair of them lands on both sides of each branch:
-// all clear and all set for the whole-container shortcuts, the strided ones for partial
-// blocks, and the endpoint ones for the first and last block specifically. The last one
-// fills every block but the last, which is the only way to reach the right operand of
-// all()'s short circuit with a false: every other pattern either fails a block below the
-// last, or fills the last one too. It compares block indices rather than a precomputed
-// bit count, so that a single-block width -- for which it selects nothing -- does not fold
-// into an unsigned comparison against zero, which -Wtype-limits reports.
-// graded_extents parameterizes on <N, Block>, as the three containers do; block_array is
-// <Block, N>, after std::array. Adapting here keeps the alias ordered by what it holds.
+// Seven patterns, every pair landing on both sides of each branch. [design.md#seven-patterns]
 template<std::size_t N, class Block>
 using graded_block_array = xstd::block_array<Block, N>;
 
@@ -305,9 +271,7 @@ auto sweep(BB const& empty) -> int
         auto const n = empty.size();
 
         auto values = std::vector<BB>();
-        // views::iota rather than i < n: n is empty.size(), which folds to a constant, and
-        // at a width of zero that leaves an unsigned comparison against zero -- -Wtype-limits
-        // on GCC, and the same C4296 the header's is_valid() carries a comment about.
+        // views::iota, not i < n: at width zero that folds to a comparison against zero. [design.md#width-zero-comparisons]
         auto const push = [&](auto fill) -> void {
                 auto b = empty;
                 for (auto const i : std::views::iota(0UZ, n)) {
@@ -315,9 +279,7 @@ auto sweep(BB const& empty) -> int
                 }
                 values.push_back(b);
         };
-        // Captured by reference throughout rather than by name: under a static width the
-        // compiler folds these to constants, and naming something usable in a constant
-        // expression is exactly what -Wunused-lambda-capture reports.
+        // Captured by reference: a static width folds these to constants. [design.md#width-zero-comparisons]
         push([&](std::size_t  ) -> bool { return false;                });
         push([&](std::size_t  ) -> bool { return true;                 });
         push([&](std::size_t i) -> bool { return i % 2 == 0;           });
@@ -335,8 +297,7 @@ auto sweep(BB const& empty) -> int
         return disagreements;
 }
 
-// Named rather than immediately-invoked lambdas: an empty parameter list before a trailing
-// return type is redundant, and dropping it would lean on P1102 for no reason.
+// Named rather than immediately-invoked lambdas, so nothing leans on P1102 for no reason.
 constexpr auto a_static_width_is_constexpr() -> bool
 {
         auto b = xstd::block_array<std::uint8_t, 9>();
@@ -353,8 +314,7 @@ constexpr auto a_run_time_width_is_constexpr() -> bool
 
 } // namespace
 
-// Both vehicles the library ships satisfy what block_sequence asks of its storage; growth is
-// detected where it exists rather than required, so a fixed one qualifies just as well.
+// Both shipped vehicles satisfy block_storage: growth is detected where it exists, never required.
 BOOST_AUTO_TEST_CASE(ItsStorageIsAContiguousSizedRangeOfUnsignedIntegers)
 {
         static_assert(xstd::block_storage<std::array<std::uint8_t, 4>>);
@@ -364,8 +324,7 @@ BOOST_AUTO_TEST_CASE(ItsStorageIsAContiguousSizedRangeOfUnsignedIntegers)
         static_assert(not xstd::block_storage<std::vector<int>>);       // nor unsigned integers
 }
 
-// A compile-time width costs nothing: the absent size member takes no storage, which is
-// the whole point of conditional_data_member_t over a plain size_t.
+// A compile-time width costs nothing: the absent size member takes no storage.
 BOOST_AUTO_TEST_CASE(AStaticWidthAddsNothingToItsBlocks)
 {
         static_assert(sizeof(xstd::block_array<std::uint64_t,  64>) == sizeof(std::array<std::uint64_t,  1>));
@@ -383,8 +342,7 @@ BOOST_AUTO_TEST_CASE(BothWidthsAreUsableAtCompileTime)
         static_assert(a_run_time_width_is_constexpr());
 }
 
-// The static width, at every extent the library instantiates. This is the same storage the
-// three owners hold, so a disagreement here is a disagreement in all of them.
+// The static width at every extent instantiated; the three owners hold this same storage.
 BOOST_AUTO_TEST_CASE_TEMPLATE(AStaticWidthAgreesWithTheModel, T, test::graded_extents<graded_block_array>)
 {
         BOOST_CHECK_EQUAL(sweep(T()), 0);
@@ -403,8 +361,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ARunTimeWidthAgreesWithTheModel, Block, test::word
         BOOST_CHECK_EQUAL(disagreements, 0);
 }
 
-// Two run-time widths are the same type, so == has to answer for a pair that a static
-// width can never form. The widths decide it before the blocks are looked at.
+// Two run-time widths share a type, so == must answer a pair a static width can never form.
 BOOST_AUTO_TEST_CASE(RunTimeWidthsOfDifferentSizeAreNotEqual)
 {
         using T = xstd::block_vector<std::uint8_t>;
@@ -420,8 +377,7 @@ BOOST_AUTO_TEST_CASE(RunTimeWidthsOfDifferentSizeAreNotEqual)
         BOOST_CHECK(x == y);
 }
 
-// A width of zero still owns one block, so that last_block() names something; every
-// operation on it has to see through that block to the width, which is what says empty.
+// A zero width still owns one block, and every operation must see through it to the width.
 BOOST_AUTO_TEST_CASE(AZeroWidthOwnsOneBlockAndReadsEmpty)
 {
         auto const b = xstd::block_vector<std::uint8_t>(0);
@@ -434,8 +390,7 @@ BOOST_AUTO_TEST_CASE(AZeroWidthOwnsOneBlockAndReadsEmpty)
         BOOST_CHECK(not b.any());
 }
 
-// The other half of it: that sole block is entirely padding, so the whole-container
-// mutators must not reach into it. This is what the last-block mask exists to say.
+// That sole block is entirely padding, which is what the last-block mask exists to say. [design.md#padding]
 BOOST_AUTO_TEST_CASE(AZeroWidthsOneBlockIsAllPaddingAndStaysZero)
 {
         auto b = xstd::block_vector<std::uint8_t>(0);
@@ -447,8 +402,7 @@ BOOST_AUTO_TEST_CASE(AZeroWidthsOneBlockIsAllPaddingAndStaysZero)
         BOOST_CHECK_EQUAL(b.block(0), 0U);
 }
 
-// A default-constructed run-time width is the zero-width one, not a block-less one: the
-// at-least-one-block invariant has to hold before any constructor of ours runs.
+// Default-constructed is zero-width, not block-less. [design.md#default-construction]
 BOOST_AUTO_TEST_CASE(ADefaultConstructedRunTimeWidthIsZeroWidthWithOneBlock)
 {
         auto const b = xstd::block_vector<std::uint8_t>();
@@ -458,11 +412,7 @@ BOOST_AUTO_TEST_CASE(ADefaultConstructedRunTimeWidthIsZeroWidthWithOneBlock)
         BOOST_CHECK(b == xstd::block_vector<std::uint8_t>(0));
 }
 
-// bit_traits over our own storage forwards and nothing more, so what these check is that each
-// entry reaches the member it names and that the contracts survive the trip. The scans keep
-// block_sequence's own preconditions rather than widening to the total ones the walks under
-// xstd::detail::bits provide -- find_next wants a valid position, find_prev a set position below
-// n -- so every call below stays inside them.
+// Each entry reaches the member it names, and every call stays inside the kept contracts. [design.md#the-ceiling-principle]
 BOOST_AUTO_TEST_CASE_TEMPLATE(TheDoorForwardsToTheStorage, T, test::graded_extents<graded_block_array>)
 {
         using traits = xstd::bit_traits<T>;
@@ -480,15 +430,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(TheDoorForwardsToTheStorage, T, test::graded_exten
         BOOST_CHECK_EQUAL(traits::count(c), 0UZ);
         BOOST_CHECK_EQUAL(traits::num_blocks(c), c.num_blocks());
 
-        // BOOST_CHECK rather than BOOST_CHECK_EQUAL: the latter prints its operands on
-        // failure, and graded_extents includes xstd::uint128, for which libc++ has no
-        // operator<< -- an ambiguity libstdc++ does not have and so does not report.
+        // BOOST_CHECK, not BOOST_CHECK_EQUAL: uint128 has no operator<<. [design.md#uint128-printing]
         for (auto k = 0UZ; k < c.num_blocks(); ++k) {
                 BOOST_CHECK(traits::block(c, k) == c.block(k));
         }
 
-        // One position at a time, set and then cleared again: assign's two arms are the point,
-        // and a single set position makes every scan's answer something the loop already knows.
+        // One position at a time, set then cleared: assign's two arms are the point.
         for (auto i = 0UZ; i < N; ++i) {
                 traits::assign(c, i, true);
                 BOOST_CHECK(traits::at(c, i));
@@ -503,11 +450,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(TheDoorForwardsToTheStorage, T, test::graded_exten
         }
 }
 
-// No ordering case here. The door carries no ordering entry: "lexicographic" names two different
-// comparisons at this layer, and each belongs to the reading that defines it. And because every
-// entry above forwards to a native member, not one of xstd::detail::bits' walks is instantiated
-// for this Traits -- exercising them here would create an instantiation nothing else uses, whose
-// branch slots this file would then owe the coverage gate. They are covered in bit_traits.cpp,
-// against the two adapters built to drive both tiers.
+// No ordering case, and no walk instantiated here: both belong elsewhere. [design.md#two-readings-disagree]
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/bits/ranges/set_view.cpp
+++ b/test/src/bits/ranges/set_view.cpp
@@ -52,8 +52,7 @@ BOOST_AUTO_TEST_CASE(TheViewedTypesAreTheOnesHoldingASetWithoutOfferingIt)
         static_assert(std::ranges::bidirectional_range<xstd::set_view<boost::dynamic_bitset<>>>);
 }
 
-// Asking is total whatever the extent: a position past the width is a key the set does not hold,
-// which every one of these answers rather than refuses, exactly as [set] has it.
+// Asking is total whatever the extent, exactly as [set] has it. [design.md#asking-is-total]
 BOOST_AUTO_TEST_CASE_TEMPLATE(EveryExtentAnswersForPositionsPastItsWidth, T, ViewedTypes)
 {
         auto bits = eight_bits_with_three_set<T>();
@@ -63,8 +62,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(EveryExtentAnswersForPositionsPastItsWidth, T, Vie
         // Both ways round, so that find and lower_bound are each seen taking either arm.
         BOOST_CHECK(v.contains(3));
         BOOST_CHECK_EQUAL(v.count(3), 1);
-        // contains is checked just above; find is the subject here, so readability-container-contains
-        // is asking for the one call this case exists to make.
+        // find is the subject here, which is the one call readability-container-contains would remove.
         BOOST_CHECK(v.find(3) != v.end());  // NOLINT(readability-container-contains)
         BOOST_CHECK(v.lower_bound(3) == v.find(3));
 
@@ -77,16 +75,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(EveryExtentAnswersForPositionsPastItsWidth, T, Vie
         BOOST_CHECK(v.upper_bound(3) == v.end());
         BOOST_CHECK(v.upper_bound(99) == v.end());
 
-        // Erasing what is not there is the no-op returning zero that std::set::erase is, and it
-        // neither shrinks the width nor disturbs what is held.
+        // Erasing what is not there is std::set::erase's no-op returning zero. [design.md#asking-is-total]
         BOOST_CHECK_EQUAL(v.erase(99), 0);
         BOOST_CHECK(v.contains(3));
         BOOST_CHECK_EQUAL(v.size(), 1);
         BOOST_CHECK_EQUAL(v.max_size(), width);
 }
 
-// The other half of the std::set reading: [set] gives insert no way to fail, so a dynamic
-// extent grows to hold a position past its current size rather than asserting on it.
+// [set] gives insert no way to fail, so a dynamic extent grows rather than asserting. [design.md#asking-is-total]
 BOOST_AUTO_TEST_CASE(ADynamicExtentGrowsToHoldAPositionPastItsCurrentSize)
 {
         auto bits = boost::dynamic_bitset<>(8);

--- a/test/src/bits/std_set/constexpr.cpp
+++ b/test/src/bits/std_set/constexpr.cpp
@@ -61,8 +61,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(AnEmptySetIsUsableInAConstantExpression, T, Types)
         static_assert(b.empty());
         static_assert(b.size() == 0);
         static_assert(b.begin() == b.end());
-        // Reflexivity is the property under test, and there is no writing it without naming the
-        // object twice; misc-redundant-expression sees only that the two operands match.
+        // Reflexivity cannot be written without naming the object twice. [design.md#clang-tidy-false-positives]
         static_assert(b == b);                                   // NOLINT(misc-redundant-expression)
         static_assert((b <=> b) == std::strong_ordering::equal); // NOLINT(misc-redundant-expression)
 }
@@ -74,8 +73,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(AFullSetIsUsableInAConstantExpression, T, Types)
         static_assert(b.size() == b.max_size());
         static_assert(b.empty() or b.front() == *b.cbegin());
         static_assert(b.empty() or b.back()  == *b.crbegin());
-        // Reflexivity is the property under test, and there is no writing it without naming the
-        // object twice; misc-redundant-expression sees only that the two operands match.
+        // Reflexivity cannot be written without naming the object twice. [design.md#clang-tidy-false-positives]
         static_assert(b == b);                                   // NOLINT(misc-redundant-expression)
         static_assert((b <=> b) == std::strong_ordering::equal); // NOLINT(misc-redundant-expression)
 }

--- a/test/src/bits/std_set/implicit.cpp
+++ b/test/src/bits/std_set/implicit.cpp
@@ -52,8 +52,7 @@ class Implicit
 
 public:
         [[nodiscard]] constexpr explicit(false) Implicit(std::size_t v) noexcept : m_value(v) {}
-        // Implicit is the point: this class exists to be converted from and to without a cast,
-        // which is what the case below checks.
+        // Implicit is the point: this class exists to convert both ways without a cast.
         [[nodiscard]] constexpr explicit(false) operator std::size_t() const noexcept { return m_value; }  // NOLINT(misc-explicit-constructor)
 };
 


### PR DESCRIPTION
Three commits, all prerequisites for step 3b of #80 and none of them changing behaviour.

## 1. Flatten the door (`c75669a`)

`bit_scan<Traits>` is gone. Its members are free function templates in `xstd::detail::bits`, beside the `countl_zero`, `countr_zero` and `popcount` they were already written in terms of. One public name above them: `bit_traits`.

**The nesting replaces what the class was for.** An unqualified `scan_first<Traits>(c)` parses its `<` as a template argument list and then performs ADL *with the explicit template arguments included* — so `std` and `boost`, the associated namespaces of the very types being adapted, would join the overload set. A class closed that by having no unqualified call to hijack; a nested detail namespace closes it better, since these names are not visible unqualified from `xstd` at all. Qualification is enforced by **scoping** rather than by remembering a prefix.

`block_readable` stays. It is flat, it is the tier test the walks need, and it is meaningful *only* because nothing supplies a default — which is also why these are free functions and not a base to inherit from: a base would satisfy the concept for every type and the tier choice would collapse silently.

The ordering entry is **deleted rather than moved**. "Lexicographic" names two comparisons at this layer and they disagree — `{0,1} < {1}` as sets, `{0,1} > {1}` as sequences — so a door serving three readings cannot hold one of them without choosing for its callers.

## 2. The long comments move to `design.md` (`2eee95c`)

The headers carried their rationale inline, which read well and scrolled badly: `block_sequence.hpp` spent 203 lines of comment across 32 blocks, and the argument for a two-block special case sat between the reader and the code doing it.

`design.md` holds that reasoning **grouped by subject rather than by file**, so the offset-guard argument is in one place instead of restated at each of the three scans depending on it. Each header comment is now one line ending in a `[design.md#anchor]`, so an editor about to undo something has a pointer to why it is there rather than a truncated hint.

## 3. The rest of the tree (`0473cb0`)

The remaining 28 prose blocks, plus four more `design.md` sections for what they carried: the harness's scratch-object shape, the views' totality rules and the proxy recursion the sequence fallback refuses, uint128's three-way support condition, and the four clang-tidy findings suppressed because the checker cannot see what makes them right.

**Four blocks are deliberately left alone.** `test/include/test/bitset/primitives.hpp` and `test/src/bits/std_bitset/o1.cpp` hold commented-out test bodies, which [CONTRIBUTING.md](CONTRIBUTING.md) *requires* rather than tolerates — code that cannot be reached from a test gets commented out so whoever uncomments it has to write the test. Compressing those would destroy the thing they exist to do.

## What the one-liners still carry

Rationale defers to `design.md`; anything an editor could undo without noticing does not:

```cpp
// No offset != 0 guard: >> 0 is the identity, and #88 measured it as pure cost. [design.md#offset-guards]
// Width zero named, not computed: MSVC folds both ?: arms and answers C4293. [design.md#padding]
// An iterator pair, not views::take, which libc++ 18 cannot form here. [design.md#libcxx-views-take]
// A while, not a for: any() makes a for's exit untestable. [design.md#while-not-for]
// States 1 <= n <= size() in one predicate, 0 - 1 being SIZE_MAX. [design.md#the-wraparound-assert]
```

## A correction carried in passing

`design.md`'s ordering section had `boost::dynamic_bitset::operator<` down as magnitude ordering. It is **reverse-lexicographic**: it pairs each bitset's highest bit with the other's highest and breaks ties on width, which is `std::lexicographical_compare_three_way` over reverse iterators — and equally, lexicographic comparison of `to_string()`.

Checked over 1,046,529 pairs spanning every width 0–9 against every other: **zero** mismatches against either characterization, **223,893** against numeric order. `"1"` and `"01"` are both the number 1, and boost orders them strictly.

## Verification

- [x] **`bit_traits.hpp` at 100% line (1333/1333) and 100% branch (574/574)** from its own TU, at the coverage gate's own thresholds.
- [x] Full suite **28/28 buildable tests pass**, before and after the sweep. The four that do not build locally fail identically on unmodified `main` — `std_set/o1` and `o2` need `std::set(from_range, ...)`, absent from gcc 14's libstdc++; both `sieve.cpp` need `fmt`.
- [x] gcc `-Werror` and clang `-Weverything` with the repo's own flag sets: **0 across all five affected tests**.
- [x] ASan + UBSan: **5/5 pass, 517 test cases**.
- [x] Unused includes dropped with the code needing them: `<compare>` from three files, `<set>` from `block_sequence.cpp`.

Commits 2 and 3 touch comments only, so no coverage change is possible from them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gfTqPbkbmFo2yfGSCDRpU