### PR TITLE
Grow block_sequence at a run-time width: step 7a of #80

### DIFF
--- a/design.md
+++ b/design.md
@@ -51,6 +51,26 @@ run-time width.
 A defaulted default constructor plus an NSDMI, rather than two constructors constrained on the extent:
 `std::vector` default-constructs empty, and the at-least-one-block invariant has to hold from the start.
 
+### growth
+
+Growth is the run-time width's alone, and every member of it leaves the unused tail clear. `resize(n, value)`
+resizes the blocks to what `n` needs, filled with `value`, moves the width, and masks the new last block;
+growing with ones first sets the old last block's tail, clear by the invariant, since those are the first new
+positions. `push_back` and `pop_back` are `resize` by one, `clear` is `resize(0)` -- the object a default
+constructor makes -- and `append(block)` is boost's: the block's bits become the next `bits_per_block`
+positions, split across two blocks where the width is not aligned, and the floor block takes the first one
+at width zero. `reserve`, `capacity` and `shrink_to_fit` are in bits and exist where the blocks have them:
+`std::vector` and `std::inplace_vector`, not `std::array`.
+
+`clear()` here is the sequence reading's, width to zero, which is what `std::vector<bool>` and
+`boost::dynamic_bitset` mean by it; the set reading's `clear()` is `fill(false)` and never reaches this
+member, so the landmine #80 recorded -- probing `clear()` on boost and emptying the width -- cannot recur.
+
+`block_inplace_vector<Block, N>` is the third storage: a run-time width under a compile-time capacity of `N`
+bits, behind `__cpp_lib_inplace_vector` until every library in the matrix has it. It needs nothing of its
+own, `std::inplace_vector` satisfying `block_storage` as it is; `resize`, `reserve` and `push_back` past the
+capacity throw `std::bad_alloc`, as that library specifies.
+
 ## Scans
 
 ### inclusive-is-the-primitive

--- a/include/xstd/bits/block_sequence.hpp
+++ b/include/xstd/bits/block_sequence.hpp
@@ -22,7 +22,7 @@
 #include <concepts>                                            // regular, swap
 #include <cstddef>                                             // ptrdiff_t, size_t
 #include <functional>                                          // plus
-#include <iterator>                                            // prev
+#include <iterator>                                            // distance, forward_iterator, input_iterator, prev
 #include <memory>                                              // allocator
 #include <ranges>                                              // begin, drop, iota, size, swap, transform, zip
                                                                // (views::drop_last when P22014R2 is accepted)
@@ -30,6 +30,10 @@
 #include <type_traits>                                         // conditional_t, is_const_v, is_nothrow_swappable_v, remove_reference_t
 #include <utility>                                             // pair
 #include <vector>                                              // vector
+#include <version>                                             // IWYU pragma: keep; __cpp_lib_inplace_vector
+#ifdef __cpp_lib_inplace_vector
+#include <inplace_vector>                                      // inplace_vector
+#endif
 
 namespace xstd {
 
@@ -76,13 +80,20 @@ private:
         static constexpr auto static_unused_bits     = static_cast<block_type>(~static_used_bits);
         static constexpr auto static_has_unused_bits = has_static_size and static_used_bits != ones;
 
+        // How many blocks a run-time width needs, floored at one like num_blocks_v. [design.md#the-one-vehicle]
+        [[nodiscard]] static constexpr auto blocks_for(std::size_t n) noexcept
+                -> std::size_t
+        {
+                return std::ranges::max(align_up(n, bits_per_block) / bits_per_block, 1UZ);
+        }
+
         // An NSDMI, not extent-constrained constructors: vector starts empty. [design.md#default-construction]
         [[nodiscard]] static constexpr auto make_blocks(std::size_t n) -> Blocks
         {
                 if constexpr (has_static_size) {
                         return Blocks{};
                 } else {
-                        return Blocks(std::ranges::max(align_up(n, bits_per_block) / bits_per_block, 1UZ));
+                        return Blocks(blocks_for(n));
                 }
         }
 
@@ -489,6 +500,89 @@ public:
                 std::ranges::swap(this->m_blocks, other.m_blocks);
         }
 
