### PR TITLE
Adapt std::bitset and boost::dynamic_bitset through the one door

### DIFF
--- a/design.md
+++ b/design.md
@@ -178,6 +178,52 @@ constraint.
 Down here nothing is visible unqualified from `xstd`, so the qualification is enforced by **scoping** rather
 than by remembering a prefix at every call site — which is what a class was previously substituting for.
 
+### what-the-door-reconciles
+
+Almost everything the two readings ask of a `Bits` is already an entry, or is the same operation under
+another name:
+
+| what a reading calls | door entry | |
+|---|---|---|
+| set `size()` (cardinality) | `count` | |
+| set `max_size()` (width) | `size` | |
+| `contains(n)` | `at(c, n)` | the same operation |
+| set `erase(n)` | `assign(c, n, false)` | the same operation |
+| set `clear()` | `fill(c, false)` | |
+| sequence `size()` / `assign` | `size` / `assign` | |
+| `bit_extent<Bits>` | `extent` | |
+
+Two entries are left over, and they are the two the readings cannot synthesize:
+
+- **`insert`** is the only operation that can *grow*, and it is exactly what the adapted types disagree
+  about: `boost::dynamic_bitset` resizes, `std::bitset` cannot, `block_sequence` asserts. Reconciling that
+  is what the door is for. It is not `assign(c, n, true)`, which has no answer for a position past the width.
+- **`fill`** is bulk, and `clear` is `fill(false)`.
+
+### the-two-reserved-names
+
+`std::bitset`'s two implementation hooks are **complementary, not paired** — which is the opposite of what
+it looks like, and worth stating because the wrong guess silently costs a tier:
+
+| | `_Getword` | `_Find_first` / `_Find_next` |
+|---|---|---|
+| libstdc++ | no — it is `_M_getword`, on an inaccessible base | yes |
+| MSVC | yes | no |
+| libc++ | no | no |
+
+So neither implies the other, and each is worth a constrained entry on its own. Where `_Getword` is
+reachable the walks run block-wise, including a `find_prev` neither library supplies; where `_Find_first` is
+reachable the forward scans are native. Both return `N` when nothing is set, which is already the door's
+total contract, so no `npos` mapping is needed — unlike boost, whose `find_first` answers `npos`.
+
+### proxies-compare-themselves
+
+Neither ordering needs a comparator. A proxy reference converts implicitly to its `value_type`, and that
+conversion is what satisfies `three_way_comparable` — checked for both this library's `sequence_reference`
+and `std::vector<bool>::reference`, on which `lexicographical_compare_three_way` works with no comparator
+at all. An explicit `[](bool a, bool b) { return int(a) <=> int(b); }` says nothing the conversion has not
+already said.
+
 ### block-writes
 
 `set_block` is the write side of `block()`, and deliberately not a trait entry: block writes are only ever

--- a/include/xstd/bits/block_sequence.hpp
+++ b/include/xstd/bits/block_sequence.hpp
@@ -845,6 +845,17 @@ struct bit_traits<block_sequence<Blocks, N>>
 
         [[nodiscard]] static constexpr auto count(bits_type const& c) noexcept -> std::size_t { return c.count(); }
 
+        // The two entries the readings cannot synthesize: insert is the one operation that can grow, and fill is bulk. [design.md#what-the-door-reconciles]
+        static constexpr void insert(bits_type& c, std::size_t n) noexcept { c.set(n); }
+        static constexpr void fill(bits_type& c, bool value) noexcept
+        {
+                if (value) {
+                        c.set();
+                } else {
+                        c.reset();
+                }
+        }
+
         [[nodiscard]] static constexpr auto num_blocks(bits_type const& c) noexcept -> std::size_t { return c.num_blocks(); }
         [[nodiscard]] static constexpr auto block(bits_type const& c, std::size_t i) noexcept { return c.block(i); }
 

--- a/include/xstd/bits/ext/boost/dynamic_bitset.hpp
+++ b/include/xstd/bits/ext/boost/dynamic_bitset.hpp
@@ -9,6 +9,7 @@
 // IWYU pragma: always_keep
 
 #include <boost/dynamic_bitset.hpp>                // IWYU pragma: export; dynamic_bitset
