### PR TITLE
Give our three owning types a door of their own

### DIFF
--- a/include/xstd/bits/bit_array.hpp
+++ b/include/xstd/bits/bit_array.hpp
@@ -159,6 +159,36 @@ template<std::size_t N, xstd::unsigned_integer Block>
 
 template<std::size_t N, xstd::unsigned_integer Block> constexpr void swap(bit_array<N, Block>& x, bit_array<N, Block>& y) noexcept(noexcept(x.swap(y))) { x.swap(y); }
 
+
+// Each entry unwraps to the storage's own door, which already answers all of them. [design.md#the-door]
+template<std::size_t N, xstd::unsigned_integer Block>
+struct bit_traits<bit_array<N, Block>>
+{
+        using bits_type = bit_array<N, Block>;
+        using backend   = bit_traits<block_array<Block, N>>;
+
+        static constexpr std::size_t extent = N;
+
+        [[nodiscard]] static constexpr auto size (bits_type const& c)                noexcept -> std::size_t { return backend::size(c.m_bits);  }
+        [[nodiscard]] static constexpr auto at   (bits_type const& c, std::size_t n) noexcept -> bool        { return backend::at(c.m_bits, n); }
+        [[nodiscard]] static constexpr auto count(bits_type const& c)                noexcept -> std::size_t { return backend::count(c.m_bits); }
+
+        static constexpr void assign(bits_type& c, std::size_t n, bool value) noexcept { backend::assign(c.m_bits, n, value); }
+        static constexpr void insert(bits_type& c, std::size_t n)             noexcept { backend::insert(c.m_bits, n);        }
+        static constexpr void fill  (bits_type& c, bool value)                noexcept { backend::fill(c.m_bits, value);      }
+
+        [[nodiscard]] static constexpr auto num_blocks(bits_type const& c)                noexcept -> std::size_t { return backend::num_blocks(c.m_bits); }
+        [[nodiscard]] static constexpr auto block     (bits_type const& c, std::size_t i) noexcept                { return backend::block(c.m_bits, i);   }
+
+        [[nodiscard]] static constexpr auto find_first(bits_type const& c)                noexcept -> std::size_t { return backend::find_first(c.m_bits);   }
+        [[nodiscard]] static constexpr auto find_last (bits_type const& c)                noexcept -> std::size_t { return backend::find_last(c.m_bits);    }
+        [[nodiscard]] static constexpr auto find_next (bits_type const& c, std::size_t n) noexcept -> std::size_t { return backend::find_next(c.m_bits, n); }
+        [[nodiscard]] static constexpr auto find_prev (bits_type const& c, std::size_t n) noexcept -> std::size_t { return backend::find_prev(c.m_bits, n); }
+
+        [[nodiscard]] static constexpr auto set_three_way     (bits_type const& x, bits_type const& y) noexcept -> std::strong_ordering { return backend::set_three_way(x.m_bits, y.m_bits);      }
+        [[nodiscard]] static constexpr auto sequence_three_way(bits_type const& x, bits_type const& y) noexcept -> std::strong_ordering { return backend::sequence_three_way(x.m_bits, y.m_bits); }
+};
+
 }       // namespace xstd
 
 #endif // XSTD_BITS_BIT_ARRAY_HPP