+        // Growth, at a run-time width alone; every path leaves the unused tail clear, so the block walks read nothing above size(). [design.md#growth]
+        constexpr void resize(std::size_t n, bool value = false)
+                requires (not has_static_size)
+        {
+                // Growing with ones: the tail above size() in the last block is clear by the invariant, and becomes the first new bits.
+                if (value and n > m_size) {
+                        m_blocks[last_block()] |= static_cast<block_type>(~used_bits());
+                }
+                m_blocks.resize(blocks_for(n), value ? ones : zero);
+                m_size = n;
+                erase_unused();
+        }
+
+        // Width zero, one block, all of it padding: the same object a default constructor makes. [design.md#default-construction]
+        constexpr void clear()
+                requires (not has_static_size)
+        {
+                resize(0UZ);
+        }
+
+        constexpr void push_back(bool value)
+                requires (not has_static_size)
+        {
+                resize(m_size + 1UZ, value);
+        }
+
+        constexpr void pop_back()
+                requires (not has_static_size)
+        {
+                assert(m_size != 0UZ);
+                resize(m_size - 1UZ);
+        }
+
+        // Boost's append: the block's bits become the positions [size(), size() + bits_per_block), split over two blocks where size() is not aligned.
+        constexpr void append(block_type value)
+                requires (not has_static_size)
+        {
+                auto const offset = m_size % bits_per_block;
+                if (offset != 0UZ) {
+                        m_blocks[last_block()] |= static_cast<block_type>(value << offset);
+                        m_blocks.push_back(static_cast<block_type>(value >> (bits_per_block - offset)));
+                } else if (m_size != 0UZ) {
+                        m_blocks.push_back(value);
+                } else {
+                        // The floor block is the fresh one.
+                        m_blocks[0] = value;
+                }
+                m_size += bits_per_block;
+        }
+
+        // Reserved first where the distance is known, so no push_back below can reallocate: the strong guarantee boost documents.
+        template<std::input_iterator I>
+        constexpr void append(I first, I last)
+                requires (not has_static_size)
+        {
+                if constexpr (std::forward_iterator<I> and requires (Blocks& b) { b.reserve(0UZ); }) {
+                        reserve(m_size + (static_cast<std::size_t>(std::ranges::distance(first, last)) * bits_per_block));
+                }
+                for (; first != last; ++first) {
+                        append(*first);
+                }
+        }
+
+        // In bits, where the blocks have the member: vector and inplace_vector do, array does not.
+        constexpr void reserve(std::size_t n)
+                requires (not has_static_size) and requires (Blocks& b) { b.reserve(0UZ); }
+        {
+                m_blocks.reserve(blocks_for(n));
+        }
+
+        [[nodiscard]] constexpr auto capacity() const noexcept
+                -> std::size_t
+                requires (not has_static_size) and requires (Blocks const& b) { b.capacity(); }
+        {
+                return m_blocks.capacity() * bits_per_block;
+        }
+
+        constexpr void shrink_to_fit()
+                requires (not has_static_size) and requires (Blocks& b) { b.shrink_to_fit(); }
+        {
+                m_blocks.shrink_to_fit();
+        }
+
         constexpr auto set(std::size_t n) noexcept -> block_sequence&
         {
                 assert(is_valid(n));
@@ -809,12 +903,18 @@ private:
         }
 };
 
-// The two vehicles shipped; std::inplace_vector needs no alias, already satisfying block_storage.
+// The three vehicles: a width in the type, a width on the heap, and a run-time width under a compile-time capacity of N bits.
 template<xstd::unsigned_integer Block, std::size_t N>
 using block_array = block_sequence<std::array<Block, num_blocks_v<Block, N>>, N>;
 
 template<xstd::unsigned_integer Block, class Allocator = std::allocator<Block>>
 using block_vector = block_sequence<std::vector<Block, Allocator>>;
+
+// Behind the feature macro until every library in the matrix has it; the storage needs nothing else, already satisfying block_storage.
+#ifdef __cpp_lib_inplace_vector
+template<xstd::unsigned_integer Block, std::size_t N>
+using block_inplace_vector = block_sequence<std::inplace_vector<Block, num_blocks_v<Block, N>>>;
+#endif
 
 // Forwards and nothing more, reaching none of the generic scans. [design.md#the-cheapest-contract]
 template<class Blocks, std::size_t N>

--- a/include/xstd/bits/ext/boost/dynamic_bitset.hpp
+++ b/include/xstd/bits/ext/boost/dynamic_bitset.hpp
@@ -66,6 +66,10 @@ struct bit_traits<boost::dynamic_bitset<Block, Allocator>>
         }
 
         // No find_last, find_prev or block access: boost has none, so the generic scans synthesize what they can. [design.md#detection-by-absence]