+#include <xstd/bits/bit_traits.hpp>                // bit_traits
 #include <xstd/bits/ranges/sequence_view.hpp>      // sequence_find
 #include <xstd/bits/ranges/set_view.hpp>           // set_find, set_view
 #include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer
@@ -17,7 +18,63 @@
 #include <compare>                                 // strong_ordering
 #include <cstddef>                                 // std::size_t
 #include <ranges>                                  // find_if, min
+#include <span>                                    // dynamic_extent
                                         // iota, reverse
+
+// The one door for boost::dynamic_bitset; a specialization cannot be shadowed by a future upstream member, as an ADL hook could. [design.md#the-door]
+namespace xstd {
+
+template<xstd::unsigned_integer Block, class Allocator>
+struct bit_traits<boost::dynamic_bitset<Block, Allocator>>
+{
+        using bits_type = boost::dynamic_bitset<Block, Allocator>;
+
+        static constexpr std::size_t extent = std::dynamic_extent;
+
+        [[nodiscard]] static constexpr auto size (bits_type const& c)                noexcept -> std::size_t { return c.size();  }
+        [[nodiscard]] static constexpr auto at   (bits_type const& c, std::size_t n) noexcept -> bool        { return c[n];      }
+        [[nodiscard]] static constexpr auto count(bits_type const& c)                noexcept -> std::size_t { return c.count(); }
+
+        static constexpr void assign(bits_type& c, std::size_t n, bool value) noexcept { c[n] = value; }
+
+        // The one entry a dynamic width answers by growing; n + 1 must be addressable, the ruled-out position being the one whose successor wraps. [design.md#what-the-door-reconciles]
+        static constexpr void insert(bits_type& c, std::size_t n)
+        {
+                if (n >= c.size()) {
+                        assert(n < c.max_size());
+                        c.resize(n + 1UZ);
+                }
+                c[n] = true;
+        }
+
+        static constexpr void fill(bits_type& c, bool value) noexcept
+        {
+                if (value) {
+                        c.set();
+                } else {
+                        c.reset();
+                }
+        }
+
+        // Native and worth keeping, the element-wise fallback being a test per position; npos becomes size(), the door being total. [design.md#total-versus-precondition]
+        [[nodiscard]] static auto find_first(bits_type const& c) noexcept
+                -> std::size_t
+        {
+                auto const n = c.find_first();
+                return n == bits_type::npos ? c.size() : n;
+        }
+
+        [[nodiscard]] static auto find_next(bits_type const& c, std::size_t n) noexcept
+                -> std::size_t
+        {
+                auto const next = c.find_next(n);
+                return next == bits_type::npos ? c.size() : next;
+        }
+
+        // No find_last, find_prev or block access: boost has none, so the door synthesizes what it can. [design.md#detection-by-absence]
+};
+
+}       // namespace xstd
 
 // Specializing set_find rather than using ADL: dynamic_bitset's own members would silently shadow a same-named free function.
 namespace xstd::ranges {

--- a/include/xstd/bits/ext/std/bitset.hpp
+++ b/include/xstd/bits/ext/std/bitset.hpp
@@ -8,6 +8,7 @@
 
 // IWYU pragma: always_keep
 
+#include <xstd/bits/bit_traits.hpp>                // bit_traits
 #include <xstd/bits/ranges/bit_extent.hpp>         // bit_extent
 #include <xstd/bits/ranges/block_access.hpp>       // block_access
 #include <xstd/bits/ranges/sequence_view.hpp>      // sequence_find, sequence_view
@@ -17,11 +18,79 @@
 #include <bitset>                                  // IWYU pragma: export; bitset
 #include <cassert>                                 // assert
 #include <compare>                                 // strong_ordering
+#include <concepts>                                // convertible_to
 #include <cstddef>                                 // size_t
 #include <limits>                                  // numeric_limits
 #include <ranges>                                  // find_if
 #include <utility>                                 // declval
                                                    // iota
+
+// The one door for std::bitset; [namespace.std] forbids ADL hooks here, and a specialization needs none. [design.md#the-door]
+namespace xstd {
+
+template<std::size_t N>
+struct bit_traits<std::bitset<N>>
+{
+        using bits_type = std::bitset<N>;
+
+        static constexpr std::size_t extent = N;
+
+        [[nodiscard]] static constexpr auto size (bits_type const&)                  noexcept -> std::size_t { return N;         }
+        [[nodiscard]] static constexpr auto at   (bits_type const& c, std::size_t n) noexcept -> bool        { return c[n];      }
+        [[nodiscard]] static constexpr auto count(bits_type const& c)                noexcept -> std::size_t { return c.count(); }
+
+        static constexpr void assign(bits_type& c, std::size_t n, bool value) noexcept { c[n] = value; }
+
+        // A static width cannot grow, so inserting is assigning with the position as a precondition. [design.md#what-the-door-reconciles]
+        static constexpr void insert(bits_type& c, std::size_t n) noexcept
+        {
+                assert(n < N);
+                c[n] = true;
+        }
+
+        static constexpr void fill(bits_type& c, bool value) noexcept
+        {
+                if (value) {
+                        c.set();
+                } else {
+                        c.reset();
+                }
+        }
+
+        // Constrained, not guarded on the platform: without _Getword block_readable goes unsatisfied and the walks stay element-wise. [design.md#detection-by-absence]
+        [[nodiscard]] static constexpr auto num_blocks(bits_type const& c) noexcept
+                -> std::size_t
+                requires requires { { c._Getword(0UZ) } -> xstd::unsigned_integer; }
+        {
+                constexpr auto digits = static_cast<std::size_t>(std::numeric_limits<decltype(c._Getword(0UZ))>::digits);
+                return N == 0UZ ? 1UZ : (N + digits - 1UZ) / digits;
+        }
+
+        [[nodiscard]] static constexpr auto block(bits_type const& c, std::size_t i) noexcept
+                requires requires { { c._Getword(0UZ) } -> xstd::unsigned_integer; }
+        {
+                return c._Getword(i);
+        }
+
+        // The two reserved names are COMPLEMENTARY, not paired: libstdc++ has these and no reachable _Getword, MSVC the reverse. [design.md#the-two-reserved-names]
+        [[nodiscard]] static constexpr auto find_first(bits_type const& c) noexcept
+                -> std::size_t
+                requires requires { { c._Find_first() } -> std::convertible_to<std::size_t>; }
+        {
+                return c._Find_first();
+        }
+
+        [[nodiscard]] static constexpr auto find_next(bits_type const& c, std::size_t n) noexcept
+                -> std::size_t
+                requires requires { { c._Find_next(n) } -> std::convertible_to<std::size_t>; }
+        {
+                return c._Find_next(n);
+        }
+
+        // No find_last or find_prev: the width answers one and neither library scans backwards. [design.md#the-two-reserved-names]
+};
+
+}       // namespace xstd
 
 // std::bitset's only associated namespace is std, where [namespace.std] forbids adding ADL hooks, so specialize set_find instead.
 namespace xstd::ranges {

--- a/include/xstd/bits/ranges/sequence_view.hpp
+++ b/include/xstd/bits/ranges/sequence_view.hpp
@@ -95,15 +95,14 @@ struct sequence_ops
         }
 };
 
