### PR TITLE
A strict extension: the reverse searches, the bit string's order, the blocks

### DIFF
--- a/design.md
+++ b/design.md
@@ -284,22 +284,22 @@ needed on storage we control, and the unused tail is `block_sequence`'s to keep.
 
 ### two-readings-disagree
 
-"Lexicographic" is underspecified below the reading layer. Both readings are lexicographic; they order over
-different sequences, and **they disagree**:
+"Lexicographic" is underspecified below the reading layer. All three readings are lexicographic; they order
+over different sequences, and **they disagree**, pairwise, as two pairs show:
 
-| `{0,1}` against `{1}` | compared as | result |
-|---|---|---|
-| set reading | ascending positions, `[0,1]` against `[1]` | `{0,1} < {1}` |
-| sequence reading | bools from index 0, `[1,1,0…]` against `[0,1,0…]` | `{0,1} > {1}` |
+| pair | set reading, ascending positions | sequence reading, bools from index 0 | bitset reading, bools from the top |
+|---|---|---|---|
+| `{0}` against `{1}` | `[0]` vs `[1]`: less | `[1,0]` vs `[0,1]`: greater | `"01"` vs `"10"`: less |
+| `{0,1}` against `{1}` | `[0,1]` vs `[1]`: less | `[1,1]` vs `[0,1]`: greater | `"11"` vs `"10"`: greater |
 
 A trait serving three readings cannot hold one of their orderings without choosing for its callers, so it
-holds neither under that name. It holds **both, separately named**: `bit_traits` has a `set_three_way` entry
-and a `sequence_three_way` entry, never one `lexicographical_three_way`, so a caller says which reading it
-means rather than being handed whichever the trait happened to pick.
+holds none under that name. It holds **all three, separately named**: `bit_traits` has a `set_three_way`
+entry, a `sequence_three_way` entry and a `bitset_three_way` entry, never one `lexicographical_three_way`, so a
+caller says which reading it means rather than being handed whichever the trait happened to pick.
 
 ### the-ordering-primitive
 
-Both orderings are answered a word at a time, from two pieces:
+The first two orderings are answered a word at a time, from two pieces:
 
 - **`first_difference`** returns the lowest block at which two values differ, together with that block's
   `xor`. `countr_zero` of that `xor` is then the lowest position at which they differ. Equal values answer
@@ -327,6 +327,11 @@ makes the two comparable, both exiting at once.
 `[i, n)` on **one** operand, the one that lacked the bit. Block `i` is the only one touched twice, so the
 pair costs `n + 1` block reads. And when the values are equal `any_above` is never reached at all, since
 `first_difference` already settles it.
+
+**The bitset reading needs neither piece.** The bit string, most significant position first, is the blocks
+from the top block down, with the unused tail kept clear, so `bitset_three_way` is the plain `<=>` of the
+blocks from the top: one comparison at a static width within a word, a loop from the last block otherwise,
+equal only when every block is. It is the one reading whose order is plain lexicographic over words.
 
 **The prefix clause is not removable.** Set order is not plain lexicographic over words under *any*
 comparator. At `digits = 4`, `A = {1}` and `B = {5}` differ in word 0, where `A₀ = {1}` and `B₀ = {}`; a
@@ -380,19 +385,20 @@ std::lexicographical_compare_three_way(a.begin(), a.end(), b.begin(), b.end()) =
 which is stated on the **reading**, never on the storage: `block_sequence` has no `begin()`/`end()`, and
 `boost::dynamic_bitset` has no public iterators, so it cannot be written against a backend at all.
 
-`bitset_adaptor` therefore has no `operator<=>`, because it does not iterate — the existing "no iteration and
-no `<=>` here by design" is a consequence rather than a separate rule.
+`bitset_adaptor` does not iterate, so its left-hand side is the sequence reading's traversal **reversed**:
+`std::views::reverse` over the bools, the order `to_string()` writes them in. That is `boost::dynamic_bitset::operator<`
+exactly, a **third** reading. Boost pairs *a*'s highest bit with *b*'s highest, second with second, then
+breaks a tie on width -- the standard algorithm over reverse iterators. Verified over 1,046,529 pairs
+spanning every width 0-9 against every other: zero mismatches against reverse-lex, 223,893 against numeric
+order. It is *not* magnitude ordering, though it coincides with one at equal width: `"1"` and `"01"` are both
+the number 1, and boost orders them strictly, the shorter first. The harness pins it three ways: against
+boost's own `<` pair for pair over those widths, against `to_string()` compared as strings, and within a word
+against `to_ullong()`.
 