+
+        // The shifts are total here, saturating to none: forwarded as they are, the guard being the counterpart's own. [design.md#checked-and-unchecked]
+        static constexpr void checked_shift_left (bits_type& c, std::size_t n) noexcept { c <<= n; }
+        static constexpr void checked_shift_right(bits_type& c, std::size_t n) noexcept { c >>= n; }
 };
 
 }       // namespace xstd

--- a/test/include/test/inplace_vector.hpp
+++ b/test/include/test/inplace_vector.hpp
@@ -1,0 +1,26 @@
+//          Copyright Rein Halbersma 2014-2026.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef TEST_INPLACE_VECTOR_HPP
+#define TEST_INPLACE_VECTOR_HPP
+
+#include <version> // IWYU pragma: keep; __cpp_lib_inplace_vector
+
+// The third storage comes and goes with the library, the way xstd::uint128 comes and goes with the compiler. [design.md#growth]
+#ifdef __cpp_lib_inplace_vector
+#define TEST_HAS_INPLACE_VECTOR
+#endif
+
+namespace test {
+
+#ifdef TEST_HAS_INPLACE_VECTOR
+inline constexpr bool has_inplace_vector = true;
+#else
+inline constexpr bool has_inplace_vector = false;
+#endif
+
+} // namespace test
+
+#endif // TEST_INPLACE_VECTOR_HPP

--- a/test/src/bits/block_sequence.cpp
+++ b/test/src/bits/block_sequence.cpp
@@ -468,7 +468,7 @@ auto append_to(model& m, Block value) -> void
 // Dependent, so a constrained-away member is a false rather than a hard error.
 template<class X> constexpr bool can_resize    = requires (X& x) { x.resize(1UZ); x.resize(1UZ, true); };
 template<class X> constexpr bool can_push_pop  = requires (X& x) { x.push_back(true); x.pop_back(); };
-template<class X> constexpr bool can_append    = requires (X& x) { x.append(typename X::block_type{}); };
+template<class X> constexpr bool can_append    = requires (X& x) { x.append(x.block(0UZ)); };
 template<class X> constexpr bool can_clear     = requires (X& x) { x.clear(); };
 template<class X> constexpr bool can_reserve   = requires (X& x) { x.reserve(1UZ); x.shrink_to_fit(); };
 template<class X> constexpr bool has_capacity  = requires (X const& x) { x.capacity(); };

--- a/test/src/bits/block_sequence.cpp
+++ b/test/src/bits/block_sequence.cpp
@@ -459,7 +459,8 @@ template<class Block>
 auto append_to(model& m, Block value) -> void
 {
         for (auto i = 0UZ; i < test::digits_v<Block>; ++i) {
-                m.push_back(((value >> i) & Block{1}) != Block{0});
+                // Cast back before the mask: a shifted narrow word is an int, which bugprone-signed-bitwise reads as a signed operand.
+                m.push_back((static_cast<Block>(value >> i) & Block{1}) != Block{0});
         }
 }
 

--- a/test/src/bits/block_sequence.cpp
+++ b/test/src/bits/block_sequence.cpp
@@ -4,14 +4,16 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/test/unit_test.hpp>    // BOOST_CHECK_EQUAL, BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
-#include <test/block_types.hpp>        // graded_extents, word_types
+#include <test/block_types.hpp>        // digits_v, graded_extents, word_types
+#include <test/inplace_vector.hpp>     // IWYU pragma: keep; TEST_HAS_INPLACE_VECTOR
 #include <xstd/bits/bit_traits.hpp>    // bit_storage, bit_traits, block_readable, static_bit_extent
-#include <xstd/bits/block_sequence.hpp> // block_array, block_sequence, block_storage, block_vector
+#include <xstd/bits/block_sequence.hpp> // block_array, block_inplace_vector, block_sequence, block_storage, block_vector
 #include <algorithm>                   // count, lexicographical_compare_three_way, min
 #include <array>                       // array
 #include <compare>                     // strong_ordering
 #include <cstddef>                     // size_t
 #include <cstdint>                     // uint8_t, uint64_t
+#include <new>                         // IWYU pragma: keep; bad_alloc, behind TEST_HAS_INPLACE_VECTOR
 #include <ranges>                      // iota
 #include <utility>                     // pair
 #include <vector>                      // vector
@@ -413,6 +415,215 @@ BOOST_AUTO_TEST_CASE(ADefaultConstructedRunTimeWidthIsZeroWidthWithOneBlock)
         BOOST_CHECK_EQUAL(b.num_blocks(), 1UZ);
         BOOST_CHECK(b == xstd::block_vector<std::uint8_t>(0));
 }