-// The sequence ordering, defined once: the bools in position order, compared lexicographically through value_type.
+// The sequence ordering, defined once: the bools in position order, lexicographically, no comparator. [design.md#proxies-compare-themselves]
 template<std::ranges::input_range X, std::ranges::input_range Y>
 [[nodiscard]] constexpr auto sequence_three_way(X const& x, Y const& y) noexcept
         -> std::strong_ordering
 {
         return std::lexicographical_compare_three_way(
                 std::ranges::begin(x), std::ranges::end(x),
-                std::ranges::begin(y), std::ranges::end(y),
-                [](bool a, bool b) static noexcept -> std::strong_ordering { return static_cast<int>(a) <=> static_cast<int>(b); }
+                std::ranges::begin(y), std::ranges::end(y)
         );
 }
 

--- a/test/src/bits/block_sequence.cpp
+++ b/test/src/bits/block_sequence.cpp
@@ -437,19 +437,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(TheDoorForwardsToTheStorage, T, test::graded_exten
                 BOOST_CHECK(traits::block(c, k) == c.block(k));
         }
 
-        // The two entries the readings cannot synthesize: insert can grow where the storage allows, and fill is bulk. [design.md#what-the-door-reconciles]
-        traits::fill(c, true);
-        BOOST_CHECK_EQUAL(traits::count(c), N);
-        traits::fill(c, false);
-        BOOST_CHECK_EQUAL(traits::count(c), 0UZ);
-
-        for (auto i = 0UZ; i < N; ++i) {
-                traits::insert(c, i);
-                BOOST_CHECK(traits::at(c, i));
-        }
-        BOOST_CHECK_EQUAL(traits::count(c), N);
-        traits::fill(c, false);
-
         // One position at a time, set then cleared: assign's two arms are the point.
         for (auto i = 0UZ; i < N; ++i) {
                 traits::assign(c, i, true);
@@ -463,6 +450,24 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(TheDoorForwardsToTheStorage, T, test::graded_exten
                 BOOST_CHECK(not traits::at(c, i));
                 BOOST_CHECK_EQUAL(traits::count(c), 0UZ);
         }
+}
+
+// The two entries the readings cannot synthesize, in their own case: insert can grow where the storage allows, and fill is bulk. [design.md#what-the-door-reconciles]
+BOOST_AUTO_TEST_CASE_TEMPLATE(TheDoorInsertsAndFills, T, test::graded_extents<graded_block_array>)
+{
+        using traits = xstd::bit_traits<T>;
+        constexpr auto N = traits::extent;
+
+        auto c = T();
+        traits::fill(c, true);
+        BOOST_CHECK_EQUAL(traits::count(c), N);
+        traits::fill(c, false);
+        BOOST_CHECK_EQUAL(traits::count(c), 0UZ);
+
+        for (auto i = 0UZ; i < N; ++i) {
+                traits::insert(c, i);
+        }
+        BOOST_CHECK_EQUAL(traits::count(c), N);
 }
 
 namespace {

--- a/test/src/bits/block_sequence.cpp
+++ b/test/src/bits/block_sequence.cpp
@@ -437,6 +437,19 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(TheDoorForwardsToTheStorage, T, test::graded_exten
                 BOOST_CHECK(traits::block(c, k) == c.block(k));
         }
 
+        // The two entries the readings cannot synthesize: insert can grow where the storage allows, and fill is bulk. [design.md#what-the-door-reconciles]
+        traits::fill(c, true);
+        BOOST_CHECK_EQUAL(traits::count(c), N);
+        traits::fill(c, false);
+        BOOST_CHECK_EQUAL(traits::count(c), 0UZ);
+
+        for (auto i = 0UZ; i < N; ++i) {
+                traits::insert(c, i);
+                BOOST_CHECK(traits::at(c, i));
+        }
+        BOOST_CHECK_EQUAL(traits::count(c), N);
+        traits::fill(c, false);
+
         // One position at a time, set then cleared: assign's two arms are the point.
         for (auto i = 0UZ; i < N; ++i) {
                 traits::assign(c, i, true);
@@ -518,12 +531,10 @@ auto disagreements(BB const& empty) -> int
                         if (std::lexicographical_compare_three_way(sx.begin(), sx.end(), sy.begin(), sy.end()) != x.set_three_way(y)) {
                                 ++n;
                         }
-                        // A comparator, std::vector<bool> yielding proxies rather than bools.
+                        // No comparator: vector<bool>'s proxy converts to bool, which is what makes it three_way_comparable.
                         auto const qx = reference(x);
                         auto const qy = reference(y);
-                        if (std::lexicographical_compare_three_way(qx.begin(), qx.end(), qy.begin(), qy.end(),
-                                [](bool a, bool b) static noexcept -> std::strong_ordering { return static_cast<int>(a) <=> static_cast<int>(b); }
-                        ) != x.sequence_three_way(y)) {
+                        if (std::lexicographical_compare_three_way(qx.begin(), qx.end(), qy.begin(), qy.end()) != x.sequence_three_way(y)) {
                                 ++n;
                         }
                 }

--- a/test/src/bits/ext/boost/dynamic_bitset.cpp
+++ b/test/src/bits/ext/boost/dynamic_bitset.cpp
@@ -67,6 +67,27 @@ BOOST_AUTO_TEST_CASE(TheDoorAdaptsIt)
         BOOST_CHECK_EQUAL(traits::count(c), 21UZ);
         traits::fill(c, false);
         BOOST_CHECK_EQUAL(traits::count(c), 0UZ);
+
+        // The element-wise tier's not-found and boundary arms, which only a type without block access reaches. [design.md#per-instantiation-slots]
+        auto const empty = T(9);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_count<traits>(empty), 0UZ);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_last <traits>(empty), 9UZ);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_first<traits>(empty), 9UZ);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_prev <traits>(empty, 9UZ), 9UZ);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_prev <traits>(empty, 0UZ), 9UZ);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_next <traits>(empty, 9UZ), 9UZ);
+
+        // And its found arms, which the empty case cannot reach; the walks are scored per instantiation. [design.md#per-instantiation-slots]
+        auto populated = T(9);
+        populated.set(1);
+        populated.set(5);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_count<traits>(populated), 2UZ);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_first<traits>(populated), 1UZ);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_next <traits>(populated, 1UZ), 5UZ);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_next <traits>(populated, 5UZ), 9UZ);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_next <traits>(populated, 8UZ), 9UZ);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_prev <traits>(populated, 9UZ), 5UZ);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_prev <traits>(populated, 1UZ), 9UZ);
 }
 
 // The one bitset that orders itself, and wrongly: over a 4-bit universe its own < disagrees with std::set on 88 of 256 pairs, the view's on none.