--- a/include/xstd/bits/bit_array.hpp
+++ b/include/xstd/bits/bit_array.hpp
@@ -35,6 +35,7 @@ using bit_array = xstd::bit_array<xstd::align_up(N, static_cast<std::size_t>(std
 }       // namespace xstd
 
 // NOLINTBEGIN(readability-duplicate-include): synopsis and implementation each list what that section needs.
+#include <xstd/bits/bit_traits.hpp>     // bit_traits
 #include <xstd/bits/block_sequence.hpp> // block_array
 #include <xstd/bits/ranges.hpp>         // begin, end, iterator, reference
 #include <xstd/ints/memory.hpp>         // align_up

--- a/include/xstd/bits/bit_finite_set.hpp
+++ b/include/xstd/bits/bit_finite_set.hpp
@@ -41,6 +41,7 @@ using bit_finite_set = xstd::bit_finite_set<xstd::align_up(N, static_cast<std::s
 
 // NOLINTBEGIN(readability-duplicate-include): synopsis and implementation each list what that section needs.
 #include <boost/hash2/hash_append.hpp>             // hash_append
+#include <xstd/bits/bit_traits.hpp>                // bit_traits
 #include <xstd/bits/block_sequence.hpp>            // block_array
 #include <xstd/bits/ranges.hpp>                    // const_iterator, const_reference
 #include <cassert>                                 // assert

--- a/include/xstd/bits/bit_finite_set.hpp
+++ b/include/xstd/bits/bit_finite_set.hpp
@@ -66,6 +66,9 @@ class bit_finite_set
 {
         block_array<Block, N> m_bits{};
 
+        // The door reaches the storage; nothing else needs to. [design.md#the-door]
+        friend struct bit_traits<bit_finite_set>;
+
         // ADL rather than a specialization, because this type is ours to add hidden friends to.
         [[nodiscard]] friend constexpr auto block_count(const bit_finite_set& c) noexcept -> std::size_t { return c.m_bits.num_blocks(); }
         [[nodiscard]] friend constexpr auto block_at(const bit_finite_set& c, std::size_t i) noexcept -> Block { return c.m_bits.block(i); }
@@ -320,6 +323,36 @@ template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr au
 
 template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr auto operator<<(const bit_finite_set<N, Block>& lhs, std::size_t n) noexcept -> bit_finite_set<N, Block> { auto nrv = lhs; nrv <<= n; return nrv; }
 template<std::size_t N, xstd::unsigned_integer Block> [[nodiscard]] constexpr auto operator>>(const bit_finite_set<N, Block>& lhs, std::size_t n) noexcept -> bit_finite_set<N, Block> { auto nrv = lhs; nrv >>= n; return nrv; }
+
+
+// Each entry unwraps to the storage's own door; one friend declaration replaces the six hidden friends. [design.md#the-door]
+template<std::size_t N, xstd::unsigned_integer Block>
+struct bit_traits<bit_finite_set<N, Block>>
+{
+        using bits_type = bit_finite_set<N, Block>;
+        using backend   = bit_traits<block_array<Block, N>>;
+
+        static constexpr std::size_t extent = N;
+
+        [[nodiscard]] static constexpr auto size (bits_type const& c)                noexcept -> std::size_t { return backend::size(c.m_bits);  }
+        [[nodiscard]] static constexpr auto at   (bits_type const& c, std::size_t n) noexcept -> bool        { return backend::at(c.m_bits, n); }
+        [[nodiscard]] static constexpr auto count(bits_type const& c)                noexcept -> std::size_t { return backend::count(c.m_bits); }
+
+        static constexpr void assign(bits_type& c, std::size_t n, bool value) noexcept { backend::assign(c.m_bits, n, value); }
+        static constexpr void insert(bits_type& c, std::size_t n)             noexcept { backend::insert(c.m_bits, n);        }
+        static constexpr void fill  (bits_type& c, bool value)                noexcept { backend::fill(c.m_bits, value);      }
+
+        [[nodiscard]] static constexpr auto num_blocks(bits_type const& c)                noexcept -> std::size_t { return backend::num_blocks(c.m_bits); }
+        [[nodiscard]] static constexpr auto block     (bits_type const& c, std::size_t i) noexcept                { return backend::block(c.m_bits, i);   }
+
+        [[nodiscard]] static constexpr auto find_first(bits_type const& c)                noexcept -> std::size_t { return backend::find_first(c.m_bits);   }
+        [[nodiscard]] static constexpr auto find_last (bits_type const& c)                noexcept -> std::size_t { return backend::find_last(c.m_bits);    }
+        [[nodiscard]] static constexpr auto find_next (bits_type const& c, std::size_t n) noexcept -> std::size_t { return backend::find_next(c.m_bits, n); }
+        [[nodiscard]] static constexpr auto find_prev (bits_type const& c, std::size_t n) noexcept -> std::size_t { return backend::find_prev(c.m_bits, n); }
+
+        [[nodiscard]] static constexpr auto set_three_way     (bits_type const& x, bits_type const& y) noexcept -> std::strong_ordering { return backend::set_three_way(x.m_bits, y.m_bits);      }
+        [[nodiscard]] static constexpr auto sequence_three_way(bits_type const& x, bits_type const& y) noexcept -> std::strong_ordering { return backend::sequence_three_way(x.m_bits, y.m_bits); }
+};
 
 }       // namespace xstd
 

--- a/include/xstd/bits/bitset.hpp
+++ b/include/xstd/bits/bitset.hpp
@@ -59,6 +59,9 @@ class bitset
         // No iteration and no <=> here by design, because std::bitset has neither: choose set_view or sequence_view.
         block_array<Block, N> m_bits{};
 
+        // The door reaches the storage; nothing else needs to. [design.md#the-door]
+        friend struct bit_traits<bitset>;
+
         // ADL rather than a specialization, because this type is ours to add hidden friends to.
         [[nodiscard]] friend constexpr auto block_count(const bitset& c) noexcept -> std::size_t { return c.m_bits.num_blocks(); }
         [[nodiscard]] friend constexpr auto block_at(const bitset& c, std::size_t i) noexcept -> Block { return c.m_bits.block(i); }
@@ -341,6 +344,36 @@ private:
                         )
                 );
         }