+
+namespace {
+
+// A run-time width built from the model, so equality against it doubles as the invariant check: a dirty tail compares unequal.
+template<class T>
+[[nodiscard]] auto from_model(model const& m) -> T
+{
+        auto b = T(m.size());
+        for (auto i = 0UZ; i < m.size(); ++i) {
+                if (m[i]) { b.set(i); }
+        }
+        return b;
+}
+
+// Two in three set, so both fill values and every block boundary change something.
+[[nodiscard]] auto patterned(std::size_t n) -> model
+{
+        auto m = model(n);
+        for (auto i = 0UZ; i < n; ++i) {
+                m[i] = i % 3 != 1;
+        }
+        return m;
+}
+
+// The same grading the static sweep uses: within one block, and across boundaries either side.
+template<class Block>
+[[nodiscard]] constexpr auto graded_widths() -> std::array<std::size_t, 10>
+{
+        constexpr auto D = test::digits_v<Block>;
+        return { 0UZ, 1UZ, D - 1, D, D + 1, (2 * D) - 1, 2 * D, (2 * D) + 1, 3 * D, (3 * D) + 1 };
+}
+
+template<class Block>
+[[nodiscard]] constexpr auto blocks_for(std::size_t n) -> std::size_t
+{
+        constexpr auto D = test::digits_v<Block>;
+        return std::ranges::max((n + D - 1) / D, 1UZ);
+}
+
+// What append(block) should do to the model: the block's bits, least significant first.
+template<class Block>
+auto append_to(model& m, Block value) -> void
+{
+        for (auto i = 0UZ; i < test::digits_v<Block>; ++i) {
+                m.push_back(((value >> i) & Block{1}) != Block{0});
+        }
+}
+
+// Alternating pairs of bits, so a split at any offset lands ones on both sides.
+// Dependent, so a constrained-away member is a false rather than a hard error.
+template<class X> constexpr bool can_resize    = requires (X& x) { x.resize(1UZ); x.resize(1UZ, true); };
+template<class X> constexpr bool can_push_pop  = requires (X& x) { x.push_back(true); x.pop_back(); };
+template<class X> constexpr bool can_append    = requires (X& x) { x.append(typename X::block_type{}); };
+template<class X> constexpr bool can_clear     = requires (X& x) { x.clear(); };
+template<class X> constexpr bool can_reserve   = requires (X& x) { x.reserve(1UZ); x.shrink_to_fit(); };
+template<class X> constexpr bool has_capacity  = requires (X const& x) { x.capacity(); };
+
+template<class Block>
+[[nodiscard]] constexpr auto striped() -> Block
+{
+        auto value = Block{0};
+        for (auto i = 0UZ; i < test::digits_v<Block>; i += 4) {
+                value = static_cast<Block>(value | static_cast<Block>(Block{3} << i));
+        }
+        return value;
+}
+
+}       // namespace
+
+// Every resize path: each graded width to each other, with both fill values, against the model and against a fresh build from it. [design.md#growth]
+BOOST_AUTO_TEST_CASE_TEMPLATE(ResizingKeepsTheModelAndTheUnusedTailClear, Block, test::word_types)
+{
+        using T = xstd::block_vector<Block>;
+
+        auto disagreements = 0;
+        for (auto const from : graded_widths<Block>()) {
+                for (auto const to : graded_widths<Block>()) {
+                        for (auto const value : { false, true }) {
+                                auto m = patterned(from);
+                                auto b = from_model<T>(m);
+                                b.resize(to, value);
+                                m.resize(to, value);
+                                disagreements += static_cast<int>(reference(b) != m);
+                                disagreements += static_cast<int>(b != from_model<T>(m));
+                                disagreements += static_cast<int>(b.num_blocks() != blocks_for<Block>(to));
+                        }
+                }
+        }
+        BOOST_CHECK_EQUAL(disagreements, 0);
+}
+
+// push_back and pop_back are resize by one, checked at every width on the way up and back down.
+BOOST_AUTO_TEST_CASE_TEMPLATE(PushingAndPoppingAreResizeByOne, Block, test::word_types)
+{
+        using T = xstd::block_vector<Block>;
+        constexpr auto D = test::digits_v<Block>;
+
+        auto disagreements = 0;
+        auto b = T();
+        auto m = model();
+        for (auto i = 0UZ; i < (3 * D) + 1; ++i) {
+                auto const value = i % 3 != 1;
+                b.push_back(value);
+                m.push_back(value);
+                disagreements += static_cast<int>(b.size() != m.size());
+                disagreements += static_cast<int>(b != from_model<T>(m));
+        }
+        while (not m.empty()) {
+                b.pop_back();
+                m.pop_back();
+                disagreements += static_cast<int>(b.size() != m.size());
+                disagreements += static_cast<int>(b != from_model<T>(m));
+        }
+        BOOST_CHECK_EQUAL(disagreements, 0);
+        BOOST_CHECK_EQUAL(b.num_blocks(), 1UZ);
+}
+
+// Boost's append: a whole block at once, split across two where the width is not aligned; at width zero the floor block takes it.
+BOOST_AUTO_TEST_CASE_TEMPLATE(AppendingABlockSplitsItAtAnUnalignedWidth, Block, test::word_types)
+{
+        using T = xstd::block_vector<Block>;
+
+        auto disagreements = 0;
+        for (auto const n : graded_widths<Block>()) {
+                auto m = patterned(n);
+                auto b = from_model<T>(m);
+
+                b.append(striped<Block>());
+                append_to(m, striped<Block>());
+                disagreements += static_cast<int>(b != from_model<T>(m));
+
+                // And a range of blocks, reserved for first, so the width grows by one block per element.
+                auto const blocks = std::array{ striped<Block>(), static_cast<Block>(~striped<Block>()), Block{1} };
+                b.append(blocks.begin(), blocks.end());
+                for (auto const value : blocks) {
+                        append_to(m, value);
+                }
+                disagreements += static_cast<int>(b != from_model<T>(m));
+                disagreements += static_cast<int>(b.size() != n + (4 * test::digits_v<Block>));
+        }
+        BOOST_CHECK_EQUAL(disagreements, 0);
+}
+
+// Capacity is in bits and follows the blocks; reserving and shrinking change it and nothing else.
+BOOST_AUTO_TEST_CASE(ReservingAndShrinkingChangeCapacityNotTheBits)
+{
+        using T = xstd::block_vector<std::uint8_t>;
+
+        auto const m = patterned(17);
+        auto b = from_model<T>(m);
+
+        b.reserve(40);
+        BOOST_CHECK_GE(b.capacity(), 40UZ);
+        BOOST_CHECK_EQUAL(b.size(), 17UZ);
+        BOOST_CHECK(b == from_model<T>(m));
+
+        b.shrink_to_fit();
+        BOOST_CHECK_GE(b.capacity(), b.size());
+        BOOST_CHECK(b == from_model<T>(m));
+}
+
+// Width zero, one block, all padding: the object a default constructor makes. [design.md#default-construction]
+BOOST_AUTO_TEST_CASE(ClearingIsResizeToZero)
+{
+        using T = xstd::block_vector<std::uint8_t>;
+
+        auto b = from_model<T>(patterned(17));
+        b.clear();
+        BOOST_CHECK_EQUAL(b.size(), 0UZ);
+        BOOST_CHECK_EQUAL(b.num_blocks(), 1UZ);
+        BOOST_CHECK_EQUAL(b.block(0), 0U);
+        BOOST_CHECK(b == T());
+}
+
+// A static width has none of it: the members are constrained away rather than asserting.
+BOOST_AUTO_TEST_CASE(AStaticWidthDoesNotGrow)
+{
+        using S = xstd::block_array<std::uint8_t, 8>;
+        using D = xstd::block_vector<std::uint8_t>;
+
+        static_assert(not can_resize<S> and not can_push_pop<S> and not can_append<S> and not can_clear<S>);
+        static_assert(not can_reserve<S> and not has_capacity<S>);
+
+        static_assert(can_resize<D> and can_push_pop<D> and can_append<D> and can_clear<D>);
+        static_assert(can_reserve<D> and has_capacity<D>);
+}
+
+#ifdef TEST_HAS_INPLACE_VECTOR
+// The third storage: a run-time width under a compile-time capacity, the sweep unchanged over it, and growth past the capacity a bad_alloc. [design.md#growth]
+BOOST_AUTO_TEST_CASE(AnInplaceVectorIsARunTimeWidthUnderAStaticCapacity)
+{
+        using T = xstd::block_inplace_vector<std::uint8_t, 24>;
+        static_assert(not T::has_static_size);
+        static_assert(xstd::block_storage<std::inplace_vector<std::uint8_t, 3>>);
+
+        BOOST_CHECK_EQUAL(sweep(T(17)), 0);
+
+        auto b = T();
+        BOOST_CHECK_EQUAL(b.capacity(), 24UZ);
+        b.resize(24, true);
+        BOOST_CHECK(b.all());
+        BOOST_CHECK_EQUAL(b.num_blocks(), 3UZ);
+        BOOST_CHECK_THROW(b.push_back(true), std::bad_alloc);
+        BOOST_CHECK_THROW(b.resize(25), std::bad_alloc);
+        BOOST_CHECK_THROW(b.reserve(25), std::bad_alloc);
+        b.shrink_to_fit();
+        BOOST_CHECK_EQUAL(b.size(), 24UZ);
+}
+#endif
 
 // Each entry reaches the member it names, and every call stays inside the kept contracts. [design.md#the-cheapest-contract]
 BOOST_AUTO_TEST_CASE_TEMPLATE(TheTraitsForwardToTheStorage, T, test::graded_extents<graded_block_array>)