--- a/test/src/bits/ext/boost/dynamic_bitset.cpp
+++ b/test/src/bits/ext/boost/dynamic_bitset.cpp
@@ -68,7 +68,13 @@ BOOST_AUTO_TEST_CASE(TheDoorAdaptsIt)
         traits::fill(c, false);
         BOOST_CHECK_EQUAL(traits::count(c), 0UZ);
 
-        // The element-wise tier's not-found and boundary arms, which only a type without block access reaches. [design.md#per-instantiation-slots]
+}
+
+// The element-wise tier's not-found and boundary arms, which only a type without block access reaches. [design.md#per-instantiation-slots]
+BOOST_AUTO_TEST_CASE(TheWalksAnswerAtTheBoundaries)
+{
+        using traits = xstd::bit_traits<T>;
+
         auto const empty = T(9);
         BOOST_CHECK_EQUAL(xstd::detail::bits::scan_count<traits>(empty), 0UZ);
         BOOST_CHECK_EQUAL(xstd::detail::bits::scan_last <traits>(empty), 9UZ);

--- a/test/src/bits/ext/boost/dynamic_bitset.cpp
+++ b/test/src/bits/ext/boost/dynamic_bitset.cpp
@@ -5,6 +5,7 @@
 
 #include <boost/test/unit_test.hpp>               // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
 #include <test/dynamic.hpp>                       // dynamic
+#include <xstd/bits/bit_traits.hpp>               // bit_storage, bit_traits, block_readable, static_bit_extent
 #include <xstd/bits/ext/boost/dynamic_bitset.hpp> // the hooks that make dynamic_bitset a bit range
 #include <xstd/bits/ranges/sequence_view.hpp>     // sequence_range
 #include <xstd/bits/ranges/set_view.hpp>          // set_range, set_view
@@ -24,6 +25,48 @@ using T = boost::dynamic_bitset<>;
 BOOST_AUTO_TEST_CASE(IsRegular)
 {
         static_assert(std::regular<T>);
+}
+
+// One specialization where three stood; the only adapted type whose width grows, and the only one with no block access. [design.md#the-door]
+BOOST_AUTO_TEST_CASE(TheDoorAdaptsIt)
+{
+        using traits = xstd::bit_traits<T>;
+
+        static_assert(xstd::bit_storage<T>);
+        static_assert(not xstd::static_bit_extent<T>);
+        static_assert(not xstd::block_readable<traits, T>);
+
+        auto c = T(9);
+        BOOST_CHECK_EQUAL(traits::size(c), 9UZ);
+        BOOST_CHECK_EQUAL(traits::count(c), 0UZ);
+
+        // npos becomes size(), the door being total where boost is not. [design.md#total-versus-precondition]
+        BOOST_CHECK_EQUAL(traits::find_first(c), 9UZ);
+
+        traits::insert(c, 3);
+        BOOST_CHECK(traits::at(c, 3));
+        BOOST_CHECK_EQUAL(traits::find_first(c), 3UZ);
+        BOOST_CHECK_EQUAL(traits::find_next(c, 3), 9UZ);
+
+        // The one entry that grows: a position past the width extends it rather than asserting.
+        traits::insert(c, 20);
+        BOOST_CHECK_EQUAL(traits::size(c), 21UZ);
+        BOOST_CHECK_EQUAL(traits::count(c), 2UZ);
+        BOOST_CHECK_EQUAL(traits::find_next(c, 3), 20UZ);
+
+        // Synthesized, boost having neither: the width answers one and the element walk the other.
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_last<traits>(c), 21UZ);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_prev<traits>(c, 21), 20UZ);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_prev<traits>(c, 20), 3UZ);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_prev<traits>(c, 3), 21UZ);
+
+        traits::assign(c, 20, false);
+        BOOST_CHECK(not traits::at(c, 20));
+
+        traits::fill(c, true);
+        BOOST_CHECK_EQUAL(traits::count(c), 21UZ);
+        traits::fill(c, false);
+        BOOST_CHECK_EQUAL(traits::count(c), 0UZ);
 }
 
 // The one bitset that orders itself, and wrongly: over a 4-bit universe its own < disagrees with std::set on 88 of 256 pairs, the view's on none.