+};
+
+
+// Each entry unwraps to the storage's own door; one friend declaration replaces the two hidden friends. [design.md#the-door]
+template<std::size_t N, xstd::unsigned_integer Block>
+struct bit_traits<bitset<N, Block>>
+{
+        using bits_type = bitset<N, Block>;
+        using backend   = bit_traits<block_array<Block, N>>;
+
+        static constexpr std::size_t extent = N;
+
+        [[nodiscard]] static constexpr auto size (bits_type const& c)                noexcept -> std::size_t { return backend::size(c.m_bits);  }
+        [[nodiscard]] static constexpr auto at   (bits_type const& c, std::size_t n) noexcept -> bool        { return backend::at(c.m_bits, n); }
+        [[nodiscard]] static constexpr auto count(bits_type const& c)                noexcept -> std::size_t { return backend::count(c.m_bits); }
+
+        static constexpr void assign(bits_type& c, std::size_t n, bool value) noexcept { backend::assign(c.m_bits, n, value); }
+        static constexpr void insert(bits_type& c, std::size_t n)             noexcept { backend::insert(c.m_bits, n);        }
+        static constexpr void fill  (bits_type& c, bool value)                noexcept { backend::fill(c.m_bits, value);      }
+
+        [[nodiscard]] static constexpr auto num_blocks(bits_type const& c)                noexcept -> std::size_t { return backend::num_blocks(c.m_bits); }
+        [[nodiscard]] static constexpr auto block     (bits_type const& c, std::size_t i) noexcept                { return backend::block(c.m_bits, i);   }
+
+        [[nodiscard]] static constexpr auto find_first(bits_type const& c)                noexcept -> std::size_t { return backend::find_first(c.m_bits);   }
+        [[nodiscard]] static constexpr auto find_last (bits_type const& c)                noexcept -> std::size_t { return backend::find_last(c.m_bits);    }
+        [[nodiscard]] static constexpr auto find_next (bits_type const& c, std::size_t n) noexcept -> std::size_t { return backend::find_next(c.m_bits, n); }
+        [[nodiscard]] static constexpr auto find_prev (bits_type const& c, std::size_t n) noexcept -> std::size_t { return backend::find_prev(c.m_bits, n); }
+
+        [[nodiscard]] static constexpr auto set_three_way     (bits_type const& x, bits_type const& y) noexcept -> std::strong_ordering { return backend::set_three_way(x.m_bits, y.m_bits);      }
+        [[nodiscard]] static constexpr auto sequence_three_way(bits_type const& x, bits_type const& y) noexcept -> std::strong_ordering { return backend::sequence_three_way(x.m_bits, y.m_bits); }
 };
 
 }       // namespace xstd

--- a/include/xstd/bits/bitset.hpp
+++ b/include/xstd/bits/bitset.hpp
@@ -30,6 +30,7 @@ template<class charT, class traits, std::size_t N, xstd::unsigned_integer Block>
 
 #include <boost/hash2/fnv1a.hpp>                   // fnv1a_64
 #include <boost/hash2/hash_append.hpp>             // hash_append
+#include <xstd/bits/bit_traits.hpp>                // bit_traits
 #include <xstd/bits/block_sequence.hpp>            // block_array
 #include <xstd/bits/ranges/bit_extent.hpp>         // bit_extent
 #include <xstd/bits/ranges/sequence_view.hpp>      // sequence_find