--- a/test/src/bits/ext/boost/dynamic_bitset.cpp
+++ b/test/src/bits/ext/boost/dynamic_bitset.cpp
@@ -69,6 +69,18 @@ BOOST_AUTO_TEST_CASE(TheTraitsAdaptIt)
         traits::fill(c, false);
         BOOST_CHECK_EQUAL(traits::count(c), 0UZ);
 
+        // The checked shifts are boost's own, total and saturating, forwarded as they are. [design.md#checked-and-unchecked]
+        traits::insert(c, 1);
+        traits::checked_shift_left(c, 19);
+        BOOST_CHECK(traits::at(c, 20));
+        traits::checked_shift_right(c, 20);
+        BOOST_CHECK(traits::at(c, 0));
+        traits::checked_shift_left(c, 21);
+        BOOST_CHECK_EQUAL(traits::count(c), 0UZ);
+        traits::insert(c, 20);
+        traits::checked_shift_right(c, 100);
+        BOOST_CHECK_EQUAL(traits::count(c), 0UZ);
+
 }
 
 // The element-wise tier's not-found and boundary arms, which only a type without block access reaches. [design.md#per-instantiation-slots]


### PR DESCRIPTION
Step 7a of #80, the first of five cuts of step 7: growth on the vehicle, no public name changes.