--- a/test/src/bits/ext/std/bitset.cpp
+++ b/test/src/bits/ext/std/bitset.cpp
@@ -67,8 +67,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(TheDoorAdaptsIt, T, Types)
         BOOST_CHECK_EQUAL(traits::count(c), N);
         traits::fill(c, false);
         BOOST_CHECK_EQUAL(traits::count(c), 0UZ);
+}
 
-        // The element-wise tier's not-found and boundary arms, which only a type without block access reaches. [design.md#per-instantiation-slots]
+// The element-wise tier's not-found and boundary arms, which only a type without block access reaches. [design.md#per-instantiation-slots]
+BOOST_AUTO_TEST_CASE_TEMPLATE(TheWalksAnswerAtTheBoundaries, T, Types)
+{
+        using traits = xstd::bit_traits<T>;
+        constexpr auto N = traits::extent;
+
         auto const empty = T();
         BOOST_CHECK_EQUAL(xstd::detail::bits::scan_count<traits>(empty), 0UZ);
         BOOST_CHECK_EQUAL(xstd::detail::bits::scan_last <traits>(empty), N);

--- a/test/src/bits/ext/std/bitset.cpp
+++ b/test/src/bits/ext/std/bitset.cpp
@@ -52,6 +52,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(TheDoorAdaptsIt, T, Types)
                 traits::insert(c, i);
                 BOOST_CHECK(traits::at(c, i));
                 BOOST_CHECK_EQUAL(traits::count(c), 1UZ);
+                // The synthesized count too, so its per-position ternary sees both a set and a clear one.
+                BOOST_CHECK_EQUAL(xstd::detail::bits::scan_count<traits>(c), 1UZ);
                 BOOST_CHECK_EQUAL(xstd::detail::bits::scan_first<traits>(c), i);
                 BOOST_CHECK_EQUAL(xstd::detail::bits::scan_prev<traits>(c, N), i);
                 BOOST_CHECK_EQUAL(xstd::detail::bits::scan_next<traits>(c, i), N);
@@ -65,6 +67,15 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(TheDoorAdaptsIt, T, Types)
         BOOST_CHECK_EQUAL(traits::count(c), N);
         traits::fill(c, false);
         BOOST_CHECK_EQUAL(traits::count(c), 0UZ);
+
+        // The element-wise tier's not-found and boundary arms, which only a type without block access reaches. [design.md#per-instantiation-slots]
+        auto const empty = T();
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_count<traits>(empty), 0UZ);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_last <traits>(empty), N);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_first<traits>(empty), N);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_prev <traits>(empty, N), N);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_prev <traits>(empty, 0UZ), N);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_next <traits>(empty, N), N);
 }
 
 // The two reserved names are complementary: libstdc++ has _Find_first and no reachable _Getword, MSVC the reverse, libc++ neither. [design.md#the-two-reserved-names]