-`boost::dynamic_bitset::operator<` is a **third** reading, not an unreachable one. It pairs *a*'s highest bit
-with *b*'s highest, second with second, then breaks a tie on width — which is that same standard algorithm
-over **reverse** iterators. Verified over 1,046,529 pairs spanning every width 0-9 against every other: zero
-mismatches against reverse-lex, 223,893 against numeric order. It is *not* magnitude ordering, though it
-coincides with one at equal width, which is the only case our operators admit: `"1"` and `"01"` are both the
-number 1, and boost orders them strictly.
-
-So it stays out of `operator<=>` because that is defined by *forward* iteration, not because nothing could
-reach it — and should a dynamic bitset ever want boost's exact ordering, it costs no new algorithm, being
-`sequence_three_way` over `rbegin`/`rend`.
+`bitset_adaptor::operator<=>` is `bitset_three_way` at equal widths, and at unequal ones boost's own walk,
+the top `min(size())` positions paired from the top and then the shorter first; the block-wise form of that
+walk needs shifted reads and arrives with the blit. `==` stays width-first, and `<=>` never answers equal at
+unequal widths, so the two agree ([the-hashing-invariant](#the-hashing-invariant)).
 
 Where a specialization offers nothing faster, the default is that standard algorithm over the reading's own
 iterators — so the default cannot disagree with the specification, and only an optimization can.
@@ -742,13 +748,24 @@ width ([growth](#growth)): `empty`, `resize`, `clear`, `push_back`, `pop_back`, 
 trait's `find_next` from the last position the word holds, and the word constructors take an
 `unsigned long long` at both widths, boost's taking the width first.
 
+Three additions are ours, with no counterpart on either side. `find_last()` and `find_prev(pos)` mirror
+boost's forward pair: the highest set position below `pos`, `npos` where none, a `pos` past the width meaning
+from the end, so `find_prev(npos)` is `find_last()` the way boost's `find_next(npos)` wraps to `find_first()`,
+and the two loops are each other's reverse. They are total, so they take the generic walk rather than the
+trait's `find_prev`, whose contract is the iterator's cheaper one ([total-versus-precondition](#total-versus-precondition)).
+`operator<=>` is the bit string's order, boost's, at both widths ([the-ordering-invariant](#the-ordering-invariant)),
+so `std::set<xstd::bitset<N>>` works and boost's `<` is no longer an omission. And boost's block interface is
+in at both widths, every storage under the wrapper having blocks: `block_type`, `bits_per_block`, `num_blocks()`,
+`to_block_range` writing every block including the clear tail, `from_block_range` reading at most every block
+with the tail masked rather than trusted, and the block-range constructor at a run-time width, a whole number
+of blocks wide. Nothing of boost's is left out.
+
 What ours does not add is a range: becoming one would change what generic code does with it, from `fmt` to
 `std::ranges::to`, which is the one addition a strict extension cannot make. `bit_set_view` and `bit_span`
 refer into its storage ([views-over-owners](#views-over-owners)) and carry the readings, and
-`ext/xstd/bitset.hpp` is the opt-in that makes iteration reachable by name. `block_type` is gone from the
-surface, since nothing used it. The remainder of the extension -- `find_last` and `find_prev`, `operator<=>`
-under boost's bit-string ordering ([the-ordering-invariant](#the-ordering-invariant)), and boost's block
-interface -- is #80's next step.
+`ext/xstd/bitset.hpp` is the opt-in that makes iteration reachable by name. Nor a `const_reference` proxy
+from the const subscript, libc++'s way: `auto x = cb[i]` would change type and could dangle, and a strict
+extension re-types nothing.
 
 Extraction is `[bitset.operators]/6` at both widths: the characters read become `x = bitset_adaptor(str)`,
 so a short read lands in the low positions, and a run-time width becomes the count of characters read,

--- a/include/xstd/bits/bitset_adaptor.hpp
+++ b/include/xstd/bits/bitset_adaptor.hpp
@@ -9,18 +9,19 @@
 // Bitsets [bitset], Header <bitset> synopsis [bitset.syn]
 
 #include <boost/hash2/hash_append.hpp> // hash_append_tag
-#include <xstd/bits/bit_traits.hpp>    // bit_storage, bit_traits, block_readable, static_bit_extent, zero_width
+#include <xstd/bits/bit_traits.hpp>    // bit_storage, bit_traits, block_readable, scan_prev, static_bit_extent, zero_width
 #include <xstd/bits/detail/hash.hpp>   // hash_append_bits, std_hash
 #include <xstd/bits/ownership.hpp>     // owned_storage, ownership
 #include <algorithm>                   // min
 #include <cassert>                     // assert
+#include <compare>                     // strong_ordering
 #include <concepts>                    // convertible_to, regular, same_as
 #include <cstddef>                     // size_t
 #include <format>                      // format
 #include <functional>                  // hash
 #include <ios>                         // ios_base
 #include <iosfwd>                      // basic_istream, basic_ostream
-#include <iterator>                    // input_iterator
+#include <iterator>                    // input_iterator, iter_value_t, output_iterator, sentinel_for
 #include <limits>                      // numeric_limits
 #include <locale>                      // ctype, use_facet
 #include <memory>                      // allocator
@@ -29,6 +30,7 @@
 #include <stdexcept>                   // invalid_argument, out_of_range, overflow_error
 #include <string>                      // basic_string, char_traits
 #include <string_view>                 // basic_string_view
+#include <type_traits>                 // remove_cvref_t
 #include <utility>                     // as_const
 
 namespace xstd {
@@ -70,6 +72,9 @@ class bitset_adaptor
         // No iteration here by design, because neither counterpart has it: the two views refer into the storage instead. [design.md#views-over-owners]
         Bits m_bits{};
 
+        template<std::input_iterator I>
+        static constexpr bool block_iterator = std::same_as<std::remove_cvref_t<std::iter_value_t<I>>, typename Bits::block_type>;
+
         template<class B, ownership O, bit_storage<B> T>         friend class set_adaptor;
         template<class B, ownership O, bool W, bit_storage<B> T> friend class sequence_adaptor;
 
@@ -81,8 +86,10 @@ class bitset_adaptor
         }
 
 public:
-        // boost's typedef, which the harness keys a run-time width on; std::bitset has none, and a typedef changes no answer.
-        using size_type = std::size_t;
+        // boost's typedefs; std::bitset has none, and a typedef changes no answer. The block is in the open again, boost's block interface being part of the extension. [design.md#a-strict-extension]
+        using size_type  = std::size_t;
+        using block_type = Bits::block_type;
+        static constexpr std::size_t bits_per_block = Bits::bits_per_block;
 
         // [bitset.refs], reaching the bits only through the unchecked way in; its own class, with the flip and ~ the sequence proxy lacks. [design.md#unchecked-writes-in-views]
         class reference
@@ -164,6 +171,14 @@ public:
                 m_bits(num_bits)
         {
                 from_ullong(val);
+        }
+
+        // boost's block-range constructor: the first block's low bit is position zero, and the width is a whole number of blocks.
+        template<std::input_iterator I, std::sentinel_for<I> S>
+        [[nodiscard]] constexpr bitset_adaptor(I first, S last)
+                requires (not has_static_width) and block_iterator<I>
+        {
+                m_bits.append(first, last);
         }
 
         template<class charT, class traits, class Allocator>
@@ -343,10 +358,23 @@ public:
         }
 
         // observers
-        [[nodiscard]] constexpr auto count() const noexcept -> std::size_t { return m_bits.count(); }
-        [[nodiscard]] constexpr auto size()  const noexcept -> std::size_t { return m_bits.size();  }
+        [[nodiscard]] constexpr auto count()      const noexcept -> std::size_t { return m_bits.count();      }
+        [[nodiscard]] constexpr auto size()       const noexcept -> std::size_t { return m_bits.size();       }
+        [[nodiscard]] constexpr auto num_blocks() const noexcept -> std::size_t { return m_bits.num_blocks(); }
 
         [[nodiscard]] constexpr auto operator==(bitset_adaptor const& rhs) const noexcept -> bool = default;
+
+        // The bit string's order, most significant position first, which is boost's: the storage's entry at equal widths, and boost's own walk over the top min(size()) positions with the shorter one first otherwise. [design.md#the-ordering-invariant]
+        [[nodiscard]] friend constexpr auto operator<=>(bitset_adaptor const& lhs, bitset_adaptor const& rhs) noexcept
+                -> std::strong_ordering
+        {
+                if constexpr (not has_static_width) {
+                        if (lhs.size() != rhs.size()) {
+                                return lhs.top_aligned_three_way(rhs);
+                        }
+                }
+                return Traits::bitset_three_way(lhs.m_bits, rhs.m_bits);
+        }
 
         [[nodiscard]] constexpr auto test(std::size_t pos) const
                 -> bool
@@ -373,7 +401,7 @@ public:
         [[nodiscard]] constexpr auto is_proper_subset_of(bitset_adaptor const& rhs) const noexcept -> bool { return m_bits.is_proper_subset_of(rhs.m_bits); }
         [[nodiscard]] constexpr auto intersects         (bitset_adaptor const& rhs) const noexcept -> bool { return m_bits.intersects         (rhs.m_bits); }
 
-        // boost's two searches at both widths, npos where the trait's total answer is the width; a zero width answers npos outright, its only answer. [design.md#degenerate-widths]
+        // boost's two searches and their mirror at both widths, npos where the total answer is the width; a zero width answers npos outright, its only answer. [design.md#degenerate-widths]
         [[nodiscard]] constexpr auto find_first() const noexcept
                 -> std::size_t
         {
@@ -393,6 +421,44 @@ public:
                 } else {
                         auto const n = detail::bits::find_next<Traits>(m_bits, pos);
                         return n == size() ? npos : n;
+                }
+        }
+
+        // The reverse pair, ours: find_prev(pos) is the highest set position below pos, a pos past the width meaning from the end, so find_prev(npos) is find_last().
+        // Total, so the generic walk rather than the trait's entry, whose contract is the iterator's cheaper one. [design.md#total-versus-precondition]
+        [[nodiscard]] constexpr auto find_last() const noexcept
+                -> std::size_t
+        {
+                return find_prev(size());
+        }
+
+        [[nodiscard]] constexpr auto find_prev(std::size_t pos) const noexcept
+                -> std::size_t
+        {
+                if constexpr (detail::bits::zero_width<Traits>) {
+                        return npos;
+                } else {
+                        auto const n = detail::bits::scan_prev<Traits>(m_bits, pos);
+                        return n == size() ? npos : n;
+                }
+        }
+
+        // boost's block interface: every block out, including the clear tail, and at most every block in, the tail kept clear. [design.md#a-strict-extension]
+        template<std::output_iterator<block_type> O>
+        friend constexpr void to_block_range(bitset_adaptor const& b, O result)
+        {
+                for (auto const i : std::views::iota(0UZ, b.num_blocks())) {
+                        *result++ = Traits::block(b.m_bits, i);
+                }
+        }
+
+        template<std::input_iterator I, std::sentinel_for<I> S>
+                requires block_iterator<I>
+        friend constexpr void from_block_range(I first, S last, bitset_adaptor& result)
+        {
+                for (auto i = 0UZ; first != last; ++first, ++i) {
+                        assert(i < result.num_blocks());
+                        result.m_bits.set_block(i, *first);
                 }
         }
 
@@ -462,6 +528,20 @@ public:
         }
 
 private:
+        // boost's unequal-width order: the highest positions paired first over the common length, then the shorter is less.
+        [[nodiscard]] constexpr auto top_aligned_three_way(bitset_adaptor const& rhs) const noexcept
+                -> std::strong_ordering
+        {
+                auto const m = std::ranges::min(size(), rhs.size());
+                for (auto const i : std::views::iota(0UZ, m)) {
+                        if (auto const cmp = Traits::at(m_bits, size() - 1UZ - i) <=> Traits::at(rhs.m_bits, rhs.size() - 1UZ - i); cmp != std::strong_ordering::equal) {
+                                return cmp;
+                        }
+                }
+                // The widths differ, which is how this walk was reached, so equal is not an answer here.
+                return size() < rhs.size() ? std::strong_ordering::less : std::strong_ordering::greater;
+        }
+
         constexpr void from_ullong(unsigned long long val) noexcept
         {
                 constexpr auto digits = static_cast<std::size_t>(std::numeric_limits<unsigned long long>::digits);

--- a/include/xstd/bits/bitset_adaptor.hpp
+++ b/include/xstd/bits/bitset_adaptor.hpp
@@ -224,10 +224,12 @@ public:
                 }
         }
 
+        // Constrained to the character types, so a pointer to a block reaches the block-range constructor above and never instantiates a string_view over the block. [design.md#a-strict-extension]
         template<class charT>
+                requires (std::same_as<charT, char> or std::same_as<charT, wchar_t> or std::same_as<charT, char8_t> or std::same_as<charT, char16_t> or std::same_as<charT, char32_t>)
         [[nodiscard]] constexpr explicit bitset_adaptor(
                 charT const* str,
-                std::basic_string_view<charT>::size_type n = std::basic_string_view<charT>::npos,
+                std::size_t n = std::basic_string_view<charT>::npos,
                 charT zero = static_cast<charT>('0'),
                 charT one  = static_cast<charT>('1')
         )

--- a/include/xstd/bits/block_sequence.hpp
+++ b/include/xstd/bits/block_sequence.hpp
@@ -155,7 +155,7 @@ public:
         // Memberwise, width first: the unused bits are kept clear, so the blocks compare as the bits do, and a zero width through the one block it still holds. [design.md#block-storage]
         [[nodiscard]] friend constexpr auto operator==(block_sequence const&, block_sequence const&) noexcept -> bool = default;
 
-        // No operator<=>: block_sequence is pure storage with no opinion on which reading orders it, so it names both and picks neither. [design.md#two-readings-disagree]
+        // No operator<=>: block_sequence is pure storage with no opinion on which reading orders it, so it names all three and picks none. [design.md#two-readings-disagree]
 
         // The set reading a word at a time: whoever HOLDS the lowest differing position is greater, unless the other holds nothing above it. [design.md#the-ordering-primitive]
         [[nodiscard]] constexpr auto set_three_way(block_sequence const& other [[maybe_unused]]) const noexcept
@@ -197,6 +197,25 @@ public:
                                 ? std::strong_ordering::greater
                                 : std::strong_ordering::less
                         ;
+                }
+        }
+
+        // The bitset reading a word at a time: the bit string, most significant position first, is the blocks from the top block down, the unused tail being clear. [design.md#the-ordering-primitive]
+        [[nodiscard]] constexpr auto bitset_three_way(block_sequence const& other [[maybe_unused]]) const noexcept
+                -> std::strong_ordering
+        {
+                assert(this->size() == other.size());
+                if constexpr (has_static_size and N == 0) {
+                        return std::strong_ordering::equal;
+                } else if constexpr (has_static_size and static_num_blocks == 1) {
+                        return this->m_blocks[0] <=> other.m_blocks[0];
+                } else {
+                        for (auto i = num_blocks(); i-- != 0UZ;) {
+                                if (auto const cmp = this->m_blocks[i] <=> other.m_blocks[i]; cmp != std::strong_ordering::equal) {
+                                        return cmp;
+                                }
+                        }
+                        return std::strong_ordering::equal;
                 }
         }
 
@@ -971,9 +990,10 @@ struct bit_traits<block_sequence<Blocks, N>>
         [[nodiscard]] static constexpr auto find_next(bits_type const& c, std::size_t n) noexcept -> std::size_t { return c.exclusive_find_next(n); }
         [[nodiscard]] static constexpr auto find_prev(bits_type const& c, std::size_t n) noexcept -> std::size_t { return c.exclusive_find_prev(n); }
 
-        // Two named entries, never one "lexicographical_three_way": the readings disagree, so the caller names the one it means. [design.md#two-readings-disagree]
+        // Three named entries, never one "lexicographical_three_way": the readings disagree, so the caller names the one it means. [design.md#two-readings-disagree]
         [[nodiscard]] static constexpr auto set_three_way     (bits_type const& x, bits_type const& y) noexcept -> std::strong_ordering { return x.set_three_way(y);      }
         [[nodiscard]] static constexpr auto sequence_three_way(bits_type const& x, bits_type const& y) noexcept -> std::strong_ordering { return x.sequence_three_way(y); }
+        [[nodiscard]] static constexpr auto bitset_three_way  (bits_type const& x, bits_type const& y) noexcept -> std::strong_ordering { return x.bitset_three_way(y);   }
 };
 
 }       // namespace xstd

--- a/test/include/test/bitset/primitives.hpp
+++ b/test/include/test/bitset/primitives.hpp
@@ -350,31 +350,39 @@ struct mem_equal_to
         }
 };
 