--- a/test/include/test/door.hpp
+++ b/test/include/test/door.hpp
@@ -1,0 +1,93 @@
+//          Copyright Rein Halbersma 2014-2026.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef TEST_DOOR_HPP
+#define TEST_DOOR_HPP
+
+#include <xstd/bits/bit_traits.hpp> // bit_traits, bit_storage, block_readable, static_bit_extent
+#include <compare>                  // strong_ordering
+#include <cstddef>                  // size_t
+#include <vector>                   // vector
+
+// Every entry the readings will ask for, driven once against a model, so a forwarding specialization cannot silently drop one.
+namespace test {
+
+// Disagreements counted rather than asserted, so one call sites reports the width that broke. [design.md#counted-not-asserted]
+template<class T>
+[[nodiscard]] auto door_disagreements() -> int
+{
+        using traits = xstd::bit_traits<T>;
+        constexpr auto N = traits::extent;
+
+        auto disagreed = 0;
+        auto const differs = [&](bool wrong) -> void { disagreed += static_cast<int>(wrong); };
+
+        auto c = T();
+        differs(traits::size(c) != N);
+        differs(traits::count(c) != 0UZ);
+        differs(traits::num_blocks(c) == 0UZ);
+        differs(traits::find_first(c) != N);
+        differs(traits::find_last(c) != N);
+
+        // fill both ways, which is what the set reading's clear() and the sequence reading's fill() become.
+        traits::fill(c, true);
+        differs(traits::count(c) != N);
+        traits::fill(c, false);
+        differs(traits::count(c) != 0UZ);
+
+        return disagreed;
+}
+
+// The position-dependent entries, which a zero width has none to drive. [design.md#per-instantiation-slots]
+template<class T>
+[[nodiscard]] auto door_disagreements_at_positions() -> int
+{
+        using traits = xstd::bit_traits<T>;
+        constexpr auto N = traits::extent;
+
+        auto disagreed = 0;
+        auto const differs = [&](bool wrong) -> void { disagreed += static_cast<int>(wrong); };
+
+        for (auto i = 0UZ; i < N; ++i) {
+                auto c = T();
+                traits::insert(c, i);
+                differs(not traits::at(c, i));
+                differs(traits::count(c) != 1UZ);
+                differs(traits::find_first(c) != i);
+                differs(traits::find_prev(c, N) != i);
+                differs(traits::find_next(c, i) != N);
+                differs(xstd::detail::bits::scan_count<traits>(c) != 1UZ);
+
+                traits::assign(c, i, false);
+                differs(traits::at(c, i));
+        }
+        return disagreed;
+}
+
+// Both orderings, on a pair that differs at one position: whoever holds it is greater under either reading.
+template<class T>
+[[nodiscard]] auto door_ordering_disagreements() -> int
+{
+        using traits = xstd::bit_traits<T>;
+        constexpr auto N = traits::extent;
+
+        if constexpr (N == 0) {
+                return 0;
+        } else {
+                auto disagreed = 0;
+                auto held = T();
+                traits::insert(held, N - 1UZ);
+                auto const empty = T();
+
+                disagreed += static_cast<int>(traits::set_three_way(held, empty)      != std::strong_ordering::greater);
+                disagreed += static_cast<int>(traits::sequence_three_way(held, empty) != std::strong_ordering::greater);
+                disagreed += static_cast<int>(traits::set_three_way(empty, empty)     != std::strong_ordering::equal);
+                return disagreed;
+        }
+}
+
+} // namespace test
+
+#endif // TEST_DOOR_HPP

--- a/test/src/bits/bit_array.cpp
+++ b/test/src/bits/bit_array.cpp
@@ -4,10 +4,12 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/test/unit_test.hpp>   // BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
+#include <test/door.hpp>       // door_disagreements
 #include <test/block_types.hpp>       // graded_extents
 #include <test/sequence/concepts.hpp> // bit_sequence
 #include <test/value_reference.hpp>   // value_reference
 #include <xstd/bits/bit_array.hpp>    // bit_array
+#include <xstd/bits/bit_traits.hpp>   // bit_storage, bit_traits, block_readable, static_bit_extent
 #include <concepts>                   // regular, totally_ordered
 #include <iterator>                   // random_access_iterator
 #include <ranges>                     // random_access_range