@@ -86,6 +97,9 @@ BOOST_AUTO_TEST_CASE(WhicheverTierThePlatformOffersIsTheOneTaken)
         BOOST_CHECK_EQUAL(xstd::detail::bits::scan_prev<traits>(c, 7UZ), 64UZ);
         BOOST_CHECK_EQUAL(xstd::detail::bits::scan_last<traits>(c), 64UZ);
         BOOST_CHECK_EQUAL(xstd::detail::bits::scan_count<traits>(c), 2UZ);
+
+        // From the last position, so the inclusive primitive is asked for one past the width. [design.md#inclusive-is-the-primitive]
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_next<traits>(c, 63UZ), 64UZ);
 }
 
 // The adaptor's whole job: std::bitset has no ordering, and none can legally be added to namespace std, so the set reading supplies it.

--- a/test/src/bits/ext/std/bitset.cpp
+++ b/test/src/bits/ext/std/bitset.cpp
@@ -4,8 +4,9 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/test/unit_test.hpp>           // BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
+#include <xstd/bits/bit_traits.hpp>           // bit_storage, bit_traits, static_bit_extent
 #include <xstd/bits/bitset.hpp>               // bitset
-#include <xstd/bits/ext/std/bitset.hpp>       // bit_extent, set_find, sequence_find
+#include <xstd/bits/ext/std/bitset.hpp>       // bit_extent, bit_traits, set_find, sequence_find
 #include <xstd/bits/ranges/sequence_view.hpp> // sequence_range
 #include <xstd/bits/ranges/set_view.hpp>      // set_range, set_view
 #include <bitset>                             // bitset