+// The bit string, most significant position first: the member where the type has one, boost's free function otherwise.
+template<class X>
+[[nodiscard]] auto bit_string(const X& x)
+{
+        if constexpr (requires { x.to_string(); }) {
+                return x.to_string();
+        } else {
+                auto s = std::string();
+                to_string(x, s);
+                return s;
+        }
+}
+
+// Two orderings. The set view's is std::set's over ascending positions, re-derived from each type's own iteration; the type's own, where it has one, is the bit string's, which is boost's operator<. [design.md#the-ordering-invariant]
 struct mem_compare_three_way
 {
-        template<class X>
-        [[nodiscard]] static auto fn_compare_three_way(const X& lhs, const X& rhs) noexcept
-        {
-                if constexpr (requires { lhs <=> rhs; }) {
-                        return lhs <=> rhs;
-                } else {
-                        return xstd::bit_set_view(lhs) <=> xstd::bit_set_view(rhs);
-                }
-        }
-
-        // The view-based check re-derives the order from each type's own ascending iteration, so it holds at any cardinality.
         template<class X>
         auto operator()(const X& self, const X& rhs) const noexcept
         {
                 auto const lhs_view = xstd::bit_set_view(self);
                 auto const rhs_view = xstd::bit_set_view(rhs);
                 BOOST_CHECK(
-                        fn_compare_three_way(self, rhs) ==
+                        (lhs_view <=> rhs_view) ==
                         std::lexicographical_compare_three_way(
                                 lhs_view.begin(), lhs_view.end(),
                                 rhs_view.begin(), rhs_view.end()
                         )
                 );
+                if constexpr (requires { self <=> rhs; }) {
+                        BOOST_CHECK((self <=> rhs) == (bit_string(self) <=> bit_string(rhs)));
+                } else if constexpr (requires { self < rhs; }) {
+                        BOOST_CHECK_EQUAL(self < rhs, bit_string(self) < bit_string(rhs));
+                }
         }
 };
 