@@ -47,6 +49,31 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ItsConstReferenceIsAValue, T, Types)
 BOOST_AUTO_TEST_CASE_TEMPLATE(IsABitSequence, T, Types)
 {
         static_assert(test::sequence::bit_sequence<T>);
+}
+
+
+// Every entry unwraps to the storage's own door, and none is silently dropped. [design.md#the-door]
+BOOST_AUTO_TEST_CASE_TEMPLATE(TheDoorAdaptsIt, T, Types)
+{
+        using traits = xstd::bit_traits<T>;
+
+        static_assert(xstd::bit_storage<T>);
+        static_assert(xstd::static_bit_extent<T>);
+        static_assert(xstd::block_readable<traits, T>);
+
+        BOOST_CHECK_EQUAL(test::door_disagreements<T>(), 0);
+}
+
+// The position-dependent entries, at every position the width offers. [design.md#per-instantiation-slots]
+BOOST_AUTO_TEST_CASE_TEMPLATE(TheDoorAnswersAtEveryPosition, T, Types)
+{
+        BOOST_CHECK_EQUAL(test::door_disagreements_at_positions<T>(), 0);
+}
+
+// Both orderings reach the storage's native block-wise members. [design.md#two-readings-disagree]
+BOOST_AUTO_TEST_CASE_TEMPLATE(TheDoorNamesBothOrderings, T, Types)
+{
+        BOOST_CHECK_EQUAL(test::door_ordering_disagreements<T>(), 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/bits/bit_finite_set.cpp
+++ b/test/src/bits/bit_finite_set.cpp
@@ -4,10 +4,12 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
+#include <test/door.hpp>         // door_disagreements
 #include <test/block_types.hpp>         // graded_extents
 #include <test/set/concepts.hpp>        // bit_set
 #include <test/value_reference.hpp>     // value_reference
 #include <xstd/bits/bit_finite_set.hpp> // bit_finite_set
+#include <xstd/bits/bit_traits.hpp>     // bit_storage, bit_traits, block_readable, static_bit_extent
 #include <concepts>                     // regular, totally_ordered
 #include <cstddef>                      // size_t
 #include <iterator>                     // bidirectional_iterator
@@ -81,6 +83,31 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(LookupIsTotalOverKeyType, T, Types)
                 check_key_outside_the_domain(T(), x);
                 check_key_outside_the_domain(full, x);
         }
+}
+
+
+// Every entry unwraps to the storage's own door, and none is silently dropped. [design.md#the-door]
+BOOST_AUTO_TEST_CASE_TEMPLATE(TheDoorAdaptsIt, T, Types)
+{
+        using traits = xstd::bit_traits<T>;
+
+        static_assert(xstd::bit_storage<T>);
+        static_assert(xstd::static_bit_extent<T>);
+        static_assert(xstd::block_readable<traits, T>);
+
+        BOOST_CHECK_EQUAL(test::door_disagreements<T>(), 0);
+}
+
+// The position-dependent entries, at every position the width offers. [design.md#per-instantiation-slots]
+BOOST_AUTO_TEST_CASE_TEMPLATE(TheDoorAnswersAtEveryPosition, T, Types)
+{
+        BOOST_CHECK_EQUAL(test::door_disagreements_at_positions<T>(), 0);
+}
+
+// Both orderings reach the storage's native block-wise members. [design.md#two-readings-disagree]
+BOOST_AUTO_TEST_CASE_TEMPLATE(TheDoorNamesBothOrderings, T, Types)
+{
+        BOOST_CHECK_EQUAL(test::door_ordering_disagreements<T>(), 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/bits/bitset.cpp
+++ b/test/src/bits/bitset.cpp
@@ -4,7 +4,9 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/test/unit_test.hpp>      // BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
+#include <test/door.hpp>          // door_disagreements
 #include <test/block_types.hpp>          // graded_extents
+#include <xstd/bits/bit_traits.hpp>      // bit_storage, bit_traits, block_readable, static_bit_extent
 #include <xstd/bits/bitset.hpp>          // bitset
 #include <xstd/bits/ranges/set_view.hpp> // set_view
 #include <concepts>                      // regular, totally_ordered
@@ -84,6 +86,31 @@ BOOST_AUTO_TEST_CASE(TheMutableSubscriptHandsOutAnAssignableProxy)
         swap(z, b[2]);
         BOOST_CHECK(b[2]);
         BOOST_CHECK(not z);
+}
+
+
+// Every entry unwraps to the storage's own door, and none is silently dropped. [design.md#the-door]
+BOOST_AUTO_TEST_CASE_TEMPLATE(TheDoorAdaptsIt, T, Types)
+{
+        using traits = xstd::bit_traits<T>;
+
+        static_assert(xstd::bit_storage<T>);
+        static_assert(xstd::static_bit_extent<T>);
+        static_assert(xstd::block_readable<traits, T>);
+
+        BOOST_CHECK_EQUAL(test::door_disagreements<T>(), 0);
+}
+
+// The position-dependent entries, at every position the width offers. [design.md#per-instantiation-slots]
+BOOST_AUTO_TEST_CASE_TEMPLATE(TheDoorAnswersAtEveryPosition, T, Types)
+{
+        BOOST_CHECK_EQUAL(test::door_disagreements_at_positions<T>(), 0);
+}
+
+// Both orderings reach the storage's native block-wise members. [design.md#two-readings-disagree]
+BOOST_AUTO_TEST_CASE_TEMPLATE(TheDoorNamesBothOrderings, T, Types)
+{
+        BOOST_CHECK_EQUAL(test::door_ordering_disagreements<T>(), 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Second half of step 3b of #80, part one. `bit_array`, `bit_finite_set` and `xstd::bitset` each get a `bit_traits` specialization, so the views can stop reaching them through hidden friends. Still additive — the probes and the friends both stand until the rewire, which is the next PR.

## Unwrap and defer

All three are a reading of a `block_array`, so none of them needs entries of its own:

```cpp
template<std::size_t N, xstd::unsigned_integer Block>
struct bit_traits<bit_finite_set<N, Block>>
{
        using bits_type = bit_finite_set<N, Block>;
        using backend   = bit_traits<block_array<Block, N>>;

        [[nodiscard]] static constexpr auto count(bits_type const& c) noexcept -> std::size_t { return backend::count(c.m_bits); }
        // …fifteen entries, each the backend's applied to m_bits
};
```

Every entry is the storage's entry, so there is nothing here that can drift from it. `bit_array` names its storage publicly and needs no privilege; the other two get **one friend declaration each**, which is what replaces their six and two hidden friends once the rewire deletes them.

## One semantic difference the rewire has to respect

The door's `find_*` are the **set** reading's scans. So `bit_array`'s door answers `find_first` with its first set position, where its old ADL friend answered `0` — the *sequence* reading's `begin`. Those friends served `sequence_find`, which is about iteration bounds, not set positions.

When `sequence_view` moves over, `sequence_begin`/`sequence_end` must map to `0` and `size`, **not** to `find_first`/`find_last`. Writing that down because it is exactly the kind of thing that compiles and passes half the tests.

## Verification, in the order the last PR taught

The two diagnostic lessons from #95 were applied as the *first* checks rather than the last, and both earned their place:

- **The project-wide mine-vs-base uncovered table, before anything else.** Built the suite with coverage on this tree and again in a worktree at `main`, then compared `(lines, branches)` per file under `include/`. Matches the new baseline exactly for every file, first try.
- **clang-tidy by check name, not by grepping its output.** That caught **four `misc-include-cleaner` findings before they could reach CI** — the three test files name `bit_traits` and its concepts, so they now include the header directly rather than leaning on `test/door.hpp`. The other findings it reports (`bit_finite_set.hpp:178`/`:180`, `bitset.hpp:106`) are `main`'s pre-existing four, shifted +3 by the friend declarations; the remaining four are in `xstd-ints`, a different repository.

Also: suite **28/28 buildable tests pass**, gcc `-Werror` **0**, no `readability-function-cognitive-complexity` finding on any of the three test files, every `[design.md#anchor]` resolves, one-line comment gate back to the four bodies CONTRIBUTING.md requires.

## Tests added

`test/include/test/door.hpp` carries the drive once rather than three times: `door_disagreements` for the width-independent entries, `door_disagreements_at_positions` for the position-dependent ones at every position the width offers, and `door_ordering_disagreements` for both orderings. Each of the three test files gets three small cases calling them — small deliberately, since a `BOOST_CHECK` inside a loop costs two points of cognitive complexity and that is what tipped the last PR over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gfTqPbkbmFo2yfGSCDRpU

---
_Generated by [Claude Code](https://claude.ai/code/session_016gfTqPbkbmFo2yfGSCDRpU)_