@@ -31,6 +32,60 @@ using Types = std::tuple
 BOOST_AUTO_TEST_CASE_TEMPLATE(IsRegular, T, Types)
 {
         static_assert(std::regular<T>);
+}
+
+// One specialization where five stood, and every entry the readings will ask for. [design.md#the-door]
+BOOST_AUTO_TEST_CASE_TEMPLATE(TheDoorAdaptsIt, T, Types)
+{
+        using traits = xstd::bit_traits<T>;
+        constexpr auto N = traits::extent;
+
+        static_assert(xstd::bit_storage<T>);
+        static_assert(xstd::static_bit_extent<T>);
+        static_assert(N == T().size());
+
+        auto c = T();
+        BOOST_CHECK_EQUAL(traits::size(c), N);
+        BOOST_CHECK_EQUAL(traits::count(c), 0UZ);
+
+        for (auto i = 0UZ; i < N; ++i) {
+                traits::insert(c, i);
+                BOOST_CHECK(traits::at(c, i));
+                BOOST_CHECK_EQUAL(traits::count(c), 1UZ);
+                BOOST_CHECK_EQUAL(xstd::detail::bits::scan_first<traits>(c), i);
+                BOOST_CHECK_EQUAL(xstd::detail::bits::scan_prev<traits>(c, N), i);
+                BOOST_CHECK_EQUAL(xstd::detail::bits::scan_next<traits>(c, i), N);
+
+                traits::assign(c, i, false);
+                BOOST_CHECK(not traits::at(c, i));
+        }
+
+        // fill both ways, which is what the set reading's clear() and the sequence reading's fill() become.
+        traits::fill(c, true);
+        BOOST_CHECK_EQUAL(traits::count(c), N);
+        traits::fill(c, false);
+        BOOST_CHECK_EQUAL(traits::count(c), 0UZ);
+}
+
+// The two reserved names are complementary: libstdc++ has _Find_first and no reachable _Getword, MSVC the reverse, libc++ neither. [design.md#the-two-reserved-names]
+BOOST_AUTO_TEST_CASE(WhicheverTierThePlatformOffersIsTheOneTaken)
+{
+        using T = std::bitset<64>;
+        using traits = xstd::bit_traits<T>;
+
+        // Whatever this platform supplies, the walks answer the same thing; nothing below is conditioned on which tier ran.
+        auto c = T();
+        c.set(7);
+        c.set(40);
+
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_first<traits>(c), 7UZ);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_next<traits>(c, 7UZ), 40UZ);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_next<traits>(c, 40UZ), 64UZ);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_prev<traits>(c, 64UZ), 40UZ);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_prev<traits>(c, 40UZ), 7UZ);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_prev<traits>(c, 7UZ), 64UZ);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_last<traits>(c), 64UZ);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::scan_count<traits>(c), 2UZ);
 }
 
 // The adaptor's whole job: std::bitset has no ordering, and none can legally be added to namespace std, so the set reading supplies it.


### PR DESCRIPTION
The first half of step 3b of #80. Both foreign types get a `bit_traits` specialization and `block_sequence` gains the two entries the readings cannot synthesize. The old probes stay, so nothing is rewired yet — this is additive, and the second half switches the views over and deletes them.