--- a/test/src/bits/bitset.cpp
+++ b/test/src/bits/bitset.cpp
@@ -21,11 +21,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(IsRegular, T, Types)
         static_assert(std::regular<T>);
 }
 
-// Deliberately not orderable by itself, because std::bitset is not: the ordering is reached through the set reading.
-BOOST_AUTO_TEST_CASE_TEMPLATE(OrderedThroughTheViewRatherThanInfix, T, Types)
+// Two orderings at every width: its own is the bit string's, boost's, and the set reading's is reached through the view. [design.md#the-ordering-invariant]
+BOOST_AUTO_TEST_CASE_TEMPLATE(OrderedInfixAndThroughTheView, T, Types)
 {
-        static_assert(not std::totally_ordered<T>);
-        static_assert(    std::totally_ordered<decltype(xstd::bit_set_view(std::declval<T&>()))>);
+        static_assert(std::totally_ordered<T>);
+        static_assert(std::totally_ordered<decltype(xstd::bit_set_view(std::declval<T&>()))>);
 }
 
 // A fixed-width bitset owns no storage, so every operation on it is nothrow.

--- a/test/src/bits/bitset_adaptor.cpp
+++ b/test/src/bits/bitset_adaptor.cpp
@@ -13,12 +13,16 @@
 #include <xstd/bits/block_sequence.hpp>           // block_array, block_vector
 #include <xstd/bits/ext/boost/dynamic_bitset.hpp> // IWYU pragma: keep; bit_traits<boost::dynamic_bitset>
 #include <xstd/bits/ext/std/bitset.hpp>           // IWYU pragma: keep; bit_traits<std::bitset>