## What changes

- **Growth on `block_sequence`, at a run-time width alone.** `resize(n, value)`, `clear`, `push_back`, `pop_back`, `append(block)`, `append(first, last)`, and where the blocks have them `reserve`, `capacity`, `shrink_to_fit`, in bits. Every path leaves the unused tail clear: `resize` masks the new last block and, growing with ones, first sets the old last block's tail; `push_back`/`pop_back` are `resize` by one; `clear` is `resize(0)`, the object a default constructor makes; `append` is boost's, a whole block at the next `bits_per_block` positions, split across two blocks at an unaligned width, the floor block taking the first at width zero. A static width has none of them, constrained away rather than asserting. `design.md#growth`.
- **`block_inplace_vector<Block, N>`**, the third storage: a run-time width under a compile-time capacity of `N` bits, behind `__cpp_lib_inplace_vector`. `std::inplace_vector` satisfies `block_storage` as it is; growth past the capacity throws `std::bad_alloc` as that library specifies. The probe `test/include/test/inplace_vector.hpp` mirrors `uint128.hpp`, and the one case behind it runs where the library has it: the gcc 16 and 17 legs, plus any other library that turns out to carry it.
- **`bit_traits<boost::dynamic_bitset>`** gains `checked_shift_left`/`checked_shift_right`, boost's shifts being total and saturating, so `basic_bitset` over boost forwards them in 7b.

## Tests

Every resize path at the graded widths with both fill values, against a `std::vector<bool>` model and against a fresh build from it, which is what checks the unused tail: a dirty tail compares unequal. Push and pop step by step up to three blocks and back; `append` at every graded width, single block and range; reserve, shrink and clear; the constraints on the static width. `block_sequence.hpp` stays at 100% line and branch coverage under gcc 14.

## Validation

Local: clang 18, clang 20 and gcc 14 on the touched tests and the adaptors over `block_sequence`; header self-sufficiency of the changed headers on all three; clang-tidy 20 over the headers and the tests. The `inplace_vector` case is not compilable locally, no installed library has it, so its first run is CI's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v8urscUNYsTMatTSnKb16

---
_Generated by [Claude Code](https://claude.ai/code/session_016v8urscUNYsTMatTSnKb16)_