## The census is mostly forced

Almost every operation the two readings need is already an entry, or is the same operation under another name:

| what a reading calls | door entry | |
|---|---|---|
| set `size()` (cardinality) | `count` | |
| set `max_size()` (width) | `size` | |
| `contains(n)` | `at(c, n)` | the same operation |
| set `erase(n)` | `assign(c, n, false)` | the same operation |
| set `clear()` | `fill(c, false)` | |
| sequence `size()` / `assign` | `size` / `assign` | |
| `bit_extent<Bits>` | `extent` | 3a replaced it |
| `set_find::*`, `sequence_find::*` | `find_*`, `at` | |
| `set_compare::lexicographical_three_way` | `set_three_way` | #94 |

Two are left over, and they are the two that cannot be derived:

- **`insert`** is the only operation that can *grow*, and it is exactly what the adapted types disagree about — boost resizes, `std::bitset` cannot, `block_sequence` asserts. Reconciling that is what a door is for. It is **not** `assign(c, n, true)`, which has no answer for a position past the width.
- **`fill`** is bulk, and `clear` is `fill(false)`.

## Two findings, both the opposite of what they look like

**`std::bitset`'s implementation hooks are complementary, not paired.**

| | `_Getword` | `_Find_first` / `_Find_next` |
|---|---|---|
| libstdc++ | no — it is `_M_getword`, on an inaccessible base | **yes** |
| MSVC | **yes** | no |
| libc++ | no | no |

I had assumed they travelled together and was about to drop the `find_*` entries on the grounds that the block tier already covered them. It would have been a real regression on libstdc++, where there is no block tier at all. Each hook now gets its own constrained entry. Both `find_*` answer `N` when nothing is set — already the door's total contract, unlike boost's `npos`, which the boost specialization maps.

**Neither ordering needs a comparator.** A proxy reference converts implicitly to its `value_type`, and that conversion is what satisfies `three_way_comparable`. Verified for this library's `sequence_reference` and for `std::vector<bool>::reference`: `lexicographical_compare_three_way` works on both with no comparator at all. The explicit `[](bool a, bool b) { return int(a) <=> int(b); }` comes out of `sequence_three_way` and out of the `block_sequence` test — it said nothing the conversion had not already said.

## What each specialization gets

`std::bitset<N>` — five specializations (`bit_extent`, `set_find`, `set_compare`, `block_access`, `sequence_find`) collapse to one, once the second half lands. Constrained `num_blocks`/`block` on `_Getword`, constrained `find_first`/`find_next` on `_Find_first`/`_Find_next`. No `find_last` (the width answers it) and no `find_prev` — neither library scans backwards, so the door synthesizes one, **block-wise wherever `_Getword` is reachable**. That fixes today's O(N²) reverse iteration on MSVC.

`boost::dynamic_bitset` — the only adapted type whose width grows, and the only one with no block access at all; it exposes its blocks as a range, never by index. Native `find_first`/`find_next` are kept because the element-wise fallback is a test per position.

## Verification

- [x] Suite **28/28 buildable tests pass**; the four that do not build locally fail identically on unmodified `main`.
- [x] The three affected TUs pass under **ASan + UBSan**.
- [x] **Coverage is neutral.** The `ext/` headers' uncovered sets match an unmodified `main` line for line after the shift (lines 56/60 → 126/130, a 70-line insertion), and `block_sequence.hpp`'s is unchanged at 61/14.
- [x] gcc `-Werror`: **0**. clang-tidy reports **nothing** in the changed files; the four findings it does report are present identically on `main`.
- [x] Every `[design.md#anchor]` resolves; the one-line comment gate is back to the four bodies CONTRIBUTING.md requires.

## Tests added

`TheDoorAdaptsIt` for each foreign type walks every entry the readings will ask for, and drives the synthesized walks alongside the native ones. `WhicheverTierThePlatformOffersIsTheOneTaken` pins the scan answers on `std::bitset<64>` without conditioning on which tier ran, so it holds on all three standard libraries. The boost case covers the growing `insert` and the `npos` → `size()` mapping. `TheDoorForwardsToTheStorage` gains the two new `block_sequence` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gfTqPbkbmFo2yfGSCDRpU

---
_Generated by [Claude Code](https://claude.ai/code/session_016gfTqPbkbmFo2yfGSCDRpU)_