+#include <algorithm>                              // equal
+#include <array>                                  // array
 #include <bitset>                                 // bitset
-#include <concepts>                               // regular, same_as
+#include <compare>                                // strong_ordering
+#include <concepts>                               // regular, same_as, totally_ordered
 #include <cstddef>                                // size_t
 #include <cstdint>                                // uint8_t, uint64_t
 #include <functional>                             // hash
-#include <ranges>                                 // range
+#include <iterator>                               // back_inserter
+#include <ranges>                                 // equal, iota, range, reverse
 #include <sstream>                                // istringstream
 #include <stdexcept>                              // out_of_range, overflow_error
 #include <string>                                 // string
@@ -191,6 +195,90 @@ BOOST_AUTO_TEST_CASE(TheExtensionIsThereAtAStaticWidth)
         BOOST_CHECK(f == d);
         BOOST_CHECK_EQUAL(d.count(), 1UZ);
         BOOST_CHECK(d.test(0) and not d.test(2));
+}
+
+// The reverse pair mirrors boost's forward pair: the highest set position below pos, npos where none, a pos past the width meaning from the end.
+BOOST_AUTO_TEST_CASE(TheReverseSearchesMirrorTheForwardOnes)
+{
+        auto const d = Ours(0b101ULL);
+        BOOST_CHECK_EQUAL(d.find_last(), 2UZ);
+        BOOST_CHECK_EQUAL(d.find_prev(2), 0UZ);
+        BOOST_CHECK_EQUAL(d.find_prev(1), 0UZ);
+        BOOST_CHECK_EQUAL(d.find_prev(0), Ours::npos);
+        BOOST_CHECK_EQUAL(d.find_prev(100), 2UZ);
+        BOOST_CHECK_EQUAL(d.find_prev(Ours::npos), d.find_last());
+        BOOST_CHECK_EQUAL(Ours().find_last(), Ours::npos);
+
+        using Empty = xstd::basic_bitset<0, std::uint8_t>;
+        BOOST_CHECK_EQUAL(Empty().find_last(), Empty::npos);
+        BOOST_CHECK_EQUAL(Empty().find_prev(0), Empty::npos);
+
+        // The two loops are each other's reverse, across blocks.
+        using Wide = xstd::basic_bitset<70, std::uint8_t>;
+        auto w = Wide();
+        w.set(1); w.set(8); w.set(9); w.set(69);
+        auto forward = std::vector<std::size_t>();
+        for (auto i = w.find_first(); i != Wide::npos; i = w.find_next(i)) {
+                forward.push_back(i);
+        }
+        auto backward = std::vector<std::size_t>();
+        for (auto i = w.find_last(); i != Wide::npos; i = w.find_prev(i)) {
+                backward.push_back(i);
+        }
+        BOOST_CHECK((forward == std::vector<std::size_t>{ 1, 8, 9, 69 }));
+        BOOST_CHECK(std::ranges::equal(forward, std::views::reverse(backward)));
+}
+
+// The ordering is the bit string's, to_string() compared, which within a word is the number's. [design.md#the-ordering-invariant]
+BOOST_AUTO_TEST_CASE(TheOrderingIsTheBitStrings)
+{
+        static_assert(std::totally_ordered<Ours>);
+        for (auto const a : std::views::iota(0ULL, 512ULL)) {
+                for (auto const b : std::views::iota(0ULL, 512ULL)) {
+                        auto const x = Ours(a);
+                        auto const y = Ours(b);
+                        BOOST_CHECK((x <=> y) == (a <=> b));
+                        BOOST_CHECK((x <=> y) == (x.to_string() <=> y.to_string()));
+                }
+        }
+
+        // Across blocks: the top block decides before the lower ones say anything.
+        using Wide = xstd::basic_bitset<70, std::uint8_t>;
+        auto top = Wide();
+        top.set(69);
+        auto rest = Wide();
+        rest.set();
+        rest.reset(69);
+        BOOST_CHECK(rest < top);
+        BOOST_CHECK((Wide() <=> Wide()) == std::strong_ordering::equal);
+        BOOST_CHECK(Wide() < top);
+}
+
+// boost's block interface: the block type and its width, the block count, every block out and at most every block in, the tail kept clear. [design.md#a-strict-extension]
+BOOST_AUTO_TEST_CASE(TheBlockInterfaceIsBoosts)
+{
+        static_assert(std::same_as<Ours::block_type, std::uint8_t>);
+        static_assert(Ours::bits_per_block == 8UZ);
+        BOOST_CHECK_EQUAL(Ours().num_blocks(), 2UZ);
+
+        auto const b = Ours("101000001");
+        auto out = std::vector<std::uint8_t>();
+        to_block_range(b, std::back_inserter(out));
+        BOOST_CHECK((out == std::vector<std::uint8_t>{ 0b0100'0001, 0b1 }));
+
+        auto c = Ours();
+        from_block_range(out.begin(), out.end(), c);
+        BOOST_CHECK(c == b);
+
+        // Fewer blocks than there are leaves the rest alone; a dirty tail is masked rather than kept.
+        auto const dirty = std::array<std::uint8_t, 2>{ 0b1000'0000, 0b1111'1111 };
+        auto e = Ours();
+        from_block_range(dirty.begin(), dirty.end(), e);
+        BOOST_CHECK_EQUAL(e.count(), 2UZ);
+        BOOST_CHECK(e.test(7) and e.test(8));
+        from_block_range(dirty.begin(), dirty.begin() + 1, c);
+        BOOST_CHECK_EQUAL(c.count(), 2UZ);
+        BOOST_CHECK(c.test(7) and c.test(8));
 }
 
 // The views reach a bitset by referring into its storage: the ordering, the keys, the blocks. [design.md#views-over-owners]

--- a/test/src/bits/block_sequence.cpp
+++ b/test/src/bits/block_sequence.cpp
@@ -13,9 +13,10 @@
 #include <compare>                     // strong_ordering
 #include <cstddef>                     // size_t
 #include <cstdint>                     // uint8_t, uint64_t
+#include <initializer_list>            // initializer_list
 #include <new>                         // IWYU pragma: keep; bad_alloc, behind TEST_HAS_INPLACE_VECTOR
 #include <ranges>                      // iota
-#include <utility>                     // pair
+#include <tuple>                       // get, tuple
 #include <vector>                      // vector
 
 BOOST_AUTO_TEST_SUITE(BitBlocks)
@@ -735,7 +736,7 @@ auto probes(BB const& empty) -> std::vector<BB>
         return out;
 }
 
-// The invariant on both readings: the block-wise answer is the standard algorithm's, or it is wrong. [design.md#the-ordering-invariant]
+// The invariant on all three readings: the block-wise answer is the standard algorithm's, or it is wrong. [design.md#the-ordering-invariant]
 template<class BB>
 auto disagreements(BB const& empty) -> int
 {
@@ -754,6 +755,10 @@ auto disagreements(BB const& empty) -> int
                         if (std::lexicographical_compare_three_way(qx.begin(), qx.end(), qy.begin(), qy.end()) != x.sequence_three_way(y)) {
                                 ++n;
                         }
+                        // The bitset reading is the sequence reading traversed from the top, which is the bit string's order.
+                        if (std::lexicographical_compare_three_way(qx.rbegin(), qx.rend(), qy.rbegin(), qy.rend()) != x.bitset_three_way(y)) {
+                                ++n;
+                        }
                 }
         }
         return n;
@@ -761,14 +766,14 @@ auto disagreements(BB const& empty) -> int
 
 }       // namespace
 
