### PR TITLE
Name the run-time width: step 7b of #80

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,11 +75,14 @@ target_sources(
         include/xstd/bits/basic_bitset.hpp
         include/xstd/bits/bit_array.hpp
         include/xstd/bits/bit_proxy.hpp
+        include/xstd/bits/bit_set.hpp
         include/xstd/bits/bitset.hpp
         include/xstd/bits/bit_static_set.hpp
+        include/xstd/bits/bit_vector.hpp
         include/xstd/bits/bit_traits.hpp
         include/xstd/bits/block_sequence.hpp
         include/xstd/bits/detail/intrin.hpp
+        include/xstd/bits/dynamic_bitset.hpp
         include/xstd/bits/detail/pred.hpp
         include/xstd/bits/ext/boost.hpp
         include/xstd/bits/ext/boost/dynamic_bitset.hpp

--- a/README.md
+++ b/README.md
@@ -445,6 +445,9 @@ Note that the benchmarks and unit tests depend on [Boost](https://www.boost.io/)
 
 ## License
 
-Copyright Rein Halbersma 2014-2025.
-Distributed under the [Boost Software License, Version 1.0](http://www.boost.org/users/license.html).
-(See accompanying file LICENSE_1_0.txt or copy at [http://www.boost.org/LICENSE_1_0.txt](http://www.boost.org/LICENSE_1_0.txt))
+<pre>
+         Copyright Rein Halbersma 2014-2026.
+Distributed under the <a href="http://www.boost.org/users/license.html">Boost Software License, Version 1.0</a>.
+   (See accompanying file LICENSE_1_0.txt or copy at
+         <a href="http://www.boost.org/LICENSE_1_0.txt">http://www.boost.org/LICENSE_1_0.txt</a>)
+</pre>

--- a/design.md
+++ b/design.md
@@ -71,6 +71,16 @@ bits, behind `__cpp_lib_inplace_vector` until every library in the matrix has it
 own, `std::inplace_vector` satisfying `block_storage` as it is; `resize`, `reserve` and `push_back` past the
 capacity throw `std::bad_alloc`, as that library specifies.
 
+The adaptors take growth by detection on the storage, never through the trait: growth is a container's
+business and no view's, so it exists on an owner and on nothing else. `basic_bit_sequence` is
+`std::vector<bool>` where its storage grows -- the count and count-value constructors, the range and
+`initializer_list` constructors and assignments, `assign`, `resize`, `clear`, `push_back`, `pop_back`,
+`emplace_back`, with `reserve`, `capacity` and `shrink_to_fit` where the blocks have them -- and
+`std::array<bool, N>` where it does not, each member requiring the storage member it forwards to.
+`basic_bitset` at a run-time width takes `boost::dynamic_bitset`'s growth the same way. `basic_bit_set`
+takes none by name: a set grows by `insert`, and the trait's `insert` grows a run-time width to hold the
+key ([asking-is-total](#asking-is-total)).
+
 ## Scans
 
 ### inclusive-is-the-primitive
@@ -593,6 +603,32 @@ The sequence row is named after the `std` container it packs, `bit_array` for `s
 therefore mark different columns, and that is correct by each row's own analogy rather than an inconsistency
 to fix.
 
+One header per public name, each an alias over one storage: `bit_set`, `bit_vector` and `dynamic_bitset`
+over `block_vector<Block, Allocator>`, beside `bit_static_set`, `bit_array` and `bitset` over `block_array`.
+The header is the name's home and the only place it is spelled; `bits.hpp` includes them all.
+
+### width-is-capacity
+
+`std::set` has no width, so `bit_set` treats its run-time width as capacity, never as value: two sets holding
+the same positions are equal whatever their storages' widths, and the width neither orders, nor hashes, nor
+is a precondition of the set operations. The storage cannot say that -- `block_sequence`'s `==` is width
+first, which is what the sequence reading and `dynamic_bitset` mean, and its bulk operators and predicates
+assert equal widths -- so the set adaptor says it. Every comparison, predicate and compound operator asks
+`same_width` first and takes the storage's own answer at equal widths, which is every answer at a static
+width, where `same_width` is constantly true and the arm folds away. At two run-time widths that differ,
+`==` is `std::ranges::equal` over the elements, `<=>` is the invariant's own algorithm, `is_subset_of` is
+`std::ranges::includes`, `intersects` walks one set asking the other, and `|=` `&=` `^=` `-=` insert and
+erase element by element, `insert` growing the narrower left operand as it grows for any key. The shifts
+translate the set, so `<<=` grows the width to hold the result and `>>=` empties past it. Hashing appends
+the elements and the count at a run-time width and the storage at a static one, where equal sets share a
+storage. The hook is reachable because the adaptor tells ContainerHash it is not a range: Hash2 chooses
+between its range overload and a `tag_invoke` hook by `enable_if`, so a range with a hook is ambiguous, and
+the range overload could not hash the proxy the set iterator returns anyway.
+
+The element walks are a fallback and priced as one: an operation at mismatched widths costs the elements
+rather than the blocks. A block-wise answer over the common prefix is an optimization the storage could
+offer later; nothing in the adaptor's contract would change.
+
 
 ### the-idempotent-wrapper
 
@@ -608,12 +644,25 @@ does, throw for throw, and the same wrapper over `block_array` is `xstd::bitset`
 because `std::bitset` is the counterpart of both. So at a static width there is no `-=`, no `is_subset_of`,
 `is_proper_subset_of` or `intersects`: `std::bitset` has none, they are set vocabulary that had leaked into
 `xstd::bitset`, and `set_view` keeps every one of them. The test harness guards those four the way it already
-guarded the three predicates. A dynamic width, whose counterpart is `boost::dynamic_bitset`, has them
-natively and gets them back when `block_vector` arrives; until then the class asserts the width static.
+guarded the three predicates. A run-time width, whose counterpart is `boost::dynamic_bitset`, has them
+natively and has them here: `xstd::dynamic_bitset` is the same wrapper over `block_vector`, and it answers as
+`basic_bitset<boost::dynamic_bitset<>>` does. That is boost's surface with two omissions. `operator<` is a
+third reading ([the-ordering-invariant](#the-ordering-invariant)) and stays out with `<=>`; the block-range
+constructor and `to_block_range`/`from_block_range` are a block interface the wrapper does not expose, since
+a `Bits` need not have blocks. Everything else is there and detected on `Bits`: the width-and-word and
+width-only constructors, `-=` and the three set predicates, `find_first` and `find_next` answering `npos`,
+`empty`, and growth ([growth](#growth)). The word conversions are the counterparts' own: `to_ulong` and
+`to_ullong` throw `overflow_error` when a set position lies past the word, asked of the door's `find_next`
+from the last position the word holds, and the word constructors take an `unsigned long long` at both widths.
 
 Not a range and no `<=>`, as its counterpart has neither; `set_view` and `sequence_view` refer into its storage
 ([views-over-owners](#views-over-owners)), and the set ordering is theirs. `block_type` is gone from the
 surface: nothing used it, and under idempotence a wrapper over a libc++ `std::bitset` would have none.
+
+Extraction is `[bitset.operators]/6` at both widths: the characters read become `x = basic_bitset(str)`,
+so a short read lands in the low positions, and a run-time width becomes the count of characters read,
+as boost's does. The static width reads at most `size()` characters; the run-time width reads to the first
+character that is neither `0` nor `1`.
 
 ### checked-and-unchecked
 
@@ -634,9 +683,9 @@ declares `checked_set`/`checked_reset`/`checked_flip`/`checked_test`, forwarded.
 door's `unchecked_assign` and `at`, with `flip` synthesised as `unchecked_assign(not at)` the way
 `basic_bit_set::complement` is;
 a `flip` entry of its own is an open call. Where no checked entry exists the wrapper guards and throws
-`out_of_range` at a static width, matching `std::bitset`, and will assert at a dynamic one, matching
-`boost::dynamic_bitset` -- a deliberate inconsistency between `xstd::bitset` and the coming
-`xstd::dynamic_bitset`, because it is exactly the one between their counterparts. The const subscript is
+`out_of_range` at a static width, matching `std::bitset`, and asserts at a run-time one, matching
+`boost::dynamic_bitset` -- a deliberate inconsistency between `xstd::bitset` and `xstd::dynamic_bitset`,
+because it is exactly the one between their counterparts. The const subscript is
 unchecked on every counterpart, so it is the door's `at` unconditionally, and the proxy from the mutable one
 writes through `unchecked_assign` alone.
 

--- a/include/opt/bitset/sieve.hpp
+++ b/include/opt/bitset/sieve.hpp
@@ -28,21 +28,17 @@ concept modern_bitset = requires(X& a, std::size_t pos)
         a.erase(pos);
 };
 
+// A static width is its own; a run-time one, boost's or ours, is resized to the count.
 template<class X>
 struct generate_empty
 {
-        auto operator()(std::size_t) const
-        {
-                return X();
-        }
-};
-
-template<xstd::unsigned_integer Block, class Allocator>
-struct generate_empty<boost::dynamic_bitset<Block, Allocator>>
-{
         auto operator()(std::size_t n) const
         {
-                return boost::dynamic_bitset<Block, Allocator>(n);
+                auto x = X();
+                if constexpr (requires { x.resize(n); }) {
+                        x.resize(n);
+                }
+                return x;
         }
 };
 

--- a/include/opt/bitset/sieve.hpp
+++ b/include/opt/bitset/sieve.hpp
@@ -6,7 +6,6 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/dynamic_bitset_fwd.hpp>            // dynamic_bitset
 #include <xstd/bits/ranges/set_view.hpp>           // set_view
 #include <cstddef>                                 // size_t
 #include <ranges>                                  // take_while

--- a/include/opt/bitset/sieve.hpp
+++ b/include/opt/bitset/sieve.hpp
@@ -8,7 +8,6 @@
 
 #include <boost/dynamic_bitset_fwd.hpp>            // dynamic_bitset
 #include <xstd/bits/ranges/set_view.hpp>           // set_view
-#include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer
 #include <cstddef>                                 // size_t
 #include <ranges>                                  // take_while
 

--- a/include/xstd/bits.hpp
+++ b/include/xstd/bits.hpp
@@ -12,9 +12,12 @@
 #include <xstd/bits/basic_bitset.hpp>   // IWYU pragma: export; basic_bitset, has_bitops
 #include <xstd/bits/bit_array.hpp>      // IWYU pragma: export; bit_array
 #include <xstd/bits/bit_proxy.hpp>      // IWYU pragma: export; bit_set_iterator, bit_set_reference, bit_sequence_iterator, bit_sequence_reference
+#include <xstd/bits/bit_set.hpp>        // IWYU pragma: export; bit_set
 #include <xstd/bits/bit_static_set.hpp> // IWYU pragma: export; bit_static_set
+#include <xstd/bits/bit_vector.hpp>     // IWYU pragma: export; bit_vector
 #include <xstd/bits/bitset.hpp>         // IWYU pragma: export; bitset
-#include <xstd/bits/block_sequence.hpp> // IWYU pragma: export; block_sequence, block_array, block_vector
+#include <xstd/bits/block_sequence.hpp> // IWYU pragma: export; block_sequence, block_array, block_inplace_vector, block_vector
+#include <xstd/bits/dynamic_bitset.hpp> // IWYU pragma: export; dynamic_bitset
 #include <xstd/bits/ownership.hpp>      // IWYU pragma: export; ownership
 #include <xstd/bits/ranges.hpp>         // IWYU pragma: export; set_view, sequence_view
 

--- a/include/xstd/bits/basic_bit_sequence.hpp
+++ b/include/xstd/bits/basic_bit_sequence.hpp
@@ -7,7 +7,7 @@
 #define XSTD_BITS_BASIC_BIT_SEQUENCE_HPP
 
 #include <xstd/bits/bit_proxy.hpp>  // bit_sequence_iterator, bit_sequence_reference
-#include <xstd/bits/bit_traits.hpp> // bit_storage, bit_traits
+#include <xstd/bits/bit_traits.hpp> // bit_storage, bit_traits, static_bit_extent
 #include <xstd/bits/ownership.hpp>  // owned_bits_t, owned_storage, owned_traits_t, owner_of, ownership, owns
 #include <algorithm>                // lexicographical_compare_three_way
 #include <cassert>                  // assert
@@ -15,8 +15,10 @@
 #include <concepts>                 // convertible_to, swap, swappable
 #include <cstddef>                  // ptrdiff_t, size_t
 #include <format>                   // format
-#include <iterator>                 // make_reverse_iterator, reverse_iterator
-#include <ranges>                   // enable_borrowed_range, enable_view
+#include <initializer_list>         // initializer_list
+#include <iterator>                 // input_iterator, make_reverse_iterator, reverse_iterator, sentinel_for
+#include <limits>                   // numeric_limits
+#include <ranges>                   // begin, enable_borrowed_range, enable_view, end, from_range_t, input_range, range_reference_t
 #include <source_location>          // source_location
 #include <stdexcept>                // out_of_range
 #include <type_traits>              // conditional_t, is_nothrow_swappable_v, remove_const_t, remove_reference_t
@@ -34,6 +36,9 @@ class basic_bit_sequence
         static constexpr bool is_owner = owns(Own);
 
         using bits_type = std::remove_const_t<Bits>;
+
+        // Growth is the owner's over storage that grows: a view must never resize what it does not own. [design.md#growth]
+        static constexpr bool can_grow = is_owner and not static_bit_extent<Traits, bits_type> and requires (bits_type& b) { b.resize(0UZ, true); b.push_back(true); b.pop_back(); b.clear(); };
 
         std::conditional_t<is_owner, Bits, Bits*> m_bits;
 
@@ -74,8 +79,78 @@ public:
         using reverse_iterator       = std::reverse_iterator<iterator>;
         using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
-        // construct/copy/destroy; an owner is built the way std::array is, a view only from what it views.
+        // construct/copy/destroy; an owner is built the way std::array is, or std::vector where the storage grows, a view only from what it views.
         [[nodiscard]] constexpr basic_bit_sequence() noexcept requires is_owner = default;
+
+        [[nodiscard]] constexpr explicit basic_bit_sequence(size_type n)
+                requires can_grow
+        :
+                m_bits(n)
+        {}
+
+        [[nodiscard]] constexpr basic_bit_sequence(size_type n, value_type const& value)
+                requires can_grow
+        :
+                m_bits(n)
+        {
+                if (value) {
+                        Traits::fill(m_bits, true);
+                }
+        }
+
+        template<std::input_iterator I, std::sentinel_for<I> S>
+                requires can_grow and std::constructible_from<value_type, std::iter_reference_t<I>>
+        [[nodiscard]] constexpr basic_bit_sequence(I first, S last)
+        {
+                for (; first != last; ++first) {
+                        m_bits.push_back(static_cast<value_type>(*first));
+                }
+        }
+
+        template<std::ranges::input_range R>
+                requires can_grow and std::constructible_from<value_type, std::ranges::range_reference_t<R>>
+        [[nodiscard]] constexpr basic_bit_sequence(std::from_range_t, R&& rg)
+        :
+                basic_bit_sequence(std::ranges::begin(rg), std::ranges::end(rg))
+        {}
+
+        [[nodiscard]] constexpr basic_bit_sequence(std::initializer_list<value_type> il)
+                requires can_grow
+        :
+                basic_bit_sequence(il.begin(), il.end())
+        {}
+
+        constexpr auto operator=(std::initializer_list<value_type> il)
+                -> basic_bit_sequence&
+                requires can_grow
+        {
+                assign(il.begin(), il.end());
+                return *this;
+        }
+
+        // [sequence.reqmts]: assign in its three shapes, each a clear and a refill.
+        constexpr void assign(size_type n, value_type const& value)
+                requires can_grow
+        {
+                m_bits.clear();
+                m_bits.resize(n, value);
+        }
+
+        template<std::input_iterator I, std::sentinel_for<I> S>
+                requires can_grow and std::constructible_from<value_type, std::iter_reference_t<I>>
+        constexpr void assign(I first, S last)
+        {
+                m_bits.clear();
+                for (; first != last; ++first) {
+                        m_bits.push_back(static_cast<value_type>(*first));
+                }
+        }
+
+        constexpr void assign(std::initializer_list<value_type> il)
+                requires can_grow
+        {
+                assign(il.begin(), il.end());
+        }
 
         [[nodiscard]] constexpr explicit basic_bit_sequence(Bits& c) noexcept
                 requires (not is_owner)
@@ -115,10 +190,53 @@ public:
         [[nodiscard]] constexpr auto crbegin() const noexcept -> const_reverse_iterator { return std::make_reverse_iterator(cend());   }
         [[nodiscard]] constexpr auto crend()   const noexcept -> const_reverse_iterator { return std::make_reverse_iterator(cbegin()); }
 
-        // capacity
+        // capacity; a static width is its own max_size, a growing one has the address space's.
         [[nodiscard]] constexpr auto    empty() const noexcept -> bool      { return size() == 0UZ; }
         [[nodiscard]] constexpr auto     size() const noexcept -> size_type { return Traits::size(storage()); }
-        [[nodiscard]] constexpr auto max_size() const noexcept -> size_type { return size(); }
+
+        [[nodiscard]] constexpr auto max_size() const noexcept
+                -> size_type
+        {
+                if constexpr (can_grow) {
+                        return std::numeric_limits<size_type>::max();
+                } else {
+                        return size();
+                }
+        }
+
+        // Growth, [vector]'s members over storage that spells them alike, so detected on the storage rather than reconciled by the trait. [design.md#growth]
+        constexpr void resize(size_type n)                          requires can_grow { m_bits.resize(n); }
+        constexpr void resize(size_type n, value_type const& value) requires can_grow { m_bits.resize(n, value); }
+        constexpr void clear() noexcept                             requires can_grow { m_bits.clear(); }
+        constexpr void push_back(value_type const& value)           requires can_grow { m_bits.push_back(value); }
+        constexpr void pop_back() noexcept                          requires can_grow { m_bits.pop_back(); }
+
+        constexpr auto emplace_back(value_type const& value)
+                -> reference
+                requires can_grow
+        {
+                m_bits.push_back(value);
+                return back();
+        }
+
+        constexpr void reserve(size_type n)
+                requires can_grow and requires (bits_type& b) { b.reserve(n); }
+        {
+                m_bits.reserve(n);
+        }
+
+        [[nodiscard]] constexpr auto capacity() const noexcept
+                -> size_type
+                requires can_grow and requires (bits_type const& b) { b.capacity(); }
+        {
+                return m_bits.capacity();
+        }
+
+        constexpr void shrink_to_fit()
+                requires can_grow and requires (bits_type& b) { b.shrink_to_fit(); }
+        {
+                m_bits.shrink_to_fit();
+        }
 
         // element access, [] unchecked and at() throwing as [array] has them. [design.md#asking-is-total]
         [[nodiscard]] constexpr auto operator[](this auto&& self, size_type n) noexcept

--- a/include/xstd/bits/basic_bit_set.hpp
+++ b/include/xstd/bits/basic_bit_set.hpp
@@ -6,11 +6,12 @@
 #ifndef XSTD_BITS_BASIC_BIT_SET_HPP
 #define XSTD_BITS_BASIC_BIT_SET_HPP
 
-#include <boost/hash2/hash_append.hpp> // hash_append
+#include <boost/container_hash/is_range.hpp> // is_range
+#include <boost/hash2/hash_append.hpp> // hash_append, hash_append_tag
 #include <xstd/bits/bit_proxy.hpp>     // bit_set_iterator, bit_set_reference
 #include <xstd/bits/bit_traits.hpp>    // bit_storage, bit_traits, count, find_first, find_next, find_prev, static_bit_extent
 #include <xstd/bits/ownership.hpp>     // owned_bits_t, owned_storage, owned_traits_t, owner_of, ownership, owns
-#include <algorithm>                   // lexicographical_compare_three_way
+#include <algorithm>                   // any_of, equal, includes, lexicographical_compare_three_way
 #include <cassert>                     // assert
 #include <compare>                     // strong_ordering
 #include <concepts>                    // constructible_from, swappable
@@ -20,7 +21,7 @@
 #include <iterator>                    // input_iterator, iter_reference_t, make_reverse_iterator, reverse_iterator, sentinel_for
 #include <limits>                      // numeric_limits
 #include <ranges>                      // begin, enable_borrowed_range, enable_view, end, input_range, range_reference_t, from_range_t, swap
-#include <type_traits>                 // conditional_t, is_nothrow_swappable_v, remove_const_t, remove_reference_t
+#include <type_traits>                 // conditional_t, false_type, is_nothrow_swappable_v, remove_const_t, remove_reference_t
 #include <utility>                     // forward, pair
 
 // The set reading, [set] over any Bits with a bit_traits specialization, owning it or referring to it. [design.md#the-three-adaptors]
@@ -51,10 +52,18 @@ class basic_bit_set
         template<class B, ownership O, bit_storage<B> T>         friend class basic_bit_set;
         template<class B, ownership O, bool W, bit_storage<B> T> friend class basic_bit_sequence;
 
+        // The storage's own hash at a static width; the elements at a run-time width, where two equal sets need not share a storage. [design.md#width-is-capacity]
         template<class Provider, class Hash, class Flavor>
         friend constexpr void tag_invoke(boost::hash2::hash_append_tag const&, Provider const&, Hash& h, Flavor const& f, basic_bit_set const* v) noexcept
         {
-                boost::hash2::hash_append(h, f, v->storage());
+                if constexpr (has_static_width) {
+                        boost::hash2::hash_append(h, f, v->storage());
+                } else {
+                        for (auto x : *v) {
+                                boost::hash2::hash_append(h, f, static_cast<std::size_t>(x));
+                        }
+                        boost::hash2::hash_append(h, f, v->size());
+                }
         }
 
 public:
@@ -64,6 +73,7 @@ public:
         using value_type             = key_type;
         using value_compare          = key_compare;
         using traits_type            = Traits;
+        static constexpr bool has_static_width = static_bit_extent<Traits, Bits>;
         using pointer                = void;
         using const_pointer          = pointer;
         using reference              = bit_set_reference<Bits, Traits>;
@@ -122,10 +132,14 @@ public:
         }
 
         // The storage's own equality, which every storage in the tree has; ordering is the trait's entry, or the invariant it must satisfy. [design.md#the-ordering-invariant]
+        // Both over the elements when two run-time widths differ: the storages then cannot agree, the sets still can. [design.md#width-is-capacity]
         [[nodiscard]] friend constexpr auto operator==(basic_bit_set const& x, basic_bit_set const& y) noexcept
                 -> bool
                 requires requires { { x.storage() == y.storage() } -> std::convertible_to<bool>; }
         {
+                if (not same_width(x, y)) {
+                        return std::ranges::equal(x, y);
+                }
                 return x.storage() == y.storage();
         }
 
@@ -133,10 +147,11 @@ public:
                 -> std::strong_ordering
         {
                 if constexpr (requires { Traits::set_three_way(x.storage(), y.storage()); }) {
-                        return Traits::set_three_way(x.storage(), y.storage());
-                } else {
-                        return std::lexicographical_compare_three_way(x.begin(), x.end(), y.begin(), y.end());
+                        if (same_width(x, y)) {
+                                return Traits::set_three_way(x.storage(), y.storage());
+                        }
                 }
+                return std::lexicographical_compare_three_way(x.begin(), x.end(), y.begin(), y.end());
         }
 
         // iterators; one type for both, this reading being read-only through its proxy. [design.md#read-only-set-proxy]
@@ -275,16 +290,97 @@ public:
                 Traits::unchecked_assign(self.storage(), x, not Traits::at(self.storage(), x));
         }
 
-        // Bulk, on the storage's own spelling: what every storage agrees on is required of it, not reconciled. [design.md#what-the-trait-reconciles]
         constexpr void complement(this auto&& self) noexcept requires requires { self.storage().flip(); } { self.storage().flip(); }
 
-        constexpr auto operator&=(this auto&& self, basic_bit_set const& other) noexcept -> auto& requires requires { self.storage() &= other.storage(); } { self.storage() &= other.storage(); return self; }
-        constexpr auto operator|=(this auto&& self, basic_bit_set const& other) noexcept -> auto& requires requires { self.storage() |= other.storage(); } { self.storage() |= other.storage(); return self; }
-        constexpr auto operator^=(this auto&& self, basic_bit_set const& other) noexcept -> auto& requires requires { self.storage() ^= other.storage(); } { self.storage() ^= other.storage(); return self; }
-        constexpr auto operator-=(this auto&& self, basic_bit_set const& other) noexcept -> auto& requires requires { self.storage() -= other.storage(); } { self.storage() -= other.storage(); return self; }
+        // Bulk, on the storage's own spelling: what every storage agrees on is required of it, not reconciled. [design.md#what-the-trait-reconciles]
+        // Two run-time widths that differ go element-wise instead, the storages' own being equal-width operations; the two that insert may then allocate. [design.md#width-is-capacity]
+        constexpr auto operator&=(this auto&& self, basic_bit_set const& other) noexcept
+                -> auto&
+                requires requires { self.storage() &= other.storage(); }
+        {
+                if (same_width(self, other)) {
+                        self.storage() &= other.storage();
+                } else {
+                        for (auto x : self) {
+                                if (not other.contains(x)) {
+                                        self.erase(x);
+                                }
+                        }
+                }
+                return self;
+        }
 
-        constexpr auto operator<<=(this auto&& self, std::size_t n) noexcept -> auto& requires requires { self.storage() <<= n; } { self.storage() <<= n; return self; }
-        constexpr auto operator>>=(this auto&& self, std::size_t n) noexcept -> auto& requires requires { self.storage() >>= n; } { self.storage() >>= n; return self; }
+        constexpr auto operator|=(this auto&& self, basic_bit_set const& other) noexcept(has_static_width)
+                -> auto&
+                requires requires { self.storage() |= other.storage(); }
+        {
+                if (same_width(self, other)) {
+                        self.storage() |= other.storage();
+                } else {
+                        for (auto x : other) {
+                                self.insert(x);
+                        }
+                }
+                return self;
+        }
+
+        constexpr auto operator^=(this auto&& self, basic_bit_set const& other) noexcept(has_static_width)
+                -> auto&
+                requires requires { self.storage() ^= other.storage(); }
+        {
+                if (same_width(self, other)) {
+                        self.storage() ^= other.storage();
+                } else {
+                        for (auto x : other) {
+                                if (self.erase(x) == 0UZ) {
+                                        self.insert(x);
+                                }
+                        }
+                }
+                return self;
+        }
+
+        constexpr auto operator-=(this auto&& self, basic_bit_set const& other) noexcept
+                -> auto&
+                requires requires { self.storage() -= other.storage(); }
+        {
+                if (same_width(self, other)) {
+                        self.storage() -= other.storage();
+                } else {
+                        for (auto x : other) {
+                                self.erase(x);
+                        }
+                }
+                return self;
+        }
+
+        // The shifts translate the set. A run-time width grows to hold a left shift and empties past a right one, the width being no precondition. [design.md#width-is-capacity]
+        constexpr auto operator<<=(this auto&& self, std::size_t n) noexcept(has_static_width)
+                -> auto&
+                requires requires { self.storage() <<= n; } and (has_static_width or requires { self.storage().resize(n); })
+        {
+                if constexpr (has_static_width) {
+                        self.storage() <<= n;
+                } else if (auto const width = Traits::size(self.storage()); width > 0UZ) {
+                        self.storage().resize(width + n);
+                        self.storage() <<= n;
+                }
+                return self;
+        }
+
+        constexpr auto operator>>=(this auto&& self, std::size_t n) noexcept
+                -> auto&
+                requires requires { self.storage() >>= n; }
+        {
+                if constexpr (not has_static_width) {
+                        if (n >= Traits::size(self.storage())) {
+                                Traits::fill(self.storage(), false);
+                                return self;
+                        }
+                }
+                self.storage() >>= n;
+                return self;
+        }
 
         // observers
         [[nodiscard]] constexpr auto   key_comp() const noexcept -> key_compare   { return {}; }
@@ -323,9 +419,13 @@ public:
         }
 
         // The storage's own member where it has one, its bulk operators otherwise: both block-wise, and every storage in the tree has one of the two.
+        // Two run-time widths that differ are asked element-wise, as the comparisons are. [design.md#width-is-capacity]
         [[nodiscard]] constexpr auto is_subset_of(basic_bit_set const& other) const noexcept
                 -> bool
         {
+                if (not same_width(*this, other)) {
+                        return std::ranges::includes(other, *this);
+                }
                 if constexpr (requires { storage().is_subset_of(other.storage()); }) {
                         return storage().is_subset_of(other.storage());
                 } else {
@@ -336,6 +436,9 @@ public:
         [[nodiscard]] constexpr auto is_proper_subset_of(basic_bit_set const& other) const noexcept
                 -> bool
         {
+                if (not same_width(*this, other)) {
+                        return is_subset_of(other) and size() != other.size();
+                }
                 if constexpr (requires { storage().is_proper_subset_of(other.storage()); }) {
                         return storage().is_proper_subset_of(other.storage());
                 } else {
@@ -346,6 +449,9 @@ public:
         [[nodiscard]] constexpr auto intersects(basic_bit_set const& other) const noexcept
                 -> bool
         {
+                if (not same_width(*this, other)) {
+                        return std::ranges::any_of(*this, [&other](auto x) { return other.contains(x); });
+                }
                 if constexpr (requires { storage().intersects(other.storage()); }) {
                         return storage().intersects(other.storage());
                 } else {
@@ -354,6 +460,17 @@ public:
         }
 
 private:
+        // Constantly true at a static width, so every arm above folds to the storage's own. [design.md#width-is-capacity]
+        [[nodiscard]] static constexpr auto same_width(basic_bit_set const& x [[maybe_unused]], basic_bit_set const& y [[maybe_unused]]) noexcept
+                -> bool
+        {
+                if constexpr (has_static_width) {
+                        return true;
+                } else {
+                        return Traits::size(x.storage()) == Traits::size(y.storage());
+                }
+        }
+
         // Traits::insert returns nothing, so "was it new" is asked first; total, an out-of-range key being the trait's precondition to refuse.
         constexpr auto do_insert(this auto&& self, value_type x)
                 -> std::pair<iterator, bool>
@@ -411,16 +528,16 @@ constexpr auto erase_if(basic_bit_set<Bits, Own, Traits>& c, Predicate pred)
         return original_size - c.size();
 }
 
-// The non-member forms copy, so they are the owner's alone: a copied view would write through to what it views.
-template<class Bits, ownership Own, class Traits> [[nodiscard]] constexpr auto operator~(basic_bit_set<Bits, Own, Traits> const& lhs) noexcept -> basic_bit_set<Bits, Own, Traits> requires (owns(Own)) and requires (basic_bit_set<Bits, Own, Traits> c) { c.complement(); } { auto nrv = lhs; nrv.complement(); return nrv; }
+// The non-member forms copy, so they are the owner's alone: a copied view would write through to what it views; the copy may allocate at a run-time width.
+template<class Bits, ownership Own, class Traits> [[nodiscard]] constexpr auto operator~(basic_bit_set<Bits, Own, Traits> const& lhs) noexcept(basic_bit_set<Bits, Own, Traits>::has_static_width) -> basic_bit_set<Bits, Own, Traits> requires (owns(Own)) and requires (basic_bit_set<Bits, Own, Traits> c) { c.complement(); } { auto nrv = lhs; nrv.complement(); return nrv; }
 
-template<class Bits, ownership Own, class Traits> [[nodiscard]] constexpr auto operator&(basic_bit_set<Bits, Own, Traits> const& lhs, basic_bit_set<Bits, Own, Traits> const& rhs) noexcept -> basic_bit_set<Bits, Own, Traits> requires (owns(Own)) and requires (basic_bit_set<Bits, Own, Traits> c) { c &= c; } { auto nrv = lhs; nrv &= rhs; return nrv; }
-template<class Bits, ownership Own, class Traits> [[nodiscard]] constexpr auto operator|(basic_bit_set<Bits, Own, Traits> const& lhs, basic_bit_set<Bits, Own, Traits> const& rhs) noexcept -> basic_bit_set<Bits, Own, Traits> requires (owns(Own)) and requires (basic_bit_set<Bits, Own, Traits> c) { c |= c; } { auto nrv = lhs; nrv |= rhs; return nrv; }
-template<class Bits, ownership Own, class Traits> [[nodiscard]] constexpr auto operator^(basic_bit_set<Bits, Own, Traits> const& lhs, basic_bit_set<Bits, Own, Traits> const& rhs) noexcept -> basic_bit_set<Bits, Own, Traits> requires (owns(Own)) and requires (basic_bit_set<Bits, Own, Traits> c) { c ^= c; } { auto nrv = lhs; nrv ^= rhs; return nrv; }
-template<class Bits, ownership Own, class Traits> [[nodiscard]] constexpr auto operator-(basic_bit_set<Bits, Own, Traits> const& lhs, basic_bit_set<Bits, Own, Traits> const& rhs) noexcept -> basic_bit_set<Bits, Own, Traits> requires (owns(Own)) and requires (basic_bit_set<Bits, Own, Traits> c) { c -= c; } { auto nrv = lhs; nrv -= rhs; return nrv; }
+template<class Bits, ownership Own, class Traits> [[nodiscard]] constexpr auto operator&(basic_bit_set<Bits, Own, Traits> const& lhs, basic_bit_set<Bits, Own, Traits> const& rhs) noexcept(basic_bit_set<Bits, Own, Traits>::has_static_width) -> basic_bit_set<Bits, Own, Traits> requires (owns(Own)) and requires (basic_bit_set<Bits, Own, Traits> c) { c &= c; } { auto nrv = lhs; nrv &= rhs; return nrv; }
+template<class Bits, ownership Own, class Traits> [[nodiscard]] constexpr auto operator|(basic_bit_set<Bits, Own, Traits> const& lhs, basic_bit_set<Bits, Own, Traits> const& rhs) noexcept(basic_bit_set<Bits, Own, Traits>::has_static_width) -> basic_bit_set<Bits, Own, Traits> requires (owns(Own)) and requires (basic_bit_set<Bits, Own, Traits> c) { c |= c; } { auto nrv = lhs; nrv |= rhs; return nrv; }
+template<class Bits, ownership Own, class Traits> [[nodiscard]] constexpr auto operator^(basic_bit_set<Bits, Own, Traits> const& lhs, basic_bit_set<Bits, Own, Traits> const& rhs) noexcept(basic_bit_set<Bits, Own, Traits>::has_static_width) -> basic_bit_set<Bits, Own, Traits> requires (owns(Own)) and requires (basic_bit_set<Bits, Own, Traits> c) { c ^= c; } { auto nrv = lhs; nrv ^= rhs; return nrv; }
+template<class Bits, ownership Own, class Traits> [[nodiscard]] constexpr auto operator-(basic_bit_set<Bits, Own, Traits> const& lhs, basic_bit_set<Bits, Own, Traits> const& rhs) noexcept(basic_bit_set<Bits, Own, Traits>::has_static_width) -> basic_bit_set<Bits, Own, Traits> requires (owns(Own)) and requires (basic_bit_set<Bits, Own, Traits> c) { c -= c; } { auto nrv = lhs; nrv -= rhs; return nrv; }
 
-template<class Bits, ownership Own, class Traits> [[nodiscard]] constexpr auto operator<<(basic_bit_set<Bits, Own, Traits> const& lhs, std::size_t n) noexcept -> basic_bit_set<Bits, Own, Traits> requires (owns(Own)) and requires (basic_bit_set<Bits, Own, Traits> c) { c <<= n; } { auto nrv = lhs; nrv <<= n; return nrv; }
-template<class Bits, ownership Own, class Traits> [[nodiscard]] constexpr auto operator>>(basic_bit_set<Bits, Own, Traits> const& lhs, std::size_t n) noexcept -> basic_bit_set<Bits, Own, Traits> requires (owns(Own)) and requires (basic_bit_set<Bits, Own, Traits> c) { c >>= n; } { auto nrv = lhs; nrv >>= n; return nrv; }
+template<class Bits, ownership Own, class Traits> [[nodiscard]] constexpr auto operator<<(basic_bit_set<Bits, Own, Traits> const& lhs, std::size_t n) noexcept(basic_bit_set<Bits, Own, Traits>::has_static_width) -> basic_bit_set<Bits, Own, Traits> requires (owns(Own)) and requires (basic_bit_set<Bits, Own, Traits> c) { c <<= n; } { auto nrv = lhs; nrv <<= n; return nrv; }
+template<class Bits, ownership Own, class Traits> [[nodiscard]] constexpr auto operator>>(basic_bit_set<Bits, Own, Traits> const& lhs, std::size_t n) noexcept(basic_bit_set<Bits, Own, Traits>::has_static_width) -> basic_bit_set<Bits, Own, Traits> requires (owns(Own)) and requires (basic_bit_set<Bits, Own, Traits> c) { c >>= n; } { auto nrv = lhs; nrv >>= n; return nrv; }
 // NOLINTEND(readability-redundant-parentheses)
 
 }       // namespace xstd
@@ -437,5 +554,13 @@ inline constexpr bool enable_borrowed_range<xstd::basic_bit_set<Bits, xstd::owne
 
 }       // namespace std::ranges
 // NOLINTEND(bugprone-std-namespace-modification)
+
+// Not a range to ContainerHash, so Hash2 takes the hook and not its range overload, which cannot hash the proxy the set iterator returns. [design.md#width-is-capacity]
+namespace boost::container_hash {
+
+template<class Bits, xstd::ownership Own, class Traits>
+struct is_range<xstd::basic_bit_set<Bits, Own, Traits>> : std::false_type {};
+
+}       // namespace boost::container_hash
 
 #endif  // XSTD_BITS_BASIC_BIT_SET_HPP

--- a/include/xstd/bits/basic_bit_set.hpp
+++ b/include/xstd/bits/basic_bit_set.hpp
@@ -59,7 +59,7 @@ class basic_bit_set
                 if constexpr (has_static_width) {
                         boost::hash2::hash_append(h, f, v->storage());
                 } else {
-                        for (auto x : *v) {
+                        for (auto const x : *v) {
                                 boost::hash2::hash_append(h, f, static_cast<std::size_t>(x));
                         }
                         boost::hash2::hash_append(h, f, v->size());
@@ -301,7 +301,7 @@ public:
                 if (same_width(self, other)) {
                         self.storage() &= other.storage();
                 } else {
-                        for (auto x : self) {
+                        for (auto const x : self) {
                                 if (not other.contains(x)) {
                                         self.erase(x);
                                 }
@@ -317,7 +317,7 @@ public:
                 if (same_width(self, other)) {
                         self.storage() |= other.storage();
                 } else {
-                        for (auto x : other) {
+                        for (auto const x : other) {
                                 self.insert(x);
                         }
                 }
@@ -331,7 +331,7 @@ public:
                 if (same_width(self, other)) {
                         self.storage() ^= other.storage();
                 } else {
-                        for (auto x : other) {
+                        for (auto const x : other) {
                                 if (self.erase(x) == 0UZ) {
                                         self.insert(x);
                                 }
@@ -347,7 +347,7 @@ public:
                 if (same_width(self, other)) {
                         self.storage() -= other.storage();
                 } else {
-                        for (auto x : other) {
+                        for (auto const x : other) {
                                 self.erase(x);
                         }
                 }

--- a/include/xstd/bits/basic_bitset.hpp
+++ b/include/xstd/bits/basic_bitset.hpp
@@ -597,7 +597,7 @@ template<class charT, class traits, class Bits, class Traits>
 auto operator>>(std::basic_istream<charT, traits>& is, basic_bitset<Bits, Traits>& x)
         -> std::basic_istream<charT, traits>&
 {
-        auto const limit = [&] {
+        auto const limit = [&] -> std::size_t {
                 if constexpr (static_bit_extent<Traits, Bits>) {
                         return x.size();
                 } else {

--- a/include/xstd/bits/basic_bitset.hpp
+++ b/include/xstd/bits/basic_bitset.hpp
@@ -13,17 +13,20 @@
 #include <xstd/bits/bit_traits.hpp>           // bit_storage, bit_traits, static_bit_extent, zero_width
 #include <xstd/bits/ownership.hpp>            // owned_storage, ownership
 #include <algorithm>                          // min
+#include <cassert>                            // assert
 #include <concepts>                           // convertible_to, regular, same_as
 #include <cstddef>                            // size_t
 #include <format>                             // format
 #include <functional>                         // hash
 #include <ios>                                // ios_base
 #include <iosfwd>                             // basic_istream, basic_ostream
+#include <iterator>                           // input_iterator
+#include <limits>                             // numeric_limits
 #include <locale>                             // ctype, use_facet
 #include <memory>                             // allocator
 #include <ranges>                             // iota
 #include <source_location>                    // source_location
-#include <stdexcept>                          // invalid_argument, out_of_range
+#include <stdexcept>                          // invalid_argument, out_of_range, overflow_error
 #include <string>                             // basic_string, char_traits
 #include <string_view>                        // basic_string_view
 #include <utility>                            // as_const
@@ -57,9 +60,10 @@ concept has_bitops =
 template<has_bitops Bits, bit_storage<Bits> Traits = bit_traits<Bits>>
 class basic_bitset
 {
-        static_assert(static_bit_extent<Traits, Bits>, "a dynamic width arrives with block_vector, in step 7 of #80");
+        // Two counterparts, one wrapper: std::bitset at a static width, boost::dynamic_bitset at a run-time one. [design.md#the-idempotent-wrapper]
+        static constexpr bool has_static_width = static_bit_extent<Traits, Bits>;
 
-        // No iteration and no <=> here by design, because std::bitset has neither: the two views refer into the storage instead. [design.md#views-over-owners]
+        // No iteration and no <=> here by design, because neither counterpart has them: the two views refer into the storage instead. [design.md#views-over-owners]
         Bits m_bits{};
 
         template<class B, ownership O, bit_storage<B> T>         friend class basic_bit_set;
@@ -72,6 +76,9 @@ class basic_bitset
         }
 
 public:
+        // boost's typedef, which the harness keys a run-time width on; std::bitset has none, and a typedef changes no answer.
+        using size_type = std::size_t;
+
         // [bitset.refs], reaching the bits only through the unchecked way in; its own class, with the flip and ~ the sequence proxy lacks. [design.md#unchecked-writes-in-views]
         class reference
         {
@@ -133,9 +140,26 @@ public:
                 }
         };
 
+        // boost's sentinel, for the two searches a run-time width answers with it.
+        static constexpr std::size_t npos = static_cast<std::size_t>(-1);
+
         // Constructors                                            [bitset.cons]
         [[nodiscard]] constexpr basic_bitset() noexcept = default;
-        [[nodiscard]] constexpr explicit(false) basic_bitset(unsigned long long val) noexcept = delete;       // TODO
+
+        // [bitset.cons]/2: the low bits of val, as many as the width admits; boost takes the width first and the value second.
+        [[nodiscard]] constexpr explicit(false) basic_bitset(unsigned long long val) noexcept  // NOLINT(misc-explicit-constructor)
+                requires has_static_width
+        {
+                from_ullong(val);
+        }
+
+        [[nodiscard]] constexpr explicit basic_bitset(std::size_t num_bits, unsigned long long val = 0ULL)
+                requires (not has_static_width)
+        :
+                m_bits(num_bits)
+        {
+                from_ullong(val);
+        }
 
         template<class charT, class traits, class Allocator>
         [[nodiscard]] constexpr explicit basic_bitset(
@@ -162,6 +186,10 @@ public:
                         throw out_of_range(pos);
                 }
                 auto const rlen = std::ranges::min(n, str.size() - pos);
+                // A run-time width is the characters read, as boost's is when no width is given.
+                if constexpr (not has_static_width) {
+                        m_bits.resize(rlen);
+                }
                 auto const M = std::ranges::min(size(), rlen);
                 for (auto const i : std::views::iota(0UZ, M)) {
                         auto const ch = str[pos + M - 1 - i];
@@ -219,10 +247,10 @@ public:
                 return *this;
         }
 
-        [[nodiscard]] constexpr auto operator<<(std::size_t pos) const noexcept -> basic_bitset { auto nrv = *this; nrv <<= pos; return nrv; }
-        [[nodiscard]] constexpr auto operator>>(std::size_t pos) const noexcept -> basic_bitset { auto nrv = *this; nrv >>= pos; return nrv; }
+        [[nodiscard]] constexpr auto operator<<(std::size_t pos) const noexcept(has_static_width) -> basic_bitset { auto nrv = *this; nrv <<= pos; return nrv; }
+        [[nodiscard]] constexpr auto operator>>(std::size_t pos) const noexcept(has_static_width) -> basic_bitset { auto nrv = *this; nrv >>= pos; return nrv; }
 
-        [[nodiscard]] constexpr auto operator~() const noexcept -> basic_bitset { auto nrv = *this; nrv.flip(); return nrv; }
+        [[nodiscard]] constexpr auto operator~() const noexcept(has_static_width) -> basic_bitset { auto nrv = *this; nrv.flip(); return nrv; }
 
         constexpr auto set  () noexcept -> basic_bitset& { m_bits.set  (); return *this; }
         constexpr auto reset() noexcept -> basic_bitset& { m_bits.reset(); return *this; }
@@ -234,10 +262,16 @@ public:
         {
                 if constexpr (requires { Traits::checked_set(m_bits, pos, val); }) {
                         Traits::checked_set(m_bits, pos, val);
-                } else if (pos < size()) {
-                        Traits::unchecked_assign(m_bits, pos, val);
+                } else if constexpr (has_static_width) {
+                        if (pos < size()) {
+                                Traits::unchecked_assign(m_bits, pos, val);
+                        } else {
+                                throw out_of_range(pos);
+                        }
                 } else {
-                        throw out_of_range(pos);
+                        // boost asserts, and so does its stand-in: the inconsistency with the static width is the counterparts' own. [design.md#checked-and-unchecked]
+                        assert(pos < size());
+                        Traits::unchecked_assign(m_bits, pos, val);
                 }
                 return *this;
         }
@@ -247,10 +281,15 @@ public:
         {
                 if constexpr (requires { Traits::checked_reset(m_bits, pos); }) {
                         Traits::checked_reset(m_bits, pos);
-                } else if (pos < size()) {
-                        Traits::unchecked_assign(m_bits, pos, false);
+                } else if constexpr (has_static_width) {
+                        if (pos < size()) {
+                                Traits::unchecked_assign(m_bits, pos, false);
+                        } else {
+                                throw out_of_range(pos);
+                        }
                 } else {
-                        throw out_of_range(pos);
+                        assert(pos < size());
+                        Traits::unchecked_assign(m_bits, pos, false);
                 }
                 return *this;
         }
@@ -260,10 +299,15 @@ public:
         {
                 if constexpr (requires { Traits::checked_flip(m_bits, pos); }) {
                         Traits::checked_flip(m_bits, pos);
-                } else if (pos < size()) {
-                        Traits::unchecked_assign(m_bits, pos, not Traits::at(m_bits, pos));
+                } else if constexpr (has_static_width) {
+                        if (pos < size()) {
+                                Traits::unchecked_assign(m_bits, pos, not Traits::at(m_bits, pos));
+                        } else {
+                                throw out_of_range(pos);
+                        }
                 } else {
-                        throw out_of_range(pos);
+                        assert(pos < size());
+                        Traits::unchecked_assign(m_bits, pos, not Traits::at(m_bits, pos));
                 }
                 return *this;
         }
@@ -281,8 +325,9 @@ public:
                 return { *this, pos };
         }
 
-        [[nodiscard]] constexpr auto to_ulong()  const -> unsigned long      = delete;  // TODO
-        [[nodiscard]] constexpr auto to_ullong() const -> unsigned long long = delete;  // TODO
+        // [bitset.members]/34-37: the value the bits spell, or overflow_error where a set position lies beyond the word; boost's to_ulong is the same contract.
+        [[nodiscard]] constexpr auto to_ulong()  const -> unsigned long      { return to_word<unsigned long>();      }
+        [[nodiscard]] constexpr auto to_ullong() const -> unsigned long long { return to_word<unsigned long long>(); }
 
         template<
                 class charT = char,
@@ -314,10 +359,14 @@ public:
         {
                 if constexpr (requires { { Traits::checked_test(m_bits, pos) } -> std::convertible_to<bool>; }) {
                         return Traits::checked_test(m_bits, pos);
-                } else if (pos < size()) {
-                        return Traits::at(m_bits, pos);
-                } else {
+                } else if constexpr (has_static_width) {
+                        if (pos < size()) {
+                                return Traits::at(m_bits, pos);
+                        }
                         throw out_of_range(pos);
+                } else {
+                        assert(pos < size());
+                        return Traits::at(m_bits, pos);
                 }
         }
 
@@ -325,9 +374,149 @@ public:
         [[nodiscard]] constexpr auto any()  const noexcept -> bool { return m_bits.any();  }
         [[nodiscard]] constexpr auto none() const noexcept -> bool { return m_bits.none(); }
 
-        // No -=, is_subset_of, is_proper_subset_of or intersects at a static width: std::bitset has none, and set_view keeps them. [design.md#the-idempotent-wrapper]
+        // The set vocabulary boost has and std::bitset has not, forwarded exactly where the counterpart is boost: a run-time width, whose storage spells them alike. [design.md#the-idempotent-wrapper]
+        constexpr auto operator-=(basic_bitset const& rhs) noexcept
+                -> basic_bitset&
+                requires (not has_static_width) and requires (Bits& b, Bits const& c) { b -= c; }
+        {
+                m_bits -= rhs.m_bits;
+                return *this;
+        }
+
+        [[nodiscard]] constexpr auto is_subset_of(basic_bitset const& rhs) const noexcept
+                -> bool
+                requires (not has_static_width) and requires (Bits const& c) { c.is_subset_of(c); }
+        {
+                return m_bits.is_subset_of(rhs.m_bits);
+        }
+
+        [[nodiscard]] constexpr auto is_proper_subset_of(basic_bitset const& rhs) const noexcept
+                -> bool
+                requires (not has_static_width) and requires (Bits const& c) { c.is_proper_subset_of(c); }
+        {
+                return m_bits.is_proper_subset_of(rhs.m_bits);
+        }
+
+        [[nodiscard]] constexpr auto intersects(basic_bitset const& rhs) const noexcept
+                -> bool
+                requires (not has_static_width) and requires (Bits const& c) { c.intersects(c); }
+        {
+                return m_bits.intersects(rhs.m_bits);
+        }
+
+        // boost's two searches, npos where the trait's total answer is the width.
+        [[nodiscard]] constexpr auto find_first() const noexcept
+                -> std::size_t
+                requires (not has_static_width)
+        {
+                auto const n = detail::bits::find_first<Traits>(m_bits);
+                return n == size() ? npos : n;
+        }
+
+        [[nodiscard]] constexpr auto find_next(std::size_t pos) const noexcept
+                -> std::size_t
+                requires (not has_static_width)
+        {
+                auto const n = detail::bits::find_next<Traits>(m_bits, pos);
+                return n == size() ? npos : n;
+        }
+
+        // Growth, boost's members, on storage that spells them alike: detected on the storage rather than reconciled by the trait. [design.md#growth]
+        [[nodiscard]] constexpr auto empty() const noexcept
+                -> bool
+                requires (not has_static_width)
+        {
+                return size() == 0UZ;
+        }
+
+        constexpr void resize(std::size_t num_bits, bool value = false)
+                requires requires (Bits& b) { b.resize(num_bits, value); }
+        {
+                m_bits.resize(num_bits, value);
+        }
+
+        constexpr void clear()
+                requires requires (Bits& b) { b.clear(); }
+        {
+                m_bits.clear();
+        }
+
+        constexpr void push_back(bool bit)
+                requires requires (Bits& b) { b.push_back(bit); }
+        {
+                m_bits.push_back(bit);
+        }
+
+        constexpr void pop_back()
+                requires requires (Bits& b) { b.pop_back(); }
+        {
+                m_bits.pop_back();
+        }
+
+        template<class Block>
+        constexpr void append(Block value)
+                requires requires (Bits& b) { b.append(value); }
+        {
+                m_bits.append(value);
+        }
+
+        template<std::input_iterator I>
+        constexpr void append(I first, I last)
+                requires requires (Bits& b) { b.append(first, last); }
+        {
+                m_bits.append(first, last);
+        }
+
+        constexpr void reserve(std::size_t num_bits)
+                requires requires (Bits& b) { b.reserve(num_bits); }
+        {
+                m_bits.reserve(num_bits);
+        }
+
+        [[nodiscard]] constexpr auto capacity() const noexcept
+                -> std::size_t
+                requires requires (Bits const& c) { c.capacity(); }
+        {
+                return m_bits.capacity();
+        }
+
+        constexpr void shrink_to_fit()
+                requires requires (Bits& b) { b.shrink_to_fit(); }
+        {
+                m_bits.shrink_to_fit();
+        }
 
 private:
+        constexpr void from_ullong(unsigned long long val) noexcept
+        {
+                constexpr auto digits = static_cast<std::size_t>(std::numeric_limits<unsigned long long>::digits);
+                auto const M = std::ranges::min(size(), digits);
+                for (auto const i : std::views::iota(0UZ, M)) {
+                        if (((val >> i) & 1ULL) != 0ULL) {
+                                Traits::unchecked_assign(m_bits, i, true);
+                        }
+                }
+        }
+
+        // One position at a time over at most a word's worth, the overflow asked of the trait's search above the word.
+        template<class Word>
+        [[nodiscard]] constexpr auto to_word() const
+                -> Word
+        {
+                constexpr auto digits = static_cast<std::size_t>(std::numeric_limits<Word>::digits);
+                if (size() > digits and detail::bits::find_next<Traits>(m_bits, digits - 1UZ) != size()) {
+                        throw overflow_error();
+                }
+                auto const M = std::ranges::min(size(), digits);
+                auto word = Word{0};
+                for (auto const i : std::views::iota(0UZ, M)) {
+                        if (Traits::at(m_bits, i)) {
+                                word |= static_cast<Word>(Word{1} << i);
+                        }
+                }
+                return word;
+        }
+
         template<class charT>
         static constexpr auto invalid_argument(
                 charT ch, charT zero = static_cast<charT>('0'), charT one = static_cast<charT>('1'),
@@ -348,6 +537,16 @@ private:
                         std::format(
                                 "{}:{}:{}: exception: ‘{}‘: argument ‘pos‘ is out of range [{} >= {}]",
                                 loc.file_name(), loc.line(), loc.column(), loc.function_name(), pos, size()
+                        )
+                );
+        }
+
+        [[nodiscard]] static constexpr auto overflow_error(std::source_location const& loc = std::source_location::current())
+        {
+                return std::overflow_error(
+                        std::format(
+                                "{}:{}:{}: exception: ‘{}‘: a set position lies beyond the word",
+                                loc.file_name(), loc.line(), loc.column(), loc.function_name()
                         )
                 );
         }
@@ -387,35 +586,40 @@ struct hash<xstd::basic_bitset<Bits, Traits>>
 namespace xstd {
 
 // bitset operators                                           [bitset.operators]
-template<class Bits, class Traits> [[nodiscard]] constexpr auto operator&(basic_bitset<Bits, Traits> const& lhs, basic_bitset<Bits, Traits> const& rhs) noexcept -> basic_bitset<Bits, Traits> { auto nrv = lhs; nrv &= rhs; return nrv; }
-template<class Bits, class Traits> [[nodiscard]] constexpr auto operator|(basic_bitset<Bits, Traits> const& lhs, basic_bitset<Bits, Traits> const& rhs) noexcept -> basic_bitset<Bits, Traits> { auto nrv = lhs; nrv |= rhs; return nrv; }
-template<class Bits, class Traits> [[nodiscard]] constexpr auto operator^(basic_bitset<Bits, Traits> const& lhs, basic_bitset<Bits, Traits> const& rhs) noexcept -> basic_bitset<Bits, Traits> { auto nrv = lhs; nrv ^= rhs; return nrv; }
+template<class Bits, class Traits> [[nodiscard]] constexpr auto operator&(basic_bitset<Bits, Traits> const& lhs, basic_bitset<Bits, Traits> const& rhs) noexcept(static_bit_extent<Traits, Bits>) -> basic_bitset<Bits, Traits> { auto nrv = lhs; nrv &= rhs; return nrv; }
+template<class Bits, class Traits> [[nodiscard]] constexpr auto operator|(basic_bitset<Bits, Traits> const& lhs, basic_bitset<Bits, Traits> const& rhs) noexcept(static_bit_extent<Traits, Bits>) -> basic_bitset<Bits, Traits> { auto nrv = lhs; nrv |= rhs; return nrv; }
+template<class Bits, class Traits> [[nodiscard]] constexpr auto operator^(basic_bitset<Bits, Traits> const& lhs, basic_bitset<Bits, Traits> const& rhs) noexcept(static_bit_extent<Traits, Bits>) -> basic_bitset<Bits, Traits> { auto nrv = lhs; nrv ^= rhs; return nrv; }
+template<class Bits, class Traits> [[nodiscard]] constexpr auto operator-(basic_bitset<Bits, Traits> const& lhs, basic_bitset<Bits, Traits> const& rhs) noexcept(static_bit_extent<Traits, Bits>) -> basic_bitset<Bits, Traits> requires requires (basic_bitset<Bits, Traits>& b) { b -= b; } { auto nrv = lhs; nrv -= rhs; return nrv; }
 
+// [bitset.operators]/6: up to N characters into a temporary string, then x = bitset(str), so a short read lands in the low bits as it does there;
+// a run-time width reads every 0 or 1 on offer and is as wide as the characters read, as boost's is.
 template<class charT, class traits, class Bits, class Traits>
 auto operator>>(std::basic_istream<charT, traits>& is, basic_bitset<Bits, Traits>& x)
         -> std::basic_istream<charT, traits>&
 {
-        auto const N = x.size();
-        auto str = std::basic_string<charT, traits>(N, is.widen('0'));  // NOLINT(bugprone-string-constructor)
+        auto const limit = [&] {
+                if constexpr (static_bit_extent<Traits, Bits>) {
+                        return x.size();
+                } else {
+                        return std::numeric_limits<std::size_t>::max();
+                }
+        }();
+        auto str = std::basic_string<charT, traits>();
         // Assigned inside an if constexpr the zero-width instantiation discards. [design.md#clang-tidy-false-positives]
         auto state = std::ios_base::goodbit;  // NOLINT(misc-const-correctness)
         charT ch;
-        auto i = 0UZ;
         // One peek per character: peeking twice sets eofbit then failbit, failing a short but valid extraction ([bitset.operators]/6).
-        while (i < N) {
+        while (str.size() < limit) {
                 auto const next = is.peek();
                 if (not traits::eq_int_type(next, is.widen('0')) and not traits::eq_int_type(next, is.widen('1'))) {
                         break;
                 }
                 is >> ch;
-                if (traits::eq(ch, is.widen('1'))) {
-                        str[i] = ch;
-                }
-                ++i;
+                str.push_back(ch);
         }
         x = basic_bitset<Bits, Traits>(str);
         if constexpr (not detail::bits::zero_width<Traits>) {
-                if (i == 0) {
+                if (str.empty()) {
                         state |= std::ios_base::failbit;
                         is.setstate(state);
                 }

--- a/include/xstd/bits/bit_set.hpp
+++ b/include/xstd/bits/bit_set.hpp
@@ -1,0 +1,23 @@
+//          Copyright Rein Halbersma 2014-2026.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef XSTD_BITS_BIT_SET_HPP
+#define XSTD_BITS_BIT_SET_HPP
+
+#include <xstd/bits/basic_bit_set.hpp>             // basic_bit_set
+#include <xstd/bits/block_sequence.hpp>            // block_vector
+#include <xstd/bits/ownership.hpp>                 // ownership
+#include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer
+#include <memory>                                  // allocator
+
+namespace xstd {
+
+// The set reading over a heap of blocks: the flagship, benchmarked against std::set, and the one name without a qualifier. [design.md#the-public-names]
+template<xstd::unsigned_integer Block, class Allocator = std::allocator<Block>>
+using bit_set = basic_bit_set<block_vector<Block, Allocator>, ownership::owns>;
+
+}       // namespace xstd
+
+#endif  // XSTD_BITS_BIT_SET_HPP

--- a/include/xstd/bits/bit_vector.hpp
+++ b/include/xstd/bits/bit_vector.hpp
@@ -1,0 +1,23 @@
+//          Copyright Rein Halbersma 2014-2026.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef XSTD_BITS_BIT_VECTOR_HPP
+#define XSTD_BITS_BIT_VECTOR_HPP
+
+#include <xstd/bits/basic_bit_sequence.hpp>        // basic_bit_sequence
+#include <xstd/bits/block_sequence.hpp>            // block_vector
+#include <xstd/bits/ownership.hpp>                 // ownership
+#include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer
+#include <memory>                                  // allocator
+
+namespace xstd {
+
+// The sequence reading over a heap of blocks: std::vector<bool> under the name Hinnant proposed for it. [design.md#the-public-names]
+template<xstd::unsigned_integer Block, class Allocator = std::allocator<Block>>
+using bit_vector = basic_bit_sequence<block_vector<Block, Allocator>, ownership::owns, false>;
+
+}       // namespace xstd
+
+#endif  // XSTD_BITS_BIT_VECTOR_HPP

--- a/include/xstd/bits/block_sequence.hpp
+++ b/include/xstd/bits/block_sequence.hpp
@@ -23,6 +23,7 @@
 #include <cstddef>                                             // ptrdiff_t, size_t
 #include <functional>                                          // plus
 #include <iterator>                                            // distance, forward_iterator, input_iterator, prev
+#include <limits>                                              // numeric_limits
 #include <memory>                                              // allocator
 #include <ranges>                                              // begin, drop, iota, size, swap, transform, zip
                                                                // (views::drop_last when P22014R2 is accepted)
@@ -940,7 +941,17 @@ struct bit_traits<block_sequence<Blocks, N>>
         [[nodiscard]] static constexpr auto count(bits_type const& c) noexcept -> std::size_t { return c.count(); }
 
         // The two entries the readings cannot synthesize: insert is the one operation that can grow, and fill is bulk. [design.md#what-the-trait-reconciles]
-        static constexpr void insert(bits_type& c, std::size_t n) noexcept { c.set(n); }
+        // A run-time width grows to hold the position, as boost's does; n + 1 must be addressable, the ruled-out position being the one whose successor wraps.
+        static constexpr void insert(bits_type& c, std::size_t n) noexcept(bits_type::has_static_size)
+        {
+                if constexpr (not bits_type::has_static_size) {
+                        if (n >= c.size()) {
+                                assert(n < std::numeric_limits<std::size_t>::max());
+                                c.resize(n + 1UZ);
+                        }
+                }
+                c.set(n);
+        }
         static constexpr void fill(bits_type& c, bool value) noexcept
         {
                 if (value) {

--- a/include/xstd/bits/dynamic_bitset.hpp
+++ b/include/xstd/bits/dynamic_bitset.hpp
@@ -1,0 +1,22 @@
+//          Copyright Rein Halbersma 2014-2026.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef XSTD_BITS_DYNAMIC_BITSET_HPP
+#define XSTD_BITS_DYNAMIC_BITSET_HPP
+
+#include <xstd/bits/basic_bitset.hpp>              // basic_bitset
+#include <xstd/bits/block_sequence.hpp>            // block_vector
+#include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer
+#include <memory>                                  // allocator
+
+namespace xstd {
+
+// The bitset reading over a heap of blocks, boost::dynamic_bitset being its counterpart. [design.md#the-idempotent-wrapper]
+template<xstd::unsigned_integer Block, class Allocator = std::allocator<Block>>
+using dynamic_bitset = basic_bitset<block_vector<Block, Allocator>>;
+
+}       // namespace xstd
+
+#endif  // XSTD_BITS_DYNAMIC_BITSET_HPP

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -70,6 +70,7 @@ set(cxx_compile_options_warnings
         -Wno-array-bounds                   # triggered by Boost.DynamicBitset for gcc >= 12 in Release mode
         -Wno-stringop-overflow              # triggered by Boost.DynamicBitset for gcc >= 12 in Release mode
         -Wno-maybe-uninitialized            # false positive on detail::array's std::array member (WinLibs gcc 15.3.0, Release mode)
+        -Wno-restrict                       # false positive on std::vector's copy inside block_sequence's, inlined into basic_bitset's non-member operators (gcc 17-SVN, Release mode)
     >
     $<$<AND:$<BOOL:${XSTD_BITS_WARNINGS_AS_ERRORS}>,$<CXX_COMPILER_ID:MSVC>>:/WX>
     $<$<AND:$<BOOL:${XSTD_BITS_WARNINGS_AS_ERRORS}>,$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>>:-Werror>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -71,6 +71,7 @@ set(cxx_compile_options_warnings
         -Wno-stringop-overflow              # triggered by Boost.DynamicBitset for gcc >= 12 in Release mode
         -Wno-maybe-uninitialized            # false positive on detail::array's std::array member (WinLibs gcc 15.3.0, Release mode)
         -Wno-restrict                       # false positive on std::vector's copy inside block_sequence's, inlined into basic_bitset's non-member operators (gcc 17-SVN, Release mode)
+        -Wno-stringop-overread              # the same site, under the name gcc 17-SVN gives it once -Wrestrict is off
     >
     $<$<AND:$<BOOL:${XSTD_BITS_WARNINGS_AS_ERRORS}>,$<CXX_COMPILER_ID:MSVC>>:/WX>
     $<$<AND:$<BOOL:${XSTD_BITS_WARNINGS_AS_ERRORS}>,$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>>:-Werror>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -71,7 +71,7 @@ set(cxx_compile_options_warnings
         -Wno-stringop-overflow              # triggered by Boost.DynamicBitset for gcc >= 12 in Release mode
         -Wno-maybe-uninitialized            # false positive on detail::array's std::array member (WinLibs gcc 15.3.0, Release mode)
         -Wno-restrict                       # false positive on std::vector's copy inside block_sequence's, inlined into basic_bitset's non-member operators (gcc 17-SVN, Release mode)
-        -Wno-stringop-overread              # the same site, under the name gcc 17-SVN gives it once -Wrestrict is off
+        -Wno-stringop-overread              # the same copy inlined into basic_bit_set's non-member operators, under the name gcc 17-SVN gives it there (Release mode)
     >
     $<$<AND:$<BOOL:${XSTD_BITS_WARNINGS_AS_ERRORS}>,$<CXX_COMPILER_ID:MSVC>>:/WX>
     $<$<AND:$<BOOL:${XSTD_BITS_WARNINGS_AS_ERRORS}>,$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>>:-Werror>

--- a/test/include/test/bitset/factory.hpp
+++ b/test/include/test/bitset/factory.hpp
@@ -7,18 +7,22 @@
 #define TEST_BITSET_FACTORY_HPP
 
 #include <boost/dynamic_bitset_fwd.hpp> // dynamic_bitset
+#include <test/dynamic.hpp>             // dynamic
 #include <concepts>                     // unsigned_integral
 #include <cstddef>                      // size_t
 
 namespace test::bitset {
 
+// A static width ignores the count; a growing one, ours or boost's, is resized to it.
 template<class T>
 struct factory
 {
-        constexpr auto operator()(std::size_t, bool value = false) const noexcept
+        constexpr auto operator()(std::size_t num_bits, bool value = false) const noexcept
         {
                 T b;
-                if (value) {
+                if constexpr (dynamic<T>) {
+                        b.resize(num_bits, value);
+                } else if (value) {
                         b.set();
                 } else {
                         b.reset();

--- a/test/include/test/bitset/primitives.hpp
+++ b/test/include/test/bitset/primitives.hpp
@@ -552,14 +552,14 @@ struct op_istream_failure
                                 BOOST_CHECK_EQUAL(is.fail(), N > 0);            // [bitset.operators]/6
                         }
 
-                        // Fewer digits than N: the loop stops on eof rather than on N, and what was read lands at the front.
+                        // Fewer digits than N: the loop stops on eof rather than on N, and x = X(str) puts what was read in the low bits.
                         if constexpr (N > 1) {
                                 auto is = std::istringstream("1");
                                 auto x = X();
                                 is >> x;
                                 BOOST_CHECK(not is.fail());
                                 BOOST_CHECK_EQUAL(x.count(), 1uz);
-                                BOOST_CHECK(x.test(N - 1));                     // [bitset.operators]/5
+                                BOOST_CHECK(x.test(0));                         // [bitset.operators]/6
                         }
                 }
         }

--- a/test/include/test/bitset/primitives.hpp
+++ b/test/include/test/bitset/primitives.hpp
@@ -8,6 +8,7 @@
 
 #include <boost/test/unit_test.hpp>      // BOOST_CHECK, BOOST_CHECK_EQUAL, BOOST_CHECK_NE, BOOST_CHECK_THROW
 #include <test/dynamic.hpp>              // dynamic
+#include <xstd/bits/ownership.hpp>       // owned_storage
 #include <xstd/bits/ranges/set_view.hpp> // view
 #include <cstddef>                       // size_t
 #include <memory>                        // addressof
@@ -24,6 +25,10 @@ namespace test::bitset {
 // These checks are on xstd::bitset's basic_string_view overload: std::bitset has none, and dynamic_bitset answers to its own contract.
 template<class X>
 concept fixed_string_view_constructible = requires { X(std::string_view()); } and not dynamic<X>;
+
+// The wrapper at a run-time width is one of ours and answers as boost does; boost itself, which has the overload from 1.87, asserts where the wrapper throws.
+template<class X>
+concept dynamic_string_view_constructible = requires { X(std::string_view()); typename xstd::owned_storage<X>::bits_type; } and dynamic<X>;
 
 template<class X>
 struct constructor
@@ -52,7 +57,7 @@ struct constructor
                                         (static_cast<void>(X(std::string_view(invalid)))), std::invalid_argument
                                 );
                         }
-                } else if constexpr (dynamic<X> and requires { X(std::string_view()); }) {
+                } else if constexpr (dynamic_string_view_constructible<X>) {
                         // A run-time width is boost's contract: the text read is the width, and the two throws are as at a static width.
                         BOOST_CHECK_EQUAL(X(std::string_view("0101")).size(), 4uz);
                         BOOST_CHECK(X(std::string_view("11")).all());

--- a/test/include/test/bitset/primitives.hpp
+++ b/test/include/test/bitset/primitives.hpp
@@ -52,6 +52,12 @@ struct constructor
                                         (static_cast<void>(X(std::string_view(invalid)))), std::invalid_argument
                                 );
                         }
+                } else if constexpr (dynamic<X> and requires { X(std::string_view()); }) {
+                        // A run-time width is boost's contract: the text read is the width, and the two throws are as at a static width.
+                        BOOST_CHECK_EQUAL(X(std::string_view("0101")).size(), 4uz);
+                        BOOST_CHECK(X(std::string_view("11")).all());
+                        BOOST_CHECK_THROW((static_cast<void>(X(std::string_view("01"), 3))),  std::out_of_range);
+                        BOOST_CHECK_THROW((static_cast<void>(X(std::string_view("012")))),   std::invalid_argument);
                 }
         }
 };

--- a/test/include/test/set/composable.hpp
+++ b/test/include/test/set/composable.hpp
@@ -97,6 +97,7 @@ struct decrement_modulo
                         constexpr auto N = X::max_size();
                         BOOST_CHECK(
                                 (a >> n) == (a
+                                        | std::views::filter   ([=](auto x) { return x >= n; })
                                         | std::views::transform([=](auto x) { return x - n; })
                                         | std::views::filter   ([ ](auto x) { return x < N; })
                                         | std::ranges::to<X>()

--- a/test/include/test/set/exhaustive.hpp
+++ b/test/include/test/set/exhaustive.hpp
@@ -6,6 +6,8 @@
 #ifndef TEST_SET_EXHAUSTIVE_HPP
 #define TEST_SET_EXHAUSTIVE_HPP
 
+#include <xstd/bits/bit_traits.hpp> // static_bit_extent
+#include <xstd/bits/ownership.hpp>  // owned_storage
 #include <algorithm>        // max
 #include <array>            // array
 #include <cassert>          // assert
@@ -24,9 +26,13 @@ inline constexpr auto L2 =  64uz;
 inline constexpr auto L3 =  32uz;
 inline constexpr auto L4 =  16uz;
 
+// A static width is its own limit; a growing one, ours or the standard library's, takes the sweep's.
+template<class X>
+concept static_width = requires { typename xstd::owned_storage<X>::bits_type; } and xstd::static_bit_extent<typename X::traits_type, typename xstd::owned_storage<X>::bits_type>;
+
 template<class X, std::size_t Limit>
 inline constexpr auto limit_v = []() {
-        if constexpr (requires { X::max_size(); }) {
+        if constexpr (static_width<X>) {
                 return X::max_size();
         } else {
                 return Limit;

--- a/test/include/test/set/primitives.hpp
+++ b/test/include/test/set/primitives.hpp
@@ -7,7 +7,8 @@
 #define TEST_SET_PRIMITIVES_HPP
 
 #include <boost/test/unit_test.hpp>     // BOOST_CHECK, BOOST_CHECK_EQUAL
-#include <xstd/bits/bit_static_set.hpp> // bit_static_set
+#include <xstd/bits/basic_bit_set.hpp> // basic_bit_set
+#include <xstd/bits/ownership.hpp>     // ownership
 #include <algorithm>                    // equal_range, lexicographical_compare_three_way
 #include <compare>                      // strong_ordering
 #include <concepts>                     // convertible_to, default_initializable, equality_comparable, integral, same_as, unsigned_integral
@@ -27,8 +28,9 @@ struct ref_same_as_pred
         static constexpr auto value = std::same_as<R, T>;
 };
 
-template<std::size_t N, std::unsigned_integral Block>
-struct ref_same_as_pred<xstd::bit_static_set<N, Block>>
+// Every set adaptor hands out a proxy converting to the key, whatever its storage or ownership.
+template<class Bits, xstd::ownership Own, class Traits>
+struct ref_same_as_pred<xstd::basic_bit_set<Bits, Own, Traits>>
 {
         template<class R, class T>
         static constexpr auto value = std::convertible_to<R, std::add_const_t<std::remove_reference_t<T>>&>;

--- a/test/src/bits.cpp
+++ b/test/src/bits.cpp
@@ -32,6 +32,11 @@ BOOST_AUTO_TEST_CASE(EveryContainerArrivesThroughTheUmbrella)
 
         auto const packed = xstd::bit_array<8>();
         static_assert(std::ranges::random_access_range<decltype(xstd::sequence_view(packed))>);
+
+        // The dynamic column, one name per reading, all three over a block_vector.
+        static_assert(std::ranges::bidirectional_range<xstd::bit_set<std::size_t>>);
+        static_assert(std::ranges::random_access_range<xstd::bit_vector<std::size_t>>);
+        static_assert(not std::ranges::range<xstd::dynamic_bitset<std::size_t>>);
 }
 
 // A packed container satisfies the same interface as the one it packs, which means something only because std::array answers to it too.

--- a/test/src/bits/basic_bit_sequence.cpp
+++ b/test/src/bits/basic_bit_sequence.cpp
@@ -16,6 +16,7 @@
 #include <cstddef>                           // size_t
 #include <cstdint>                           // uint64_t
 #include <iterator>                          // reverse_iterator
+#include <limits>                            // numeric_limits
 #include <ranges>                            // random_access_range
 #include <stdexcept>                         // out_of_range
 #include <type_traits>                       // is_const_v
@@ -180,6 +181,28 @@ BOOST_AUTO_TEST_CASE(TheOrderingIsTheLexicographicOrderOfTheBools)
                         BOOST_CHECK((s == t) == (p == q));
                 }
         }
+}
+
+// Dependent, so a constrained-away member is a false rather than a hard error.
+template<class X>
+constexpr bool can_grow = requires (X& x) { x.push_back(true); x.pop_back(); x.resize(1UZ); x.resize(1UZ, true); x.clear(); x.reserve(1UZ); x.shrink_to_fit(); };
+
+// Growth is the owner's over storage that grows; a static width and a view have none of it. [design.md#growth]
+BOOST_AUTO_TEST_CASE(GrowthIsTheOwnersOverStorageThatGrows)
+{
+        using Dynamic = xstd::basic_bit_sequence<xstd::block_vector<std::uint64_t>, xstd::ownership::owns, false>;
+        using Span    = xstd::basic_bit_sequence<xstd::block_vector<std::uint64_t>, xstd::ownership::refers, false>;
+
+        static_assert(    can_grow<Dynamic>);
+        static_assert(not can_grow<Owner>);
+        static_assert(not can_grow<Span>);
+
+        auto d = Dynamic(3, true);
+        d.push_back(false);
+        BOOST_CHECK_EQUAL(d.size(), 4UZ);
+        BOOST_CHECK(std::ranges::equal(d, std::vector<bool>{ true, true, true, false }));
+        BOOST_CHECK_EQUAL(d.max_size(), std::numeric_limits<std::size_t>::max());
+        BOOST_CHECK_EQUAL(Owner().max_size(), 100UZ);
 }
 
 BOOST_AUTO_TEST_CASE(AZeroWidthSequenceIsEmpty)

--- a/test/src/bits/basic_bitset.cpp
+++ b/test/src/bits/basic_bitset.cpp
@@ -208,6 +208,7 @@ BOOST_AUTO_TEST_CASE(TheWordConstructorAndConversionsAgreeWithStdBitset)
         using Narrow = xstd::bitset<3, std::uint8_t>;
         using Empty  = xstd::bitset<0, std::uint8_t>;
         BOOST_CHECK_EQUAL(Narrow(0b1111ULL).to_ullong(), 7ULL);
+        BOOST_CHECK_EQUAL(Narrow(0b1101ULL).to_ullong(), 5ULL);
         BOOST_CHECK_EQUAL(Empty(0b1111ULL).to_ullong(), 0ULL);
 
         auto wide = xstd::bitset<70, std::uint8_t>();

--- a/test/src/bits/basic_bitset.cpp
+++ b/test/src/bits/basic_bitset.cpp
@@ -17,7 +17,8 @@
 #include <cstdint>                            // uint8_t
 #include <functional>                         // hash
 #include <ranges>                             // range
-#include <stdexcept>                          // out_of_range
+#include <sstream>                            // istringstream
+#include <stdexcept>                          // out_of_range, overflow_error
 #include <string>                             // string
 #include <tuple>                              // tuple
 #include <type_traits>                        // is_nothrow_*, is_trivially_*
@@ -190,6 +191,49 @@ BOOST_AUTO_TEST_CASE(TheDerivedMembersHoldOverEitherStorage)
 
         // A count on the character-pointer form takes that many characters and no more.
         BOOST_CHECK_EQUAL(Packed("1111", 2).count(), 2UZ);
+}
+
+// [bitset.cons]/2 and [bitset.members]/34-37: the word in and the word out, the overflow where a set position lies beyond it.
+BOOST_AUTO_TEST_CASE(TheWordConstructorAndConversionsAgreeWithStdBitset)
+{
+        auto const s = std::bitset<9>(0b101ULL);
+        auto const w = xstd::basic_bitset<std::bitset<9>>(0b101ULL);
+        auto const p = xstd::bitset<9, std::uint8_t>(0b101ULL);
+        BOOST_CHECK_EQUAL(w.to_string(), s.to_string());
+        BOOST_CHECK_EQUAL(p.to_string(), s.to_string());
+        BOOST_CHECK_EQUAL(p.to_ullong(), s.to_ullong());
+        BOOST_CHECK_EQUAL(p.to_ulong(), s.to_ulong());
+
+        // The high bits of the value drop where the width is narrower, as [bitset.cons]/2 has it.
+        using Narrow = xstd::bitset<3, std::uint8_t>;
+        using Empty  = xstd::bitset<0, std::uint8_t>;
+        BOOST_CHECK_EQUAL(Narrow(0b1111ULL).to_ullong(), 7ULL);
+        BOOST_CHECK_EQUAL(Empty(0b1111ULL).to_ullong(), 0ULL);
+
+        auto wide = xstd::bitset<70, std::uint8_t>();
+        BOOST_CHECK_EQUAL(wide.to_ullong(), 0ULL);
+        wide.set(69);
+        BOOST_CHECK_THROW(static_cast<void>(wide.to_ullong()), std::overflow_error);
+        BOOST_CHECK_THROW(static_cast<void>(wide.to_ulong()), std::overflow_error);
+}
+
+// [bitset.operators]/6: a short read lands in the low bits, as std::bitset(str) puts it, and an empty read fails the stream.
+BOOST_AUTO_TEST_CASE(ExtractionOfAShortInputAgreesWithStdBitset)
+{
+        auto in = std::istringstream("1");
+        auto s = std::bitset<4>();
+        in >> s;
+        auto ours = std::istringstream("1");
+        auto x = xstd::bitset<4, std::uint8_t>();
+        ours >> x;
+        BOOST_CHECK_EQUAL(x.to_string(), s.to_string());
+        BOOST_CHECK_EQUAL(x.to_ullong(), 1ULL);
+
+        auto stop = std::istringstream("01x");
+        auto y = xstd::bitset<4, std::uint8_t>();
+        stop >> y;
+        BOOST_CHECK_EQUAL(y.to_string(), "0001");
+        BOOST_CHECK(not stop.fail());
 }
 
 // The text constructors reject as std::bitset's do: a stray character, and a position past the end.

--- a/test/src/bits/bit_set.cpp
+++ b/test/src/bits/bit_set.cpp
@@ -12,9 +12,10 @@
 #include <xstd/bits/block_sequence.hpp> // block_vector
 #include <xstd/bits/ownership.hpp>      // ownership
 #include <xstd/bits/ranges/set_view.hpp> // set_view
+#include <algorithm>                    // equal
 #include <concepts>                     // same_as
 #include <cstddef>                      // size_t
-#include <cstdint>                      // uint8_t
+#include <cstdint>                      // uint8_t, uint64_t
 #include <limits>                       // numeric_limits
 #include <memory>                       // allocator
 #include <ranges>                       // iota, to
@@ -74,11 +75,11 @@ BOOST_AUTO_TEST_CASE(ItIsBuiltAndOrderedLikeAStdSet)
 // The width is capacity, never value: two sets holding the same positions agree on everything std::set answers, whatever their storages' widths. [design.md#width-is-capacity]
 BOOST_AUTO_TEST_CASE(TheWidthIsCapacityNotValue)
 {
-        auto narrow = T({ 1, 3 });
-        auto wide   = T({ 1, 3 });
+        auto const narrow = T({ 1, 3 });
+        auto wide = T({ 1, 3 });
         wide.insert(100);
         wide.erase(100);
-        auto const digest = [](T const& s) { auto h = boost::hash2::fnv1a_64(); boost::hash2::hash_append(h, {}, s); return h.result(); };
+        auto const digest = [](T const& s) -> std::uint64_t { auto h = boost::hash2::fnv1a_64(); boost::hash2::hash_append(h, {}, s); return h.result(); };
         BOOST_CHECK(narrow == wide);
         BOOST_CHECK((narrow <=> wide) == 0);
         BOOST_CHECK_EQUAL(digest(narrow), digest(wide));
@@ -86,8 +87,11 @@ BOOST_AUTO_TEST_CASE(TheWidthIsCapacityNotValue)
         BOOST_CHECK(narrow.is_subset_of(wide) and wide.is_subset_of(narrow));
         BOOST_CHECK(not narrow.is_proper_subset_of(wide));
         BOOST_CHECK(narrow.intersects(wide));
+}
 
-        // The compound operators at two widths that differ, either way round, against the answers over the elements.
+// The compound operators and predicates at two widths that differ, either way round, against the answers over the elements. [design.md#width-is-capacity]
+BOOST_AUTO_TEST_CASE(TheSetOperationsIgnoreTheWidth)
+{
         auto const a = T({ 1, 3, 200 });
         auto const b = T({ 3, 5 });
         BOOST_CHECK((a | b) == T({ 1, 3, 5, 200 }));
@@ -99,12 +103,20 @@ BOOST_AUTO_TEST_CASE(TheWidthIsCapacityNotValue)
         BOOST_CHECK((a - b) == T({ 1, 200 }));
         BOOST_CHECK((b - a) == T({ 5 }));
         BOOST_CHECK(a < b);
-        BOOST_CHECK(b.is_proper_subset_of(a | b) and (a | b).intersects(b));
-        BOOST_CHECK(not b.is_subset_of(a) and not a.is_subset_of(b));
-        BOOST_CHECK(not a.is_proper_subset_of(b) and not b.is_proper_subset_of(a));
-        BOOST_CHECK(not T({ 5 }).intersects(a) and not a.intersects(T({ 5 })));
+        BOOST_CHECK(b.is_proper_subset_of(a | b));
+        BOOST_CHECK((a | b).intersects(b));
+        BOOST_CHECK(not b.is_subset_of(a));
+        BOOST_CHECK(not a.is_subset_of(b));
+        BOOST_CHECK(not a.is_proper_subset_of(b));
+        BOOST_CHECK(not b.is_proper_subset_of(a));
+        BOOST_CHECK(not T({ 5 }).intersects(a));
+        BOOST_CHECK(not a.intersects(T({ 5 })));
+}
 
-        // The shifts translate: left grows the width to hold the result, right empties past it, and neither has the width as a precondition.
+// The shifts translate: left grows the width to hold the result, right empties past it, and neither has the width as a precondition. [design.md#width-is-capacity]
+BOOST_AUTO_TEST_CASE(TheShiftsTranslateWhateverTheWidth)
+{
+        auto const b = T({ 3, 5 });
         BOOST_CHECK((b << 300) == T({ 303, 305 }));
         BOOST_CHECK((b >> 4) == T({ 1 }));
         BOOST_CHECK((b >> 300).empty());

--- a/test/src/bits/bit_set.cpp
+++ b/test/src/bits/bit_set.cpp
@@ -1,0 +1,114 @@
+//          Copyright Rein Halbersma 2014-2026.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/hash2/fnv1a.hpp>        // fnv1a_64
+#include <boost/hash2/hash_append.hpp>  // hash_append
+#include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL
+#include <test/set/concepts.hpp>        // bit_set
+#include <xstd/bits/basic_bit_set.hpp>  // basic_bit_set
+#include <xstd/bits/bit_set.hpp>        // bit_set
+#include <xstd/bits/block_sequence.hpp> // block_vector
+#include <xstd/bits/ownership.hpp>      // ownership
+#include <xstd/bits/ranges/set_view.hpp> // set_view
+#include <concepts>                     // same_as
+#include <cstddef>                      // size_t
+#include <cstdint>                      // uint8_t
+#include <limits>                       // numeric_limits
+#include <memory>                       // allocator
+#include <ranges>                       // iota, to
+#include <set>                          // set
+
+BOOST_AUTO_TEST_SUITE(BitSet)
+
+using T = xstd::bit_set<std::uint8_t>;
+
+// The flagship: the set reading over a heap of blocks, an alias and nothing more. [design.md#the-public-names]
+BOOST_AUTO_TEST_CASE(TheDynamicSetIsTheSetAdaptorOverAHeapOfBlocks)
+{
+        static_assert(std::same_as<T, xstd::basic_bit_set<xstd::block_vector<std::uint8_t>, xstd::ownership::owns>>);
+        static_assert(std::same_as<xstd::bit_set<std::uint8_t, std::allocator<std::uint8_t>>, T>);
+        static_assert(test::set::bit_set<T>);
+}
+
+// A key past the width grows the width: insert is the one operation a dynamic set cannot refuse. [design.md#asking-is-total]
+BOOST_AUTO_TEST_CASE(InsertingPastTheWidthGrowsIt)
+{
+        auto s = T();
+        BOOST_CHECK(s.empty());
+        BOOST_CHECK_EQUAL(T::max_size(), std::numeric_limits<std::size_t>::max() - 1UZ);
+
+        auto const [ where, inserted ] = s.insert(100);
+        BOOST_CHECK(inserted);
+        BOOST_CHECK(*where == 100UZ);
+        BOOST_CHECK(s.contains(100));
+        BOOST_CHECK_EQUAL(s.size(), 1UZ);
+
+        // Erasing never shrinks the width, and asking below or above it stays total.
+        BOOST_CHECK_EQUAL(s.erase(100), 1UZ);
+        BOOST_CHECK(not s.contains(100));
+        BOOST_CHECK(not s.contains(1000));
+        BOOST_CHECK(s.find(1000) == s.end());  // NOLINT(readability-container-contains)
+}
+
+// Built from a range as std::set is, iterated as std::set is, and ordered as std::set is.
+BOOST_AUTO_TEST_CASE(ItIsBuiltAndOrderedLikeAStdSet)
+{
+        auto const s = std::views::iota(0UZ, 300UZ) | std::views::filter([](auto i) { return i % 7 == 0; }) | std::ranges::to<T>();
+        auto const k = std::views::iota(0UZ, 300UZ) | std::views::filter([](auto i) { return i % 7 == 0; }) | std::ranges::to<std::set<std::size_t>>();
+        BOOST_CHECK(std::ranges::equal(s, k));
+
+        auto t = s;
+        t.insert(1);
+        BOOST_CHECK(t < s);
+        BOOST_CHECK(s.is_subset_of(t));
+        BOOST_CHECK(t.intersects(s));
+
+        // The view over it refers into the block_vector, as over every owner. [design.md#views-over-owners]
+        auto const v = xstd::set_view(t);
+        BOOST_CHECK(*v.begin() == 0UZ);
+        BOOST_CHECK_EQUAL(v.size(), t.size());
+}
+
+// The width is capacity, never value: two sets holding the same positions agree on everything std::set answers, whatever their storages' widths. [design.md#width-is-capacity]
+BOOST_AUTO_TEST_CASE(TheWidthIsCapacityNotValue)
+{
+        auto narrow = T({ 1, 3 });
+        auto wide   = T({ 1, 3 });
+        wide.insert(100);
+        wide.erase(100);
+        auto const digest = [](T const& s) { auto h = boost::hash2::fnv1a_64(); boost::hash2::hash_append(h, {}, s); return h.result(); };
+        BOOST_CHECK(narrow == wide);
+        BOOST_CHECK((narrow <=> wide) == 0);
+        BOOST_CHECK_EQUAL(digest(narrow), digest(wide));
+        BOOST_CHECK(digest(narrow) != digest(T({ 1 })));
+        BOOST_CHECK(narrow.is_subset_of(wide) and wide.is_subset_of(narrow));
+        BOOST_CHECK(not narrow.is_proper_subset_of(wide));
+        BOOST_CHECK(narrow.intersects(wide));
+
+        // The compound operators at two widths that differ, either way round, against the answers over the elements.
+        auto const a = T({ 1, 3, 200 });
+        auto const b = T({ 3, 5 });
+        BOOST_CHECK((a | b) == T({ 1, 3, 5, 200 }));
+        BOOST_CHECK((b | a) == T({ 1, 3, 5, 200 }));
+        BOOST_CHECK((a & b) == T({ 3 }));
+        BOOST_CHECK((b & a) == T({ 3 }));
+        BOOST_CHECK((a ^ b) == T({ 1, 5, 200 }));
+        BOOST_CHECK((b ^ a) == T({ 1, 5, 200 }));
+        BOOST_CHECK((a - b) == T({ 1, 200 }));
+        BOOST_CHECK((b - a) == T({ 5 }));
+        BOOST_CHECK(a < b);
+        BOOST_CHECK(b.is_proper_subset_of(a | b) and (a | b).intersects(b));
+        BOOST_CHECK(not b.is_subset_of(a) and not a.is_subset_of(b));
+        BOOST_CHECK(not a.is_proper_subset_of(b) and not b.is_proper_subset_of(a));
+        BOOST_CHECK(not T({ 5 }).intersects(a) and not a.intersects(T({ 5 })));
+
+        // The shifts translate: left grows the width to hold the result, right empties past it, and neither has the width as a precondition.
+        BOOST_CHECK((b << 300) == T({ 303, 305 }));
+        BOOST_CHECK((b >> 4) == T({ 1 }));
+        BOOST_CHECK((b >> 300).empty());
+        BOOST_CHECK((T() << 3).empty());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/bits/bit_vector.cpp
+++ b/test/src/bits/bit_vector.cpp
@@ -1,0 +1,109 @@
+//          Copyright Rein Halbersma 2014-2026.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/test/unit_test.hpp>          // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL
+#include <test/sequence/concepts.hpp>        // bit_sequence
+#include <xstd/bits/basic_bit_sequence.hpp>  // basic_bit_sequence
+#include <xstd/bits/bit_vector.hpp>          // bit_vector
+#include <xstd/bits/block_sequence.hpp>      // block_vector
+#include <xstd/bits/ownership.hpp>           // ownership
+#include <xstd/bits/ranges/sequence_view.hpp> // sequence_view
+#include <algorithm>                         // equal
+#include <concepts>                          // same_as
+#include <cstddef>                           // size_t
+#include <cstdint>                           // uint8_t
+#include <limits>                            // numeric_limits
+#include <memory>                            // allocator
+#include <ranges>                            // iota, transform
+#include <vector>                            // vector
+
+BOOST_AUTO_TEST_SUITE(BitVector)
+
+using T = xstd::bit_vector<std::uint8_t>;
+
+// Dependent, so a constrained-away member is a false rather than a hard error.
+template<class X>
+constexpr bool can_grow = requires (X& x) { x.push_back(true); x.resize(1UZ); };
+
+// std::vector<bool> under its own name: the sequence adaptor over a heap of blocks. [design.md#the-public-names]
+BOOST_AUTO_TEST_CASE(TheDynamicSequenceIsTheSequenceAdaptorOverAHeapOfBlocks)
+{
+        static_assert(std::same_as<T, xstd::basic_bit_sequence<xstd::block_vector<std::uint8_t>, xstd::ownership::owns, false>>);
+        static_assert(std::same_as<xstd::bit_vector<std::uint8_t, std::allocator<std::uint8_t>>, T>);
+        static_assert(test::sequence::bit_sequence<T>);
+}
+
+// [vector]'s constructors, every shape, against std::vector<bool> built the same way.
+BOOST_AUTO_TEST_CASE(ItIsBuiltLikeAStdVector)
+{
+        auto const pattern = std::views::iota(0UZ, 20UZ) | std::views::transform([](auto i) { return i % 3 == 0; });
+        auto const model = std::vector<bool>(pattern.begin(), pattern.end());
+
+        BOOST_CHECK(T().empty());
+        BOOST_CHECK_EQUAL(T(17).size(), 17UZ);
+        BOOST_CHECK(std::ranges::equal(T(5, true), std::vector<bool>(5, true)));
+        BOOST_CHECK(std::ranges::equal(T(5, false), std::vector<bool>(5, false)));
+        BOOST_CHECK(std::ranges::equal(T(pattern.begin(), pattern.end()), model));
+        BOOST_CHECK(std::ranges::equal(T(std::from_range, pattern), model));
+        BOOST_CHECK(std::ranges::equal(T{ true, false, true }, std::vector<bool>{ true, false, true }));
+
+        auto v = T();
+        v = { false, true };
+        BOOST_CHECK(std::ranges::equal(v, std::vector<bool>{ false, true }));
+        v.assign(3, true);
+        BOOST_CHECK(std::ranges::equal(v, std::vector<bool>(3, true)));
+        v.assign(pattern.begin(), pattern.end());
+        BOOST_CHECK(std::ranges::equal(v, model));
+        v.assign({ true });
+        BOOST_CHECK(std::ranges::equal(v, std::vector<bool>{ true }));
+}
+
+// Growth is the owner's: push, pop, emplace, resize, reserve, shrink and clear, each against the model.
+BOOST_AUTO_TEST_CASE(ItGrowsLikeAStdVector)
+{
+        auto v = T();
+        auto m = std::vector<bool>();
+        for (auto i = 0UZ; i < 30UZ; ++i) {
+                v.push_back(i % 2 == 0);
+                m.push_back(i % 2 == 0);
+        }
+        BOOST_CHECK(std::ranges::equal(v, m));
+        BOOST_CHECK_EQUAL(static_cast<bool>(v.emplace_back(true)), true);
+        v.pop_back();
+        BOOST_CHECK(std::ranges::equal(v, m));
+
+        v.resize(40, true);
+        m.resize(40, true);
+        BOOST_CHECK(std::ranges::equal(v, m));
+        v.resize(7);
+        m.resize(7);
+        BOOST_CHECK(std::ranges::equal(v, m));
+
+        v.reserve(100);
+        BOOST_CHECK_GE(v.capacity(), 100UZ);
+        BOOST_CHECK(std::ranges::equal(v, m));
+        v.shrink_to_fit();
+        BOOST_CHECK_GE(v.capacity(), v.size());
+
+        BOOST_CHECK_EQUAL(v.max_size(), std::numeric_limits<std::size_t>::max());
+
+        v.clear();
+        BOOST_CHECK(v.empty());
+        BOOST_CHECK(v == T());
+}
+
+// The view over it refers into the block_vector and cannot grow it. [design.md#views-over-owners]
+BOOST_AUTO_TEST_CASE(AViewOverItCannotGrowIt)
+{
+        auto v = T(5);
+        auto const s = xstd::sequence_view(v);
+        s[2] = true;
+        BOOST_CHECK(static_cast<bool>(v[2]));
+
+        static_assert(not can_grow<decltype(s)>);
+        static_assert(    can_grow<T>);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/bits/bit_vector.cpp
+++ b/test/src/bits/bit_vector.cpp
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(ItGrowsLikeAStdVector)
 
         v.clear();
         BOOST_CHECK(v.empty());
-        BOOST_CHECK(v == T());
+        BOOST_CHECK_EQUAL(v.size(), 0UZ);
 }
 
 // The view over it refers into the block_vector and cannot grow it. [design.md#views-over-owners]

--- a/test/src/bits/dynamic_bitset.cpp
+++ b/test/src/bits/dynamic_bitset.cpp
@@ -49,6 +49,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ItAnswersAsBoostDoes, T, Dynamic)
         BOOST_CHECK_EQUAL(d.find_first(), 0UZ);
         BOOST_CHECK_EQUAL(d.find_next(0), 2UZ);
         BOOST_CHECK_EQUAL(d.find_next(2), T::npos);
+        BOOST_CHECK_EQUAL(T(9).find_first(), T::npos);
 
         auto e = T(9);
         e.set(2);

--- a/test/src/bits/dynamic_bitset.cpp
+++ b/test/src/bits/dynamic_bitset.cpp
@@ -15,7 +15,7 @@
 #include <cstdint>                                // uint8_t, uint64_t
 #include <memory>                                 // allocator
 #include <sstream>                                // istringstream, ostringstream
-#include <stdexcept>                              // overflow_error
+#include <stdexcept>                              // invalid_argument, out_of_range, overflow_error
 #include <string>                                 // string
 #include <tuple>                                  // tuple
 
@@ -114,6 +114,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ItIsAsWideAsItsText, T, Dynamic)
         auto q = T();
         bad >> q;
         BOOST_CHECK(bad.fail());
+
+        // The text constructor's two throws, as [bitset.cons]/3-4 has them at a static width.
+        BOOST_CHECK_THROW(static_cast<void>(T(std::string("0101"), 5)), std::out_of_range);
+        BOOST_CHECK_THROW(static_cast<void>(T(std::string("0x01"))),   std::invalid_argument);
 }
 
 // Appending blocks is the storage's own where it has it: ours has, boost has, and the widths agree.

--- a/test/src/bits/dynamic_bitset.cpp
+++ b/test/src/bits/dynamic_bitset.cpp
@@ -1,0 +1,135 @@
+//          Copyright Rein Halbersma 2014-2026.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/dynamic_bitset.hpp>               // dynamic_bitset
+#include <boost/test/unit_test.hpp>               // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL, BOOST_CHECK_THROW
+#include <xstd/bits/basic_bitset.hpp>             // basic_bitset
+#include <xstd/bits/block_sequence.hpp>           // block_vector
+#include <xstd/bits/dynamic_bitset.hpp>           // dynamic_bitset
+#include <xstd/bits/ext/boost/dynamic_bitset.hpp> // bit_traits over boost::dynamic_bitset
+#include <array>                                  // array
+#include <concepts>                               // regular, same_as
+#include <cstddef>                                // size_t
+#include <cstdint>                                // uint8_t, uint64_t
+#include <memory>                                 // allocator
+#include <sstream>                                // istringstream, ostringstream
+#include <stdexcept>                              // overflow_error
+#include <string>                                 // string
+#include <tuple>                                  // tuple
+
+BOOST_AUTO_TEST_SUITE(DynamicBitset)
+
+// boost::dynamic_bitset's counterpart over a heap of blocks: the same wrapper, at a run-time width. [design.md#the-idempotent-wrapper]
+BOOST_AUTO_TEST_CASE(TheDynamicBitsetIsTheWrapperOverAHeapOfBlocks)
+{
+        static_assert(std::same_as<xstd::dynamic_bitset<std::uint8_t>, xstd::basic_bitset<xstd::block_vector<std::uint8_t>>>);
+        static_assert(std::same_as<xstd::dynamic_bitset<std::uint8_t, std::allocator<std::uint8_t>>, xstd::dynamic_bitset<std::uint8_t>>);
+        static_assert(std::regular<xstd::dynamic_bitset<std::uint8_t>>);
+}
+
+// Ours over a block_vector, ours over boost itself: the counterpart's contract on both.
+using Dynamic = std::tuple
+<       xstd::dynamic_bitset<std::uint8_t>
+,       xstd::dynamic_bitset<std::uint64_t>
+,       xstd::basic_bitset<boost::dynamic_bitset<>>
+>;
+
+// The width-and-value constructor, the searches with boost's sentinel, and the set vocabulary boost has.
+BOOST_AUTO_TEST_CASE_TEMPLATE(ItAnswersAsBoostDoes, T, Dynamic)
+{
+        auto d = T(9, 0b101ULL);
+        BOOST_CHECK_EQUAL(d.size(), 9UZ);
+        BOOST_CHECK_EQUAL(d.count(), 2UZ);
+        BOOST_CHECK_EQUAL(d.to_ullong(), 5ULL);
+        BOOST_CHECK_EQUAL(d.to_ulong(), 5UL);
+        BOOST_CHECK(not d.empty());
+
+        BOOST_CHECK_EQUAL(d.find_first(), 0UZ);
+        BOOST_CHECK_EQUAL(d.find_next(0), 2UZ);
+        BOOST_CHECK_EQUAL(d.find_next(2), T::npos);
+
+        auto e = T(9);
+        e.set(2);
+        BOOST_CHECK(e.is_subset_of(d));
+        BOOST_CHECK(e.is_proper_subset_of(d));
+        BOOST_CHECK(d.intersects(e));
+        BOOST_CHECK(not e.is_proper_subset_of(e));
+
+        auto const f = d - e;
+        d -= e;
+        BOOST_CHECK(f == d);
+        BOOST_CHECK_EQUAL(d.count(), 1UZ);
+}
+
+// Growth, boost's members: resize with either fill, push and pop, append a block and a range, reserve, shrink, clear.
+BOOST_AUTO_TEST_CASE_TEMPLATE(ItGrowsAsBoostDoes, T, Dynamic)
+{
+        auto d = T(9, 0b101ULL);
+        d.resize(70, true);
+        BOOST_CHECK_EQUAL(d.size(), 70UZ);
+        BOOST_CHECK_EQUAL(d.count(), 63UZ);
+        BOOST_CHECK_THROW(static_cast<void>(d.to_ullong()), std::overflow_error);
+
+        d.resize(9);
+        BOOST_CHECK_EQUAL(d.count(), 2UZ);
+        d.push_back(true);
+        BOOST_CHECK_EQUAL(d.size(), 10UZ);
+        BOOST_CHECK(d.test(9));
+        d.pop_back();
+        BOOST_CHECK_EQUAL(d.size(), 9UZ);
+
+        d.reserve(100);
+        BOOST_CHECK_GE(d.capacity(), 100UZ);
+        d.shrink_to_fit();
+        BOOST_CHECK_GE(d.capacity(), d.size());
+
+        d.clear();
+        BOOST_CHECK(d.empty());
+        BOOST_CHECK_EQUAL(d.size(), 0UZ);
+}
+
+// A run-time width is as wide as the text: the constructors and the extractor read every character, as boost's do.
+BOOST_AUTO_TEST_CASE_TEMPLATE(ItIsAsWideAsItsText, T, Dynamic)
+{
+        auto const s = T(std::string("0101"));
+        BOOST_CHECK_EQUAL(s.size(), 4UZ);
+        BOOST_CHECK_EQUAL(s.to_ullong(), 5ULL);
+        BOOST_CHECK_EQUAL(s.to_string(), "0101");
+
+        auto in = std::istringstream("1101x");
+        auto r = T();
+        in >> r;
+        BOOST_CHECK_EQUAL(r.size(), 4UZ);
+        BOOST_CHECK_EQUAL(r.to_ullong(), 13ULL);
+        BOOST_CHECK(not in.fail());
+
+        auto out = std::ostringstream();
+        out << r;
+        BOOST_CHECK_EQUAL(out.str(), "1101");
+
+        auto bad = std::istringstream("x");
+        auto q = T();
+        bad >> q;
+        BOOST_CHECK(bad.fail());
+}
+
+// Appending blocks is the storage's own where it has it: ours has, boost has, and the widths agree.
+BOOST_AUTO_TEST_CASE(AppendingBlocksWidensByAWord)
+{
+        using T = xstd::dynamic_bitset<std::uint8_t>;
+        auto d = T(3, 0b111ULL);
+        d.append(std::uint8_t{0b1});
+        BOOST_CHECK_EQUAL(d.size(), 11UZ);
+        BOOST_CHECK(d.test(3));
+        BOOST_CHECK_EQUAL(d.count(), 4UZ);
+
+        auto const more = std::array<std::uint8_t, 2>{ 0b11, 0b100 };
+        d.append(more.begin(), more.end());
+        BOOST_CHECK_EQUAL(d.size(), 27UZ);
+        BOOST_CHECK_EQUAL(d.count(), 7UZ);
+        BOOST_CHECK(d.test(11) and d.test(12) and d.test(21));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/bits/dynamic_bitset.cpp
+++ b/test/src/bits/dynamic_bitset.cpp
@@ -11,7 +11,6 @@
 #include <xstd/bits/ext/boost/dynamic_bitset.hpp> // bit_traits over boost::dynamic_bitset
 #include <array>                                  // array
 #include <concepts>                               // regular, same_as
-#include <cstddef>                                // size_t
 #include <cstdint>                                // uint8_t, uint64_t
 #include <memory>                                 // allocator
 #include <sstream>                                // istringstream, ostringstream

--- a/test/src/bits/std_bitset/o0.cpp
+++ b/test/src/bits/std_bitset/o0.cpp
@@ -9,6 +9,7 @@
 #include <test/uint128.hpp>                       // TEST_HAS_UINT128, uint128
 #include <xstd/bits/basic_bitset.hpp>             // basic_bitset
 #include <xstd/bits/bitset.hpp>                   // bitset
+#include <xstd/bits/dynamic_bitset.hpp>           // dynamic_bitset
 #include <xstd/bits/ext/boost/dynamic_bitset.hpp> // dynamic_bitset
 #include <xstd/bits/ext/std/bitset.hpp>           // bitset
 #include <xstd/bits/ext/xstd/bitset.hpp>          // bitset
@@ -71,6 +72,9 @@ using Types = std::tuple
 ,        xstd::bitset<128, xstd::uint128>
 ,        xstd::bitset<129, xstd::uint128>
 #endif
+,        xstd::basic_bitset<boost::dynamic_bitset<>>
+,        xstd::dynamic_bitset<uint8_t>
+,        xstd::dynamic_bitset<uint64_t>
 >;
 
 using namespace test::bitset;

--- a/test/src/bits/std_bitset/o1.cpp
+++ b/test/src/bits/std_bitset/o1.cpp
@@ -9,6 +9,7 @@
 #include <test/uint128.hpp>                       // TEST_HAS_UINT128, uint128
 #include <xstd/bits/basic_bitset.hpp>             // basic_bitset
 #include <xstd/bits/bitset.hpp>                   // bitset
+#include <xstd/bits/dynamic_bitset.hpp>           // dynamic_bitset
 #include <xstd/bits/ext/boost/dynamic_bitset.hpp> // dynamic_bitset
 #include <xstd/bits/ext/std/bitset.hpp>           // bitset
 #include <bitset>                                 // bitset
@@ -39,6 +40,9 @@ using Types = std::tuple
 #ifdef TEST_HAS_UINT128
 ,        xstd::bitset<24, xstd::uint128>
 #endif
+,        xstd::basic_bitset<boost::dynamic_bitset<>>
+,        xstd::dynamic_bitset<uint8_t>
+,        xstd::dynamic_bitset<uint64_t>
 >;
 
 using namespace test::bitset;

--- a/test/src/bits/std_bitset/o2.cpp
+++ b/test/src/bits/std_bitset/o2.cpp
@@ -9,6 +9,7 @@
 #include <test/uint128.hpp>                       // TEST_HAS_UINT128, uint128
 #include <xstd/bits/basic_bitset.hpp>             // basic_bitset
 #include <xstd/bits/bitset.hpp>                   // bitset
+#include <xstd/bits/dynamic_bitset.hpp>           // dynamic_bitset
 #include <xstd/bits/ext/boost/dynamic_bitset.hpp> // dynamic_bitset
 #include <xstd/bits/ext/std/bitset.hpp>           // bitset
 #include <xstd/bits/ext/xstd/bitset.hpp>          // bitset
@@ -35,6 +36,9 @@ using Types = std::tuple
 #ifdef TEST_HAS_UINT128
 ,        xstd::bitset< 8, xstd::uint128>
 #endif
+,        xstd::basic_bitset<boost::dynamic_bitset<>>
+,        xstd::dynamic_bitset<uint8_t>
+,        xstd::dynamic_bitset<uint64_t>
 >;
 
 using namespace test::bitset;

--- a/test/src/bits/std_bitset/o3.cpp
+++ b/test/src/bits/std_bitset/o3.cpp
@@ -9,6 +9,7 @@
 #include <test/uint128.hpp>                       // TEST_HAS_UINT128, uint128
 #include <xstd/bits/basic_bitset.hpp>             // basic_bitset
 #include <xstd/bits/bitset.hpp>                   // bitset
+#include <xstd/bits/dynamic_bitset.hpp>           // dynamic_bitset
 #include <xstd/bits/ext/boost/dynamic_bitset.hpp> // dynamic_bitset
 #include <xstd/bits/ext/std/bitset.hpp>           // bitset
 #include <xstd/bits/ext/xstd/bitset.hpp>          // bitset
@@ -37,6 +38,9 @@ using Types = std::tuple
 #ifdef TEST_HAS_UINT128
 ,        xstd::bitset<17, xstd::uint128>
 #endif
+,        xstd::basic_bitset<boost::dynamic_bitset<>>
+,        xstd::dynamic_bitset<uint8_t>
+,        xstd::dynamic_bitset<uint64_t>
 >;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(CompareThreeWayHoldsOverEveryTripletAndDoubleton, T, Types)

--- a/test/src/bits/std_bitset/o4.cpp
+++ b/test/src/bits/std_bitset/o4.cpp
@@ -9,6 +9,7 @@
 #include <test/uint128.hpp>                       // TEST_HAS_UINT128, uint128
 #include <xstd/bits/basic_bitset.hpp>             // basic_bitset
 #include <xstd/bits/bitset.hpp>                   // bitset
+#include <xstd/bits/dynamic_bitset.hpp>           // dynamic_bitset
 #include <xstd/bits/ext/boost/dynamic_bitset.hpp> // dynamic_bitset
 #include <xstd/bits/ext/std/bitset.hpp>           // bitset
 #include <xstd/bits/ext/xstd/bitset.hpp>          // bitset
@@ -37,6 +38,9 @@ using Types = std::tuple
 #ifdef TEST_HAS_UINT128
 ,        xstd::bitset<17, xstd::uint128>
 #endif
+,        xstd::basic_bitset<boost::dynamic_bitset<>>
+,        xstd::dynamic_bitset<uint8_t>
+,        xstd::dynamic_bitset<uint64_t>
 >;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(TheOrderingAndSubsetTestsHoldOverEveryDoubletonPair, T, Types)

--- a/test/src/bits/std_bitset/sieve.cpp
+++ b/test/src/bits/std_bitset/sieve.cpp
@@ -10,11 +10,13 @@
 #include <xstd/bits/bit_static_set.hpp>           // bit_static_set
 #include <xstd/bits/basic_bitset.hpp>             // basic_bitset
 #include <xstd/bits/bitset.hpp>                   // bitset
+#include <xstd/bits/dynamic_bitset.hpp>           // dynamic_bitset
 #include <xstd/bits/ext/boost/dynamic_bitset.hpp> // dynamic_bitset
 #include <xstd/bits/ext/std/bitset.hpp>           // bitset
 #include <xstd/bits/ext/xstd/bitset.hpp>          // bitset
 #include <xstd/bits/ranges/set_view.hpp>          // set_view
 #include <bitset>                                 // bitset
+#include <cstddef>                                // size_t
 #include <tuple>                                  // tuple
 
 BOOST_AUTO_TEST_SUITE(StdBitset)
@@ -28,6 +30,8 @@ using Types = std::tuple
 ,        xstd::basic_bitset<std::bitset<N>>
 ,        xstd::bitset<N>
 ,        xstd::bit_static_set<N>
+,        xstd::basic_bitset<boost::dynamic_bitset<>>
+,        xstd::dynamic_bitset<std::size_t>
 >;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(TheSiftedPrimesAndTwinsFormatAsExpected, T, Types)

--- a/test/src/bits/std_set/o0.cpp
+++ b/test/src/bits/std_set/o0.cpp
@@ -10,6 +10,7 @@
                                         // op_compare_three_way op_less, op_greater, op_less_equal, op_greater_equal,
 #include <test/uint128.hpp>             // TEST_HAS_UINT128, uint128
 #include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE_TEMPLATE
+#include <xstd/bits/bit_set.hpp>        // bit_set
 #include <xstd/bits/bit_static_set.hpp> // bit_static_set
 #include <cstddef>                      // size_t
 #include <cstdint>                      // uint8_t, uint16_t, uint32_t, uint64_t
@@ -65,6 +66,8 @@ using Types = std::tuple
 ,       xstd::bit_static_set<128, xstd::uint128>
 ,       xstd::bit_static_set<129, xstd::uint128>
 #endif
+,       xstd::bit_set<uint8_t>
+,       xstd::bit_set<uint64_t>
 >;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(TheSetOperationsHoldOnAnEmptyPair, T, Types)

--- a/test/src/bits/std_set/o1.cpp
+++ b/test/src/bits/std_set/o1.cpp
@@ -9,6 +9,7 @@
 #include <test/flat_set.hpp>            // TEST_HAS_FLAT_SET, is_flat_set
 #include <test/set/primitives.hpp>      // constructor, mem_const_reference, mem_const_iterator, mem_front, mem_back,
 #include <test/uint128.hpp>             // TEST_HAS_UINT128, uint128
+#include <xstd/bits/bit_set.hpp>        // bit_set
 #include <xstd/bits/bit_static_set.hpp> // bit_static_set
 #include <cstddef>                      // size_t
 #include <cstdint>                      // uint8_t, uint16_t, uint32_t, uint64_t
@@ -40,6 +41,8 @@ using Types = std::tuple
 #ifdef TEST_HAS_UINT128
 ,       xstd::bit_static_set<24, xstd::uint128>
 #endif
+,       xstd::bit_set<uint8_t>
+,       xstd::bit_set<uint64_t>
 >;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(TheSetOperationsHoldOverEverySingleton, T, Types)

--- a/test/src/bits/std_set/o2.cpp
+++ b/test/src/bits/std_set/o2.cpp
@@ -11,6 +11,7 @@
 #include <test/flat_set.hpp>            // TEST_HAS_FLAT_SET, is_flat_set
 #include <test/set/primitives.hpp>      // constructor, op_assign, mem_insert, mem_erase, mem_swap, mem_find, mem_count,
 #include <test/uint128.hpp>             // TEST_HAS_UINT128, uint128
+#include <xstd/bits/bit_set.hpp>        // bit_set
 #include <xstd/bits/bit_static_set.hpp> // bit_static_set
 #include <cstddef>                      // size_t
 #include <cstdint>                      // uint8_t, uint16_t, uint32_t, uint64_t
@@ -42,6 +43,8 @@ using Types = std::tuple
 #ifdef TEST_HAS_UINT128
 ,       xstd::bit_static_set<24, xstd::uint128>
 #endif
+,       xstd::bit_set<uint8_t>
+,       xstd::bit_set<uint64_t>
 >;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(TheSetOperationsHoldOverEveryDoubletonAndSingletonPair, T, Types)

--- a/test/src/bits/std_set/o3.cpp
+++ b/test/src/bits/std_set/o3.cpp
@@ -8,6 +8,7 @@
 #include <test/set/exhaustive.hpp>      // all_singleton_set_triples
 #include <test/set/primitives.hpp>      // op_less
 #include <test/uint128.hpp>             // TEST_HAS_UINT128, uint128
+#include <xstd/bits/bit_set.hpp>        // bit_set
 #include <xstd/bits/bit_static_set.hpp> // bit_static_set
 #include <cstddef>                      // size_t
 #include <cstdint>                      // uint8_t, uint16_t, uint32_t, uint64_t
@@ -35,6 +36,8 @@ using Types = std::tuple
 #ifdef TEST_HAS_UINT128
 ,       xstd::bit_static_set<17, xstd::uint128>
 #endif
+,       xstd::bit_set<uint8_t>
+,       xstd::bit_set<uint64_t>
 >;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(LessIsTransitiveOverEverySingletonTriple, T, Types)

--- a/test/src/bits/std_set/o4.cpp
+++ b/test/src/bits/std_set/o4.cpp
@@ -9,6 +9,7 @@
 #include <test/set/exhaustive.hpp>      // all_doubleton_set_pairs
 #include <test/set/primitives.hpp>      // op_compare_three_way
 #include <test/uint128.hpp>             // TEST_HAS_UINT128, uint128
+#include <xstd/bits/bit_set.hpp>        // bit_set
 #include <xstd/bits/bit_static_set.hpp> // bit_static_set
 #include <cstddef>                      // size_t
 #include <cstdint>                      // uint8_t, uint16_t, uint32_t, uint64_t
@@ -36,6 +37,8 @@ using Types = std::tuple
 #ifdef TEST_HAS_UINT128
 ,       xstd::bit_static_set<17, xstd::uint128>
 #endif
+,       xstd::bit_set<uint8_t>
+,       xstd::bit_set<uint64_t>
 >;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(CompareThreeWayHoldsOverEveryDoubletonPair, T, Types)


### PR DESCRIPTION
Step 7b of #80: the three public names over `block_vector`, growth on the adaptors, and `basic_bitset` at a run-time width.

## What

- **One header per public name**: `bit_set`, `bit_vector` and `dynamic_bitset` over `block_vector<Block, Allocator>`, included by `bits.hpp` and listed in the file set. The README's naming table still says `dynamic_bit_set` in the dynamic column; that is the README rewrite's, not this step's.
- **Growth on `basic_bit_sequence`**, by detection on the storage and never through the trait: `std::vector<bool>`'s count and count-value constructors, range and `initializer_list` constructors and assignments, `assign`, `resize`, `clear`, `push_back`, `pop_back`, `emplace_back`, and `reserve`/`capacity`/`shrink_to_fit` where the blocks have them. `max_size` is the numeric limit where it can grow and the width where it cannot.
- **`basic_bitset` at a run-time width** is `boost::dynamic_bitset`'s surface minus `operator<` (a third reading) and the block-range I/O: the width-and-word and width-only constructors, `-=`, the three set predicates, `find_first`/`find_next` answering `npos`, `empty`, and growth, each detected on `Bits`. Element access asserts at a run-time width and throws at a static one, as the counterparts do. `to_ulong`/`to_ullong` overflow through the door's `find_next` from the last position the word holds; the word constructors take an `unsigned long long` at both widths.
- **`bit_traits<block_sequence>::insert` grows** a run-time width to hold the key, so `insert` is total on `bit_set` as it is on `std::set`.

## Two calls made here, both reversible

**Width is capacity on `bit_set`.** `std::set` has no width, so two sets holding the same positions are equal whatever their storages' widths, and the width neither orders, hashes, nor is a precondition of the set operations. `block_sequence` cannot say that (its `==` is width first, which the sequence reading and `dynamic_bitset` mean), so the set adaptor does: every comparison, predicate and compound operator asks `same_width` first and takes the storage's own answer at equal widths, which is every answer at a static width, where the arm folds away. At two run-time widths that differ the fallback is element-wise: `==` is `ranges::equal`, `<=>` the invariant's algorithm, `is_subset_of` is `ranges::includes`, `intersects` walks one set asking the other, and `|=` `&=` `^=` `-=` insert and erase one element at a time; `<<=` grows the width to hold the result and `>>=` empties past it. Block-wise answers over the common prefix are a later optimization the storage could offer. The alternative, width as value, would have `s.insert(100); s.erase(100); s == bit_set{}` be false, which no `std::set` drop-in can do. [design.md#width-is-capacity]

**Extraction lands in the low positions.** The harness's `op_istream_failure` expected a short read to land at the front (`x.test(N - 1)`); `[bitset.operators]/6` says `x = bitset<N>(str)`, and `std::bitset<4>` from `"1"` is `0001`. The extractor is rewritten to that at both widths, a run-time width becoming the count read as boost's does, and the harness now expects position zero. So `xstd::bitset` agrees with `std::bitset` on a short read where it did not before.

## Also

- The set adaptor's `hash_append` hook was never reachable: Hash2 chooses between its range overload and a `tag_invoke` hook by `enable_if`, and the adaptor satisfied both. It now tells ContainerHash it is not a range, and hashes the elements at a run-time width so that equal sets hash equal.
- The free operators that copy (`~ & | ^ - << >>` on both adaptors) are `noexcept` at a static width alone: a copy of a `block_vector` allocates.
- The sieve's `generate_empty` resizes whatever can resize, instead of special-casing boost.
- Harness: `test::set::static_width` asks the owner's storage so `limit_v` sweeps a run-time width at the harness's limit; the bitset factory resizes a dynamic type; `decrement_modulo` drops the positions below `n` before subtracting, which at a static width it did by wrapping.
- The `std_set` and `std_bitset` matrices take the run-time widths (`bit_set<uint8_t>`, `bit_set<uint64_t>`; `basic_bitset<boost::dynamic_bitset<>>`, `dynamic_bitset<uint8_t>`, `dynamic_bitset<uint64_t>`), `sieve` takes `dynamic_bitset` and the boost wrapper, and `bit_set.cpp`, `bit_vector.cpp`, `dynamic_bitset.cpp` are the names' own tests.
- design.md: growth on the adaptors, the dynamic wrapper under `the-idempotent-wrapper`, the assert arm under `checked-and-unchecked`, the headers under `the-public-names`, and the new `width-is-capacity`.
- A separate commit puts the README's license section in the `<pre>` banner form xstd-ints and xstd-misc carry, and says 2014-2026.

## Validation

Local: the full suite on clang 18 with `-Weverything -Werror` (the two `std_set` files the local libstdc++ cannot compile were run with `std::set` swapped for a third `bit_set` width), the alias-CTAD files on clang 20, clang-tidy-20 over the touched and new header shims, gcc-14 coverage over the suite, and header self-sufficiency of the three new headers on both compilers.

## During CI

- gcovr merges a function's branches across translation units by gcov's block ids, and gcc 15 numbers the run-time-width string constructor's blocks differently in the matrix files than in `dynamic_bitset.cpp`; the harness's constructor primitive now exercises the dynamic wrappers' string constructor and its two throws too, gated on `owned_storage` so boost's own `string_view` constructor (Boost 1.87+, on the macOS runners) stays on boost's contract. `find_first` on an empty run-time width and a zero bit in the narrow word are covered as well.
- clang-tidy: the includes the sieve's dropped boost special case took with it, const range-for variables in the set adaptor's element walks, trailing return types on two lambdas, and the width-is-capacity test split under the complexity threshold.
- gcc 17-SVN Release reports the memcpy inside `std::vector`'s copy constructor, inlined through `block_sequence` into the adaptors' non-member operators, with impossible byte counts, first as `-Wrestrict` and then as `-Wstringop-overread`; both join the Release-only GCC suppressions beside `-Warray-bounds`.

Next: 7c (windows), 7d (blit, range members, the sequence sweep), 7e (the inplace column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v8urscUNYsTMatTSnKb16

---
_Generated by [Claude Code](https://claude.ai/code/session_016v8urscUNYsTMatTSnKb16)_


---
_Generated by [Claude Code](https://claude.ai/code)_