### PR TITLE
The letter of the extension: boost's remaining members

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ target_sources(
         include/xstd/bits/bit_vector.hpp
         include/xstd/bits/bit_traits.hpp
         include/xstd/bits/block_sequence.hpp
+        include/xstd/bits/detail/allocator_typedef.hpp
         include/xstd/bits/detail/hash.hpp
         include/xstd/bits/detail/intrin.hpp
         include/xstd/bits/dynamic_bitset.hpp

--- a/design.md
+++ b/design.md
@@ -758,7 +758,15 @@ so `std::set<xstd::bitset<N>>` works and boost's `<` is no longer an omission. A
 in at both widths, every storage under the wrapper having blocks: `block_type`, `bits_per_block`, `num_blocks()`,
 `to_block_range` writing every block including the clear tail, `from_block_range` reading at most every block
 with the tail masked rather than trusted, and the block-range constructor at a run-time width, a whole number
-of blocks wide. Nothing of boost's is left out.
+of blocks wide. The rest of boost's surface is there too, at both widths where a width does not preclude it:
+the throwing `at(pos)`, `test_set`, the ranged `set`/`reset`/`flip(pos, len)` behind the one guard on the whole
+range, element-wise until the blit brings the masked block; `max_size()` in bits, the width at a static one and
+the widest whole number of blocks the blocks and the address space admit at a run-time one; and where the
+storage takes an allocator, `allocator_type`, `get_allocator()` and the allocator arguments on the
+constructors. The name `allocator_type` is an empty base a class either has or has not, a class having no
+conditional typedef. One boost constructor is left out on purpose: `dynamic_bitset(str, pos, n, num_bits,
+alloc)` puts a width where `std::bitset`'s `(str, pos, n, zero, one)` puts a character, and one signature
+cannot extend both; `std::bitset`'s wins, the width being the characters read.
 
 What ours does not add is a range: becoming one would change what generic code does with it, from `fmt` to
 `std::ranges::to`, which is the one addition a strict extension cannot make. `bit_set_view` and `bit_span`

--- a/include/xstd/bits/bitset_adaptor.hpp
+++ b/include/xstd/bits/bitset_adaptor.hpp
@@ -8,30 +8,31 @@
 
 // Bitsets [bitset], Header <bitset> synopsis [bitset.syn]
 
-#include <boost/hash2/hash_append.hpp> // hash_append_tag
-#include <xstd/bits/bit_traits.hpp>    // bit_storage, bit_traits, block_readable, scan_prev, static_bit_extent, zero_width
-#include <xstd/bits/detail/hash.hpp>   // hash_append_bits, std_hash
-#include <xstd/bits/ownership.hpp>     // owned_storage, ownership
-#include <algorithm>                   // min
-#include <cassert>                     // assert
-#include <compare>                     // strong_ordering
-#include <concepts>                    // convertible_to, regular, same_as
-#include <cstddef>                     // size_t
-#include <format>                      // format
-#include <functional>                  // hash
-#include <ios>                         // ios_base
-#include <iosfwd>                      // basic_istream, basic_ostream
-#include <iterator>                    // input_iterator, iter_value_t, output_iterator, sentinel_for
-#include <limits>                      // numeric_limits
-#include <locale>                      // ctype, use_facet
-#include <memory>                      // allocator
-#include <ranges>                      // iota
-#include <source_location>             // source_location
-#include <stdexcept>                   // invalid_argument, out_of_range, overflow_error
-#include <string>                      // basic_string, char_traits
-#include <string_view>                 // basic_string_view
-#include <type_traits>                 // remove_cvref_t
-#include <utility>                     // as_const
+#include <boost/hash2/hash_append.hpp>            // hash_append_tag
+#include <xstd/bits/bit_traits.hpp>               // bit_storage, bit_traits, block_readable, scan_prev, static_bit_extent, zero_width
+#include <xstd/bits/detail/allocator_typedef.hpp> // allocator_typedef
+#include <xstd/bits/detail/hash.hpp>              // hash_append_bits, std_hash
+#include <xstd/bits/ownership.hpp>                // owned_storage, ownership
+#include <algorithm>                              // min
+#include <cassert>                                // assert
+#include <compare>                                // strong_ordering
+#include <concepts>                               // convertible_to, regular, same_as
+#include <cstddef>                                // size_t
+#include <format>                                 // format
+#include <functional>                             // hash
+#include <ios>                                    // ios_base
+#include <iosfwd>                                 // basic_istream, basic_ostream
+#include <iterator>                               // input_iterator, iter_value_t, output_iterator, sentinel_for
+#include <limits>                                 // numeric_limits
+#include <locale>                                 // ctype, use_facet
+#include <memory>                                 // allocator
+#include <ranges>                                 // iota
+#include <source_location>                        // source_location
+#include <stdexcept>                              // invalid_argument, out_of_range, overflow_error
+#include <string>                                 // basic_string, char_traits
+#include <string_view>                            // basic_string_view
+#include <type_traits>                            // remove_cvref_t
+#include <utility>                                // as_const
 
 namespace xstd {
 
@@ -64,7 +65,7 @@ concept has_bitops =
 // [template.bitset] over a storage of ours, which speaks the vocabulary and reads by block: what the storage has is forwarded, what it lacks is added through Traits. [design.md#owning-is-ours]
 template<has_bitops Bits, bit_storage<Bits> Traits = bit_traits<Bits>>
         requires block_readable<Traits, Bits>
-class bitset_adaptor
+class bitset_adaptor : public detail::bits::allocator_typedef<Bits>
 {
         // One wrapper, two counterparts it strictly extends: std::bitset at a static width, boost::dynamic_bitset at a run-time one. [design.md#a-strict-extension]
         static constexpr bool has_static_width = static_bit_extent<Traits, Bits>;
@@ -181,6 +182,38 @@ public:
                 m_bits.append(first, last);
         }
 
+        // boost's allocator arguments, where the storage takes one. [design.md#a-strict-extension]
+        template<class Alloc>
+                requires (not has_static_width) and std::same_as<Alloc, typename Bits::allocator_type>
+        [[nodiscard]] constexpr explicit bitset_adaptor(Alloc const& alloc)
+        :
+                m_bits(alloc)
+        {}
+
+        template<class Alloc>
+                requires (not has_static_width) and std::same_as<Alloc, typename Bits::allocator_type>
+        [[nodiscard]] constexpr bitset_adaptor(std::size_t num_bits, unsigned long long val, Alloc const& alloc)
+        :
+                m_bits(num_bits, alloc)
+        {
+                from_ullong(val);
+        }
+
+        template<std::input_iterator I, std::sentinel_for<I> S, class Alloc>
+                requires (not has_static_width) and block_iterator<I> and std::same_as<Alloc, typename Bits::allocator_type>
+        [[nodiscard]] constexpr bitset_adaptor(I first, S last, Alloc const& alloc)
+        :
+                m_bits(alloc)
+        {
+                m_bits.append(first, last);
+        }
+
+        [[nodiscard]] constexpr auto get_allocator() const noexcept
+                requires requires (Bits const& b) { b.get_allocator(); }
+        {
+                return m_bits.get_allocator();
+        }
+
         template<class charT, class traits, class Allocator>
         [[nodiscard]] constexpr explicit bitset_adaptor(
                 std::basic_string<charT, traits, Allocator> const& str,
@@ -274,53 +307,66 @@ public:
         constexpr auto reset() noexcept -> bitset_adaptor& { m_bits.reset(); return *this; }
         constexpr auto flip () noexcept -> bitset_adaptor& { m_bits.flip (); return *this; }
 
-        // Element access: the guard, then the unchecked write. It throws out_of_range at a static width as std::bitset does and asserts at a run-time one as boost does: the inconsistency is the counterparts' own. [design.md#the-one-guard]
+        // Element access: the one guard, then the unchecked write. It throws out_of_range at a static width as std::bitset does and asserts at a run-time one as boost does: the inconsistency is the counterparts' own. [design.md#the-one-guard]
         constexpr auto set(std::size_t pos, bool val = true)
                 -> bitset_adaptor&
         {
-                if constexpr (has_static_width) {
-                        if (pos < size()) {
-                                Traits::unchecked_assign(m_bits, pos, val);
-                        } else {
-                                throw out_of_range(pos);
-                        }
-                } else {
-                        assert(pos < size());
-                        Traits::unchecked_assign(m_bits, pos, val);
-                }
+                guard(pos);
+                Traits::unchecked_assign(m_bits, pos, val);
                 return *this;
         }
 
         constexpr auto reset(std::size_t pos)
                 -> bitset_adaptor&
         {
-                if constexpr (has_static_width) {
-                        if (pos < size()) {
-                                Traits::unchecked_assign(m_bits, pos, false);
-                        } else {
-                                throw out_of_range(pos);
-                        }
-                } else {
-                        assert(pos < size());
-                        Traits::unchecked_assign(m_bits, pos, false);
-                }
+                guard(pos);
+                Traits::unchecked_assign(m_bits, pos, false);
                 return *this;
         }
 
         constexpr auto flip(std::size_t pos)
                 -> bitset_adaptor&
         {
-                if constexpr (has_static_width) {
-                        if (pos < size()) {
-                                Traits::unchecked_assign(m_bits, pos, not Traits::at(m_bits, pos));
-                        } else {
-                                throw out_of_range(pos);
-                        }
-                } else {
-                        assert(pos < size());
-                        Traits::unchecked_assign(m_bits, pos, not Traits::at(m_bits, pos));
+                guard(pos);
+                Traits::unchecked_assign(m_bits, pos, not Traits::at(m_bits, pos));
+                return *this;
+        }
+
+        // boost's ranged forms, the one guard on the whole range; element-wise until the blit brings the masked block. [design.md#the-one-guard]
+        constexpr auto set(std::size_t pos, std::size_t len, bool val)
+                -> bitset_adaptor&
+        {
+                guard_range(pos, len);
+                for (auto const i : std::views::iota(pos, pos + len)) {
+                        Traits::unchecked_assign(m_bits, i, val);
                 }
                 return *this;
+        }
+
+        constexpr auto reset(std::size_t pos, std::size_t len)
+                -> bitset_adaptor&
+        {
+                return set(pos, len, false);
+        }
+
+        constexpr auto flip(std::size_t pos, std::size_t len)
+                -> bitset_adaptor&
+        {
+                guard_range(pos, len);
+                for (auto const i : std::views::iota(pos, pos + len)) {
+                        Traits::unchecked_assign(m_bits, i, not Traits::at(m_bits, i));
+                }
+                return *this;
+        }
+
+        // boost's test_set: the old value out, the new one in, behind the one guard.
+        constexpr auto test_set(std::size_t pos, bool val = true)
+                -> bool
+        {
+                guard(pos);
+                auto const old = Traits::at(m_bits, pos);
+                Traits::unchecked_assign(m_bits, pos, val);
+                return old;
         }
 
         // The const subscript is unchecked on every counterpart, so it is Traits::at unconditionally.
@@ -334,6 +380,25 @@ public:
                 -> reference
         {
                 return { *this, pos };
+        }
+
+        // boost's at, throwing at both widths: an extension of std::bitset, which has none, and boost's own contract.
+        [[nodiscard]] constexpr auto at(std::size_t pos) const
+                -> bool
+        {
+                if (pos < size()) {
+                        return Traits::at(m_bits, pos);
+                }
+                throw out_of_range(pos);
+        }
+
+        [[nodiscard]] constexpr auto at(std::size_t pos)
+                -> reference
+        {
+                if (pos < size()) {
+                        return { *this, pos };
+                }
+                throw out_of_range(pos);
         }
 
         // [bitset.members]/34-37: the value the bits spell, or overflow_error where a set position lies beyond the word; boost's to_ulong is the same contract.
@@ -363,6 +428,7 @@ public:
         [[nodiscard]] constexpr auto count()      const noexcept -> std::size_t { return m_bits.count();      }
         [[nodiscard]] constexpr auto size()       const noexcept -> std::size_t { return m_bits.size();       }
         [[nodiscard]] constexpr auto num_blocks() const noexcept -> std::size_t { return m_bits.num_blocks(); }
+        [[nodiscard]] constexpr auto max_size()   const noexcept -> std::size_t { return m_bits.max_size();   }
 
         [[nodiscard]] constexpr auto operator==(bitset_adaptor const& rhs) const noexcept -> bool = default;
 
@@ -381,15 +447,8 @@ public:
         [[nodiscard]] constexpr auto test(std::size_t pos) const
                 -> bool
         {
-                if constexpr (has_static_width) {
-                        if (pos < size()) {
-                                return Traits::at(m_bits, pos);
-                        }
-                        throw out_of_range(pos);
-                } else {
-                        assert(pos < size());
-                        return Traits::at(m_bits, pos);
-                }
+                guard(pos);
+                return Traits::at(m_bits, pos);
         }
 
         [[nodiscard]] constexpr auto all()  const noexcept -> bool { return m_bits.all();  }
@@ -530,6 +589,29 @@ public:
         }
 
 private:
+        // The one guard: out_of_range at a static width, std::bitset's, an assert at a run-time one, boost's. [design.md#the-one-guard]
+        constexpr void guard(std::size_t pos) const
+        {
+                if constexpr (has_static_width) {
+                        if (pos >= size()) {
+                                throw out_of_range(pos);
+                        }
+                } else {
+                        assert(pos < size());
+                }
+        }
+
+        constexpr void guard_range(std::size_t pos, std::size_t len) const
+        {
+                if constexpr (has_static_width) {
+                        if (pos + len > size()) {
+                                throw out_of_range(pos + len);
+                        }
+                } else {
+                        assert(pos + len <= size());
+                }
+        }
+
         // boost's unequal-width order: the highest positions paired first over the common length, then the shorter is less.
         [[nodiscard]] constexpr auto top_aligned_three_way(bitset_adaptor const& rhs) const noexcept
                 -> std::strong_ordering

--- a/include/xstd/bits/block_sequence.hpp
+++ b/include/xstd/bits/block_sequence.hpp
@@ -8,6 +8,7 @@
 
 #include <boost/hash2/hash_append_fwd.hpp>                     // hash_append, hash_append_tag
 #include <xstd/bits/bit_traits.hpp>                            // bit_traits
+#include <xstd/bits/detail/allocator_typedef.hpp>              // allocator_typedef
 #include <xstd/bits/detail/intrin.hpp>                         // countl_zero, countr_zero, popcount
 #include <xstd/bits/detail/pred.hpp>                           // intersects, is_subset_of, not_equal_to
 #include <xstd/ints/concepts/unsigned_integer.hpp>             // unsigned_integer
@@ -15,11 +16,11 @@
 #include <xstd/ints/limits.hpp>                                // numeric_limits
 #include <xstd/ints/memory.hpp>                                // align_up
 #include <xstd/misc/type_traits/conditional_data_member.hpp>   // XSTD_NO_UNIQUE_ADDRESS, conditional_data_member_t
-#include <algorithm>                                           // all_of, any_of, fill, fill_n, fold_left, max, shift_left, shift_right
+#include <algorithm>                                           // all_of, any_of, fill, fill_n, fold_left, max, min, shift_left, shift_right
 #include <array>                                               // array
 #include <cassert>                                             // assert
 #include <compare>                                             // strong_ordering
-#include <concepts>                                            // regular, swap
+#include <concepts>                                            // regular, same_as, swap
 #include <cstddef>                                             // ptrdiff_t, size_t
 #include <functional>                                          // plus
 #include <iterator>                                            // distance, forward_iterator, input_iterator, prev
@@ -57,7 +58,7 @@ inline constexpr auto num_blocks_v = std::ranges::max(
 
 // The one vehicle: it owns the unused-tail invariant, and has no iterators. [design.md#the-one-vehicle]
 template<block_storage Blocks, std::size_t N = std::dynamic_extent>
-class block_sequence
+class block_sequence : public detail::bits::allocator_typedef<Blocks>
 {
 public:
         using block_type = std::ranges::range_value_t<Blocks>;
@@ -115,6 +116,39 @@ public:
                 m_size(n),
                 m_blocks(make_blocks(n))
         {}
+
+        // boost's allocator arguments, where the blocks take one: deduced and matched, so a storage without an allocator has no such constructor. [design.md#a-strict-extension]
+        template<class Alloc>
+                requires (not has_static_size) and std::same_as<Alloc, typename Blocks::allocator_type>
+        [[nodiscard]] constexpr explicit block_sequence(Alloc const& alloc)
+        :
+                m_blocks(blocks_for(0UZ), alloc)
+        {}
+
+        template<class Alloc>
+                requires (not has_static_size) and std::same_as<Alloc, typename Blocks::allocator_type>
+        [[nodiscard]] constexpr block_sequence(std::size_t n, Alloc const& alloc)
+        :
+                m_size(n),
+                m_blocks(blocks_for(n), alloc)
+        {}
+
+        [[nodiscard]] constexpr auto get_allocator() const noexcept
+                requires requires (Blocks const& b) { b.get_allocator(); }
+        {
+                return m_blocks.get_allocator();
+        }
+
+        // In bits: the width, or the widest whole number of blocks the blocks can hold and the address space can count. [design.md#a-strict-extension]
+        [[nodiscard]] constexpr auto max_size() const noexcept
+                -> std::size_t
+        {
+                if constexpr (has_static_size) {
+                        return N;
+                } else {
+                        return std::ranges::min(m_blocks.max_size(), std::numeric_limits<std::size_t>::max() / bits_per_block) * bits_per_block;
+                }
+        }
 
         [[nodiscard]] constexpr auto size() const noexcept
                 -> std::size_t

--- a/include/xstd/bits/detail/allocator_typedef.hpp
+++ b/include/xstd/bits/detail/allocator_typedef.hpp
@@ -1,0 +1,30 @@
+//          Copyright Rein Halbersma 2014-2026.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef XSTD_BITS_DETAIL_ALLOCATOR_TYPEDEF_HPP
+#define XSTD_BITS_DETAIL_ALLOCATOR_TYPEDEF_HPP
+
+namespace xstd::detail::bits {
+
+// The allocator's name where the storage below has one and nothing where it does not: an empty base, a class having no conditional typedef.
+// Equality is defaulted so a derived class's defaulted == still compares, this base having nothing to compare. [design.md#a-strict-extension]
+template<class Storage>
+struct allocator_typedef
+{
+        [[nodiscard]] friend constexpr auto operator==(allocator_typedef const&, allocator_typedef const&) noexcept -> bool = default;
+};
+
+template<class Storage>
+        requires requires { typename Storage::allocator_type; }
+struct allocator_typedef<Storage>
+{
+        using allocator_type = Storage::allocator_type;
+
+        [[nodiscard]] friend constexpr auto operator==(allocator_typedef const&, allocator_typedef const&) noexcept -> bool = default;
+};
+
+}       // namespace xstd::detail::bits
+
+#endif  // XSTD_BITS_DETAIL_ALLOCATOR_TYPEDEF_HPP

--- a/test/src/bits/bitset_adaptor.cpp
+++ b/test/src/bits/bitset_adaptor.cpp
@@ -38,9 +38,12 @@ BOOST_AUTO_TEST_SUITE(BitsetAdaptor)
 template<class B>
 constexpr bool wrappable = requires { sizeof(xstd::bitset_adaptor<B>); };
 
-// Dependent likewise, so a storage without an allocator answers false.
+// Dependent likewise, so a storage without an allocator answers false; the alias spells the typedef without a typename, which clang-tidy 22 reads as redundant.
 template<class X>
-constexpr bool has_allocator = requires (X const& x) { sizeof(typename X::allocator_type); x.get_allocator(); };
+using allocator_of = X::allocator_type;
+
+template<class X>
+constexpr bool has_allocator = requires (X const& x) { sizeof(allocator_of<X>); x.get_allocator(); };
 
 // The vocabulary is our storages': std::bitset's members and boost's set vocabulary, read by block. The counterparts themselves are not wrapped. [design.md#owning-is-ours]
 BOOST_AUTO_TEST_CASE(TheVocabularyIsWhatOurStoragesSpeakAndTheCounterpartsDoNot)

--- a/test/src/bits/bitset_adaptor.cpp
+++ b/test/src/bits/bitset_adaptor.cpp
@@ -11,6 +11,7 @@
 #include <xstd/bits/bitset.hpp>                   // basic_bitset, bitset
 #include <xstd/bits/bitset_adaptor.hpp>           // bitset_adaptor, has_bitops
 #include <xstd/bits/block_sequence.hpp>           // block_array, block_vector
+#include <xstd/bits/dynamic_bitset.hpp>           // basic_dynamic_bitset
 #include <xstd/bits/ext/boost/dynamic_bitset.hpp> // IWYU pragma: keep; bit_traits<boost::dynamic_bitset>
 #include <xstd/bits/ext/std/bitset.hpp>           // IWYU pragma: keep; bit_traits<std::bitset>
 #include <algorithm>                              // equal
@@ -36,6 +37,10 @@ BOOST_AUTO_TEST_SUITE(BitsetAdaptor)
 // Dependent, so an unsatisfied class constraint is a false rather than a hard error; an expression rather than a type requirement, which clang-tidy 22 misreads.
 template<class B>
 constexpr bool wrappable = requires { sizeof(xstd::bitset_adaptor<B>); };
+
+// Dependent likewise, so a storage without an allocator answers false.
+template<class X>
+constexpr bool has_allocator = requires (X const& x) { sizeof(typename X::allocator_type); x.get_allocator(); };
 
 // The vocabulary is our storages': std::bitset's members and boost's set vocabulary, read by block. The counterparts themselves are not wrapped. [design.md#owning-is-ours]
 BOOST_AUTO_TEST_CASE(TheVocabularyIsWhatOurStoragesSpeakAndTheCounterpartsDoNot)
@@ -279,6 +284,38 @@ BOOST_AUTO_TEST_CASE(TheBlockInterfaceIsBoosts)
         from_block_range(dirty.begin(), dirty.begin() + 1, c);
         BOOST_CHECK_EQUAL(c.count(), 2UZ);
         BOOST_CHECK(c.test(7) and c.test(8));
+}
+
+// boost's remaining members at a static width, where every guard throws: at, test_set, the ranged forms, max_size; no allocator, the storage having none. [design.md#a-strict-extension]
+BOOST_AUTO_TEST_CASE(TheRestOfBoostsSurfaceIsThereAtAStaticWidth)
+{
+        static_assert(not has_allocator<Ours>);
+        static_assert(has_allocator<xstd::basic_dynamic_bitset<std::uint8_t>>);
+        BOOST_CHECK_EQUAL(Ours().max_size(), 9UZ);
+
+        auto d = Ours(0b101ULL);
+        BOOST_CHECK_EQUAL(d.at(0), true);
+        BOOST_CHECK_EQUAL(std::as_const(d).at(1), false);
+        d.at(1) = true;
+        BOOST_CHECK(d.test(1));
+        BOOST_CHECK_THROW(static_cast<void>(d.at(9)), std::out_of_range);
+        BOOST_CHECK_THROW(static_cast<void>(std::as_const(d).at(9)), std::out_of_range);
+
+        BOOST_CHECK_EQUAL(d.test_set(1, false), true);
+        BOOST_CHECK_EQUAL(d.test_set(1), false);
+        BOOST_CHECK(d.test(1));
+        BOOST_CHECK_THROW(static_cast<void>(d.test_set(9)), std::out_of_range);
+
+        d.set(3, 5, true);
+        BOOST_CHECK_EQUAL(d.to_ullong(), 0b1111'1111ULL - 0b100ULL + 0b100ULL);
+        d.reset(0, 2);
+        BOOST_CHECK_EQUAL(d.to_ullong(), 0b1111'1100ULL);
+        d.flip(0, 9);
+        BOOST_CHECK_EQUAL(d.to_ullong(), 0b1'0000'0011ULL);
+        d.set(9, 0, true);
+        BOOST_CHECK_THROW(d.set(8, 2, true), std::out_of_range);
+        BOOST_CHECK_THROW(d.reset(9, 1), std::out_of_range);
+        BOOST_CHECK_THROW(d.flip(5, 5), std::out_of_range);
 }
 
 // The views reach a bitset by referring into its storage: the ordering, the keys, the blocks. [design.md#views-over-owners]

--- a/test/src/bits/block_sequence.cpp
+++ b/test/src/bits/block_sequence.cpp
@@ -9,10 +9,12 @@
 #include <xstd/bits/bit_traits.hpp>    // bit_storage, bit_traits, block_readable, static_bit_extent
 #include <xstd/bits/block_sequence.hpp> // block_array, block_inplace_vector, block_sequence, block_storage, block_vector
 #include <algorithm>                   // count, lexicographical_compare_three_way, min
+#include <concepts>                    // same_as
 #include <array>                       // array
 #include <compare>                     // strong_ordering
 #include <cstddef>                     // size_t
 #include <cstdint>                     // uint8_t, uint64_t
+#include <memory>                      // allocator
 #include <initializer_list>            // initializer_list
 #include <new>                         // IWYU pragma: keep; bad_alloc, behind TEST_HAS_INPLACE_VECTOR
 #include <ranges>                      // iota
@@ -844,6 +846,31 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(TheTraitsNameAllThreeOrderings, T, test::graded_ex
                         BOOST_CHECK(traits::bitset_three_way(x, y)   == x.bitset_three_way(y));
                 }
         }
+}
+
+// Dependent, so a storage without an allocator answers false.
+template<class X>
+constexpr bool has_allocator = requires (X const& x) { sizeof(typename X::allocator_type); x.get_allocator(); };
+
+// The allocator where the blocks have one, and max_size in bits at both widths. [design.md#a-strict-extension]
+BOOST_AUTO_TEST_CASE(TheAllocatorAndTheMaximumWidth)
+{
+        using V = xstd::block_vector<std::uint8_t>;
+        static_assert(has_allocator<V>);
+        static_assert(std::same_as<V::allocator_type, std::allocator<std::uint8_t>>);
+        auto const alloc = std::allocator<std::uint8_t>();
+        auto const empty = V(alloc);
+        BOOST_CHECK_EQUAL(empty.size(), 0UZ);
+        BOOST_CHECK(empty.get_allocator() == alloc);
+        auto const nine = V(9UZ, alloc);
+        BOOST_CHECK_EQUAL(nine.size(), 9UZ);
+        BOOST_CHECK_EQUAL(nine.num_blocks(), 2UZ);
+        BOOST_CHECK_EQUAL(nine.max_size() % V::bits_per_block, 0UZ);
+        BOOST_CHECK_GE(nine.max_size(), std::vector<std::uint8_t>().max_size() / 2);
+
+        using A = xstd::block_array<std::uint8_t, 9>;
+        static_assert(not has_allocator<A>);
+        static_assert(A().max_size() == 9UZ);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/bits/block_sequence.cpp
+++ b/test/src/bits/block_sequence.cpp
@@ -848,9 +848,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(TheTraitsNameAllThreeOrderings, T, test::graded_ex
         }
 }
 
-// Dependent, so a storage without an allocator answers false.
+// Dependent, so a storage without an allocator answers false; the alias spells the typedef without a typename, which clang-tidy 22 reads as redundant.
 template<class X>
-constexpr bool has_allocator = requires (X const& x) { sizeof(typename X::allocator_type); x.get_allocator(); };
+using allocator_of = X::allocator_type;
+
+template<class X>
+constexpr bool has_allocator = requires (X const& x) { sizeof(allocator_of<X>); x.get_allocator(); };
 
 // The allocator where the blocks have one, and max_size in bits at both widths. [design.md#a-strict-extension]
 BOOST_AUTO_TEST_CASE(TheAllocatorAndTheMaximumWidth)

--- a/test/src/bits/dynamic_bitset.cpp
+++ b/test/src/bits/dynamic_bitset.cpp
@@ -20,7 +20,7 @@
 #include <stdexcept>                              // invalid_argument, out_of_range, overflow_error
 #include <string>                                 // string
 #include <tuple>                                  // tuple
-#include <utility>                                // pair
+#include <utility>                                // as_const, pair
 #include <vector>                                 // vector
 
 BOOST_AUTO_TEST_SUITE(DynamicBitset)
@@ -137,6 +137,62 @@ BOOST_AUTO_TEST_CASE(TheBlockInterfaceIsBoosts)
 
         // The two-argument form stays the width-and-value constructor, as boost's dispatch keeps it.
         BOOST_CHECK_EQUAL(T(3, 7).to_ullong(), 7ULL);
+}
+
+// The rest of boost's surface, first the allocator and max_size. [design.md#a-strict-extension]
+BOOST_AUTO_TEST_CASE_TEMPLATE(TheAllocatorAndMaxSizeAreBoosts, T, Dynamic)
+{
+        using Block = T::block_type;
+        using Boost = boost::dynamic_bitset<Block>;
+        static_assert(std::same_as<typename T::allocator_type, std::allocator<Block>>);
+
+        auto const alloc = std::allocator<Block>();
+        auto const a = T(alloc);
+        BOOST_CHECK(a.empty());
+        BOOST_CHECK(a.get_allocator() == alloc);
+        auto const b = T(9, 0b101ULL, alloc);
+        BOOST_CHECK_EQUAL(b.to_ullong(), 5ULL);
+        auto const blocks = std::array<Block, 2>{ 1, 2 };
+        auto const c = T(blocks.begin(), blocks.end(), alloc);
+        BOOST_CHECK_EQUAL(c.num_blocks(), 2UZ);
+
+        // A whole number of blocks, no larger than boost's bound over the same blocks.
+        BOOST_CHECK_EQUAL(b.max_size() % T::bits_per_block, 0UZ);
+        BOOST_CHECK_GE(b.max_size(), b.size());
+        BOOST_CHECK_LE(b.max_size(), Boost(9).max_size());
+}
+
+// Then the throwing at and test_set. [design.md#a-strict-extension]
+BOOST_AUTO_TEST_CASE_TEMPLATE(AtAndTestSetAreBoosts, T, Dynamic)
+{
+        auto d = T(9, 0b101ULL);
+        BOOST_CHECK_EQUAL(d.at(0), true);
+        BOOST_CHECK_EQUAL(std::as_const(d).at(1), false);
+        d.at(1) = true;
+        BOOST_CHECK(d.test(1));
+        BOOST_CHECK_THROW(static_cast<void>(d.at(9)), std::out_of_range);
+        BOOST_CHECK_THROW(static_cast<void>(std::as_const(d).at(9)), std::out_of_range);
+
+        BOOST_CHECK_EQUAL(d.test_set(1, false), true);
+        BOOST_CHECK_EQUAL(d.test_set(1), false);
+        BOOST_CHECK(d.test(1));
+}
+
+// The ranged forms against boost's, across a block boundary and up to the last position.
+BOOST_AUTO_TEST_CASE_TEMPLATE(TheRangedFormsAreBoosts, T, Dynamic)
+{
+        using Boost = boost::dynamic_bitset<typename T::block_type>;
+
+        for (auto const& [ pos, len ] : { std::pair{ 0UZ, 0UZ }, std::pair{ 3UZ, 4UZ }, std::pair{ 6UZ, 14UZ }, std::pair{ 0UZ, 20UZ } }) {
+                auto ours = T(20, 0b1010'1010'1010'1010'1010ULL);
+                auto theirs = Boost(20, 0b1010'1010'1010'1010'1010UL);
+                ours.set(pos, len, true); theirs.set(pos, len, true);
+                BOOST_CHECK_EQUAL(ours.to_ullong(), theirs.to_ulong());
+                ours.flip(pos, len); theirs.flip(pos, len);
+                BOOST_CHECK_EQUAL(ours.to_ullong(), theirs.to_ulong());
+                ours.reset(pos, len); theirs.reset(pos, len);
+                BOOST_CHECK_EQUAL(ours.to_ullong(), theirs.to_ulong());
+        }
 }
 
 // Growth, boost's members: resize with either fill, push and pop, append a block and a range, reserve, shrink, clear.


### PR DESCRIPTION
Open call 5 of #80, resolved by shipping it: the members `boost::dynamic_bitset` has that a strict extension of it still lacked.

## What

- **`at(pos)`**, const and mutable, throwing `out_of_range` at both widths: boost's contract, and an extension of `std::bitset`, which has none.
- **`test_set(pos, val)`** and the ranged **`set`/`reset`/`flip(pos, len)`**, behind the one guard on the whole range, throwing at a static width and asserting at a run-time one as every checked member does. Element-wise for now; 7d's blit brings the masked block.
- **`max_size()`** in bits, on `block_sequence` and forwarded: the width at a static one, the widest whole number of blocks the blocks and the address space admit at a run-time one.
- **The allocator**, where the storage takes one: `allocator_type`, `get_allocator()`, and the allocator arguments on the constructors, on `block_sequence` and the wrapper alike. `allocator_type` is an empty base a class either has or has not, since a class cannot have a conditional typedef; its equality is defaulted so the derived classes' defaulted `==` still compares.
- The guard itself is now one function, `guard(pos)`, with a ranged twin.

One boost constructor stays out on purpose: `dynamic_bitset(str, pos, n, num_bits, alloc)` puts a width where `std::bitset`'s `(str, pos, n, zero, one)` puts a character, and one signature cannot extend both. `std::bitset`'s wins; the width is the characters read.

## Tests

`dynamic_bitset.cpp`: the allocator constructors and `get_allocator`, `max_size` as a whole number of blocks within boost's bound, `at` reading, writing and throwing, `test_set`, and the ranged forms against boost's over a block boundary. `bitset_adaptor.cpp`: the same at a static width, where every guard throws, and no allocator where the storage has none. `block_sequence.cpp`: the allocator and `max_size` at both widths. design.md `a-strict-extension` records the members and the one deviation.

## Validation

As before: the full suite on clang 18, gcc 15 coverage with the touched headers at every line and branch, header self-sufficiency on gcc 14, clang 18 and libc++, clang-tidy 20 over every header and the touched tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v8urscUNYsTMatTSnKb16

---
_Generated by [Claude Code](https://claude.ai/code/session_016v8urscUNYsTMatTSnKb16)_