-// Both orderings, at every static extent, against the algorithms that define them. [design.md#the-ordering-invariant]
-BOOST_AUTO_TEST_CASE_TEMPLATE(BothOrderingsAgreeWithTheirReading, T, test::graded_extents<graded_block_array>)
+// All three orderings, at every static extent, against the algorithms that define them. [design.md#the-ordering-invariant]
+BOOST_AUTO_TEST_CASE_TEMPLATE(AllThreeOrderingsAgreeWithTheirReading, T, test::graded_extents<graded_block_array>)
 {
         BOOST_CHECK_EQUAL(disagreements(T()), 0);
 }
 
 // The same at a run-time width, which shares no instantiation with the static one. [design.md#per-instantiation-slots]
-BOOST_AUTO_TEST_CASE_TEMPLATE(BothOrderingsAgreeAtARunTimeWidth, Block, test::word_types)
+BOOST_AUTO_TEST_CASE_TEMPLATE(AllThreeOrderingsAgreeAtARunTimeWidth, Block, test::word_types)
 {
         using T = xstd::block_vector<Block>;
         constexpr auto D = test::digits_v<Block>;
@@ -780,23 +785,31 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(BothOrderingsAgreeAtARunTimeWidth, Block, test::wo
         BOOST_CHECK_EQUAL(disagreed, 0);
 }
 
-// The pair that separates the readings: {0,1} holds the lower position, and holds more. [design.md#two-readings-disagree]
-BOOST_AUTO_TEST_CASE(TheTwoOrderingsDisagree)
+// Two pairs that separate the three readings pairwise: {0} against {1}, and {0,1} against {1}. [design.md#two-readings-disagree]
+BOOST_AUTO_TEST_CASE(TheThreeOrderingsDisagree)
 {
         using T = xstd::block_array<std::uint8_t, 9>;
 
-        using orderings = std::pair<std::strong_ordering, std::strong_ordering>;
-        constexpr auto disagreed = [] -> orderings {
+        using orderings = std::tuple<std::strong_ordering, std::strong_ordering, std::strong_ordering>;
+        constexpr auto compare = [](std::initializer_list<std::size_t> p, std::initializer_list<std::size_t> q) -> orderings {
                 auto x = T();
-                x.set(0);
-                x.set(1);
+                for (auto const i : p) { x.set(i); }
                 auto y = T();
-                y.set(1);
-                return std::pair{ x.set_three_way(y), x.sequence_three_way(y) };
-        }();
+                for (auto const i : q) { y.set(i); }
+                return { x.set_three_way(y), x.sequence_three_way(y), x.bitset_three_way(y) };
+        };
 
-        static_assert(disagreed.first  == std::strong_ordering::less);
-        static_assert(disagreed.second == std::strong_ordering::greater);
+        // {0} against {1}: [0] < [1]; [1,0] > [0,1]; "01" < "10".
+        constexpr auto singletons = compare({ 0 }, { 1 });
+        static_assert(std::get<0>(singletons) == std::strong_ordering::less);
+        static_assert(std::get<1>(singletons) == std::strong_ordering::greater);
+        static_assert(std::get<2>(singletons) == std::strong_ordering::less);
+
+        // {0,1} against {1}: [0,1] < [1]; [1,1] > [0,1]; "11" > "10".
+        constexpr auto prefix = compare({ 0, 1 }, { 1 });
+        static_assert(std::get<0>(prefix) == std::strong_ordering::less);
+        static_assert(std::get<1>(prefix) == std::strong_ordering::greater);
+        static_assert(std::get<2>(prefix) == std::strong_ordering::greater);
 }
 
 // The prefix clause, which is the whole of what the set reading adds: {1} beats {} only by being longer.
@@ -817,8 +830,8 @@ BOOST_AUTO_TEST_CASE(TheSetOrderingPutsAPrefixFirst)
         BOOST_CHECK(x.set_three_way(z) == std::strong_ordering::less);
 }
 
-// Two named entries, so a caller says which reading it means rather than being handed one. [design.md#two-readings-disagree]
-BOOST_AUTO_TEST_CASE_TEMPLATE(TheTraitsNameBothOrderings, T, test::graded_extents<graded_block_array>)
+// Three named entries, so a caller says which reading it means rather than being handed one. [design.md#two-readings-disagree]
+BOOST_AUTO_TEST_CASE_TEMPLATE(TheTraitsNameAllThreeOrderings, T, test::graded_extents<graded_block_array>)
 {
         using traits = xstd::bit_traits<T>;
 
@@ -828,6 +841,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(TheTraitsNameBothOrderings, T, test::graded_extent
                 for (auto const& y : values) {
                         BOOST_CHECK(traits::set_three_way(x, y)      == x.set_three_way(y));
                         BOOST_CHECK(traits::sequence_three_way(x, y) == x.sequence_three_way(y));
+                        BOOST_CHECK(traits::bitset_three_way(x, y)   == x.bitset_three_way(y));
                 }
         }
 }

--- a/test/src/bits/dynamic_bitset.cpp
+++ b/test/src/bits/dynamic_bitset.cpp
@@ -3,19 +3,25 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
+#include <boost/dynamic_bitset.hpp>               // dynamic_bitset, to_string
 #include <boost/test/unit_test.hpp>               // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL, BOOST_CHECK_THROW
 #include <xstd/bits/bitset_adaptor.hpp>             // bitset_adaptor
 #include <xstd/bits/block_sequence.hpp>           // block_vector
 #include <xstd/bits/dynamic_bitset.hpp>           // dynamic_bitset
+#include <algorithm>                              // equal
 #include <array>                                  // array
-#include <concepts>                               // regular, same_as
+#include <concepts>                               // regular, same_as, totally_ordered
 #include <cstdint>                                // uint8_t, uint64_t
 #include <functional>                             // hash
+#include <iterator>                               // back_inserter
 #include <memory>                                 // allocator
+#include <ranges>                                 // equal, iota
 #include <sstream>                                // istringstream, ostringstream
 #include <stdexcept>                              // invalid_argument, out_of_range, overflow_error
 #include <string>                                 // string
 #include <tuple>                                  // tuple
+#include <utility>                                // pair
+#include <vector>                                 // vector
 
 BOOST_AUTO_TEST_SUITE(DynamicBitset)
 
@@ -63,6 +69,74 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ItAnswersAsBoostDoes, T, Dynamic)
         d -= e;
         BOOST_CHECK(f == d);
         BOOST_CHECK_EQUAL(d.count(), 1UZ);
+}
+
+// The reverse pair at a run-time width: the highest set position below pos, npos where none, a pos past the width meaning from the end.
+BOOST_AUTO_TEST_CASE_TEMPLATE(TheReverseSearchesMirrorTheForwardOnes, T, Dynamic)
+{
+        auto d = T(70);
+        d.set(1);
+        d.set(69);
+        BOOST_CHECK_EQUAL(d.find_last(), 69UZ);
+        BOOST_CHECK_EQUAL(d.find_prev(69), 1UZ);
+        BOOST_CHECK_EQUAL(d.find_prev(1), T::npos);
+        BOOST_CHECK_EQUAL(d.find_prev(T::npos), 69UZ);
+        BOOST_CHECK_EQUAL(T(9).find_last(), T::npos);
+        BOOST_CHECK_EQUAL(T().find_last(), T::npos);
+        BOOST_CHECK_EQUAL(T().find_prev(0), T::npos);
+}
+
+// The ordering is boost's, pair for pair: every value at every width up to nine against every other, unequal widths included. [design.md#the-ordering-invariant]
+BOOST_AUTO_TEST_CASE_TEMPLATE(TheOrderingIsBoosts, T, Dynamic)
+{
+        static_assert(std::totally_ordered<T>);
+
+        auto values = std::vector<std::pair<T, boost::dynamic_bitset<>>>();
+        for (auto const w : std::views::iota(0UZ, 10UZ)) {
+                for (auto const v : std::views::iota(0ULL, 1ULL << w)) {
+                        values.emplace_back(T(w, v), boost::dynamic_bitset<>(w, static_cast<unsigned long>(v)));
+                }
+        }
+        auto disagreements = 0;
+        for (auto const& [ x, bx ] : values) {
+                for (auto const& [ y, by ] : values) {
+                        auto const cmp = x <=> y;
+                        disagreements += static_cast<int>((cmp < 0) != (bx < by));
+                        disagreements += static_cast<int>((cmp > 0) != (by < bx));
+                        disagreements += static_cast<int>((cmp == 0) != (bx == by));
+                        disagreements += static_cast<int>(cmp != (x.to_string() <=> y.to_string()));
+                }
+        }
+        BOOST_CHECK_EQUAL(disagreements, 0);
+}
+
+// boost's block interface: the block-range constructor, every block out, at most every block in.
+BOOST_AUTO_TEST_CASE(TheBlockInterfaceIsBoosts)
+{
+        using T = xstd::basic_dynamic_bitset<std::uint8_t>;
+        static_assert(std::same_as<T::block_type, std::uint8_t>);
+        static_assert(T::bits_per_block == 8UZ);
+
+        auto const blocks = std::array<std::uint8_t, 2>{ 0b1000'0001, 0b11 };
+        auto const d = T(blocks.begin(), blocks.end());
+        auto const b = boost::dynamic_bitset<std::uint8_t>(blocks.begin(), blocks.end());
+        BOOST_CHECK_EQUAL(d.size(), 16UZ);
+        BOOST_CHECK_EQUAL(d.num_blocks(), 2UZ);
+        BOOST_CHECK_EQUAL(d.count(), 4UZ);
+        auto s = std::string();
+        boost::to_string(b, s);
+        BOOST_CHECK_EQUAL(d.to_string(), s);
+
+        auto out = std::vector<std::uint8_t>();
+        to_block_range(d, std::back_inserter(out));
+        BOOST_CHECK(std::ranges::equal(out, blocks));
+
+        auto e = T(16);
+        from_block_range(blocks.begin(), blocks.end(), e);
+        BOOST_CHECK(e == d);
+
+        // The two-argument form stays the width-and-value constructor, as boost's dispatch keeps it.
+        BOOST_CHECK_EQUAL(T(3, 7).to_ullong(), 7ULL);
 }
 
 // Growth, boost's members: resize with either fill, push and pop, append a block and a range, reserve, shrink, clear.

--- a/test/src/bits/ext/std/bitset.cpp
+++ b/test/src/bits/ext/std/bitset.cpp
@@ -157,7 +157,8 @@ BOOST_AUTO_TEST_CASE(OursReproducesItsTraits)
         using ours   = xstd::bitset<64>;
 
         static_assert(std::regular<theirs>       == std::regular<ours>);
-        static_assert(std::totally_ordered<theirs> == std::totally_ordered<ours>);
+        // The one trait ours adds rather than reproduces: the bit string's order. [design.md#a-strict-extension]
+        static_assert(not std::totally_ordered<theirs> and std::totally_ordered<ours>);
 
         static_assert(std::is_nothrow_default_constructible_v<theirs> == std::is_nothrow_default_constructible_v<ours>);
         static_assert(std::is_nothrow_copy_constructible_v<theirs>    == std::is_nothrow_copy_constructible_v<ours>);


### PR DESCRIPTION
The second of the two PRs scoped after 7c′, on top of #107: what a strict extension of `std::bitset` and `boost::dynamic_bitset<>` still lacked.

## What

- **The reverse searches.** `find_last()` and `find_prev(pos)` mirror boost's forward pair: the highest set position below `pos`, `npos` where none, a `pos` past the width meaning from the end, so `find_prev(npos)` is `find_last()` and the two loops are each other's reverse. Total, so they take the generic walk rather than the trait's `find_prev`, whose contract is the iterator's cheaper one.
- **The bit string's order.** `operator<=>` orders as `to_string()` compares, most significant position first, which is `boost::dynamic_bitset::operator<`. `block_sequence::bitset_three_way` is the third named entry beside `set_three_way` and `sequence_three_way`: the blocks compared from the top block down, one comparison within a word at a static width. The wrapper takes it at equal widths and boost's own top-aligned walk at unequal ones, the shorter first; the block-wise form of that walk needs shifted reads and arrives with 7d's blit. `==` stays width-first and the two agree. `std::set<xstd::bitset<N>>` works, and boost's `<` is no longer an omission.
- **The block interface.** `block_type`, `bits_per_block`, `num_blocks()`, `to_block_range` writing every block including the clear tail, `from_block_range` reading at most every block with the tail masked rather than trusted, and the block-range constructor at a run-time width. Nothing of boost's is left out.

`operator[] const` stays `bool`: libc++'s const proxy would re-type an expression, which a strict extension may not.

## Tests

`block_sequence.cpp` checks the third entry against the reversed sequence reading at every graded extent and run-time width, and pins the three readings' pairwise disagreements on two pairs. `bitset_adaptor.cpp` and `dynamic_bitset.cpp` cover the reverse loop against the forward one, the order against `to_string()`, `to_ullong()` and boost's own `<` over every value at every width up to nine (1,046,529 pairs, unequal widths included), and the block round trip against boost. The harness's ordering primitive now checks the set view's order for every type and a type's own `<=>`, or boost's `<`, against its bit string. design.md: the three-reading table under `two-readings-disagree`, `the-ordering-invariant`, `the-ordering-primitive` and `a-strict-extension`.

## Validation

As before: the full suite on clang 18, gcc 15 coverage with `bitset_adaptor.hpp` and `block_sequence.hpp` at every line and branch, header self-sufficiency on gcc 14 and clang 18, clang-tidy 20 over every header and the touched tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v8urscUNYsTMatTSnKb16

---
_Generated by [Claude Code](https://claude.ai/code/session_016v8urscUNYsTMatTSnKb16)_