### PR TITLE
The range members: step 7d of #80

### DIFF
--- a/benchmark/src/bitset/sieve.cpp
+++ b/benchmark/src/bitset/sieve.cpp
@@ -1,15 +1,12 @@
-//          Copyright Rein Halbersma 2014-2025.
+//          Copyright Rein Halbersma 2014-2026.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include <benchmark/benchmark.h>                  // DoNotOptimize, BENCHMARK_TEMPLATE1, BENCHMARK_MAIN
 #include <opt/bitset/sieve.hpp>                   // filter_twins, sift_primes
-#include <xstd/bits/bit_static_set.hpp>           // bit_static_set
-#include <xstd/bits/bitset.hpp>                   // bitset
+#include <xstd/bits/dynamic_bitset.hpp>           // dynamic_bitset
 #include <xstd/bits/ext/boost/dynamic_bitset.hpp> // dynamic_bitset
-#include <xstd/bits/ext/std/bitset.hpp>           // bitset
-#include <xstd/bits/ext/xstd/bitset.hpp>          // bitset
 
 constexpr auto N = 10'000uz;
 
@@ -35,19 +32,14 @@ static void bm_filter_twins(benchmark::State& state) {
         }
 }
 
+// Dynamic containers only, so the bench compares like with like. [design.md#the-sieve]
 BENCHMARK_TEMPLATE1(bm_sift_primes0, boost::dynamic_bitset<>);
-BENCHMARK_TEMPLATE1(bm_sift_primes0,   std::bitset<N>);
-BENCHMARK_TEMPLATE1(bm_sift_primes0,  xstd::bitset<N>);
-BENCHMARK_TEMPLATE1(bm_sift_primes0,  xstd::bit_static_set<N>);
+BENCHMARK_TEMPLATE1(bm_sift_primes0,  xstd::dynamic_bitset);
 
 BENCHMARK_TEMPLATE1(bm_sift_primes1, boost::dynamic_bitset<>);
-BENCHMARK_TEMPLATE1(bm_sift_primes1,   std::bitset<N>);
-BENCHMARK_TEMPLATE1(bm_sift_primes1,  xstd::bitset<N>);
-BENCHMARK_TEMPLATE1(bm_sift_primes1,  xstd::bit_static_set<N>);
+BENCHMARK_TEMPLATE1(bm_sift_primes1,  xstd::dynamic_bitset);
 
 BENCHMARK_TEMPLATE1(bm_filter_twins, boost::dynamic_bitset<>);
-BENCHMARK_TEMPLATE1(bm_filter_twins,   std::bitset<N>);
-BENCHMARK_TEMPLATE1(bm_filter_twins,  xstd::bitset<N>);
-BENCHMARK_TEMPLATE1(bm_filter_twins,  xstd::bit_static_set<N>);
+BENCHMARK_TEMPLATE1(bm_filter_twins,  xstd::dynamic_bitset);
 
 BENCHMARK_MAIN();

--- a/benchmark/src/set/sieve.cpp
+++ b/benchmark/src/set/sieve.cpp
@@ -5,7 +5,7 @@
 
 #include <benchmark/benchmark.h>        // DoNotOptimize, BENCHMARK_TEMPLATE1, BENCHMARK_MAIN
 #include <opt/set/sieve.hpp>            // filter_twins, sift_primes
-#include <xstd/bits/bit_static_set.hpp> // bit_static_set
+#include <xstd/bits/bit_set.hpp>        // bit_set
 #include <set>                          // set
 #include <version>                      // __cpp_lib_flat_set
 #if defined(__cpp_lib_flat_set)
@@ -36,22 +36,23 @@ static void bm_filter_twins(benchmark::State& state) {
         }
 }
 
+// Dynamic containers only, so the bench compares like with like: a set sized for its universe is not measuring what a growing one is. [design.md#the-sieve]
 #if defined(__cpp_lib_flat_set)
 BENCHMARK_TEMPLATE1(bm_sift_primes0, std::flat_set<std::size_t>);
 #endif
 BENCHMARK_TEMPLATE1(bm_sift_primes0, std::set<std::size_t>);
-BENCHMARK_TEMPLATE1(bm_sift_primes0, xstd::bit_static_set<N>);
+BENCHMARK_TEMPLATE1(bm_sift_primes0, xstd::bit_set);
 
 #if defined(__cpp_lib_flat_set)
 BENCHMARK_TEMPLATE1(bm_sift_primes1, std::flat_set<std::size_t>);
 #endif
 BENCHMARK_TEMPLATE1(bm_sift_primes1, std::set<std::size_t>);
-BENCHMARK_TEMPLATE1(bm_sift_primes1, xstd::bit_static_set<N>);
+BENCHMARK_TEMPLATE1(bm_sift_primes1, xstd::bit_set);
 
-BENCHMARK_TEMPLATE1(bm_filter_twins, std::set<std::size_t>);
-BENCHMARK_TEMPLATE1(bm_filter_twins, xstd::bit_static_set<N>);
 #if defined(__cpp_lib_flat_set)
 BENCHMARK_TEMPLATE1(bm_filter_twins, std::flat_set<std::size_t>);
 #endif
+BENCHMARK_TEMPLATE1(bm_filter_twins, std::set<std::size_t>);
+BENCHMARK_TEMPLATE1(bm_filter_twins, xstd::bit_set);
 
 BENCHMARK_MAIN();

--- a/design.md
+++ b/design.md
@@ -708,6 +708,32 @@ the suffix stays available as a later optimization behind profiling.
 view have it and a window does not; the static `swap(reference, reference)` is the proxies' own swap under
 the name the standard gives it.
 
+### the-sequence-contract
+
+`bit_vector` answers every line of `[vector.bool]`'s synopsis and `bit_array<N>` every line of `[array]`'s,
+and the test says so as a checklist rather than a claim: `test/sequence/concepts.hpp` spells each synopsis
+as one requires-expression, `vector_bool` and `array_bool`, and `std::vector<bool>` and `std::array<bool, N>`
+are asserted against it first. A line the model itself fails is a wrong line, so the checklist is known to
+be honest before ours is held to it; the C++23 range members are a second concept, `vector_bool_ranges`, so
+the model is held to them only where its standard library has them.
+
+The sweep found what the range members had not needed. The allocator: `allocator_type` through the same
+empty base `bitset_adaptor` has, `get_allocator`, and the allocator-extended constructors,
+`[container.alloc.reqmts]`'s copy and move included, which `block_sequence` gains beneath them, deduced and
+matched to the storage's own so a static owner has none. `[vector.erasure]`'s `erase` and `erase_if` as
+non-members over the owner's `erase(first, last)`, `std::ranges::remove_if` running unchanged over the
+proxies, which move and swap. And `std::array`'s aggregate initialization as an `initializer_list`
+constructor on the static owner, the listed values leading and the rest false, a longer list being the
+error it is on `std::array`.
+
+Three things are not offered, each because packed bits have no address. `data()`, and the `pointer` and
+`const_pointer` typedefs, name what a proxy cannot give; the checklist leaves them out of
+`[container.reqmts]`'s typedefs rather than inventing a pointer to a bit. `std::array`'s tuple interface,
+`get<I>`, `tuple_size` and `tuple_element`, is left out with them: it is `std::array`'s claim to be a
+product of `N` objects, and a packed sequence is one object. `std::hash` is asked of the vector alone,
+`std::array` having none, while `bit_array` hashes as every owner does
+([the-hashing-invariant](#the-hashing-invariant)).
+
 ### views-over-owners
 
 An owner has no trait of its own — `bit_static_set`, `bit_array` and `bitset` are thin wrappers over a
@@ -929,6 +955,29 @@ single-block set proves nothing on its own. And `erase` was an out-of-bounds *wr
 failed on its returned value rather than on memory at all: `find_next`'s `++n` wrapped before it could test
 the bound, so it answered with a real element where `end()` was due. That second one is why this stays a gate
 on the jobs that build without sanitizers.
+
+### the-sieve
+
+The two sieves under `include/opt/` are the library's worked example and its bench, and each speaks one
+vocabulary. `opt/set/sieve.hpp` runs over any ordered set of integers, `std::set`, `std::flat_set`,
+`bit_static_set` or `bit_set`: the candidates are `iota(2, n)` converted to the set, and a sift is `erase`.
+`opt/bitset/sieve.hpp` runs over any bitset, `std::bitset`, `boost::dynamic_bitset` or ours, in the same
+vocabulary through `bit_set_view`: the storage is resized to the count where it can be, then the view
+`fill`s and `erase`s 0 and 1, and every sift is an `erase` through it. The `legacy_bitset`/`modern_bitset`
+ladders, the `generate_empty` trait and the `static_assert(false)` arms that #84 catalogued are gone with
+the absence they papered over: the view is what reconciles `set(pos)`/`reset(pos)` with `insert`/`erase`,
+and a bitset's own spelling reaches the sieve through it and nowhere else. A bitset's `erase` invalidates no
+iterator, so the bitset sieve walks the view live where the set sieve walks a snapshot.
+
+The benches are dynamic containers only, so each compares like with like: the set bench holds
+`std::flat_set`, `std::set` and `bit_set`, the bitset bench `boost::dynamic_bitset<>` and `dynamic_bitset`.
+A `bit_static_set<N>` sifting a universe it was sized for is not measuring what a `std::set` growing and
+shrinking is. `bit_set` is on the set bench and not the bitset one: a set has no `resize`, its width being
+capacity ([width-is-capacity](#width-is-capacity)), and it shares `block_sequence` with `dynamic_bitset`,
+so the bitset bench would only time the same storage twice. The tests keep the static types, `std::bitset<N>`,
+`xstd::bitset<N>` and `bit_static_set<N>`, since the sieve is an example before it is a bench; the two-bit
+sieve that runs `sift_primes1` to exhaustion is over the run-time widths, boost's and ours, as only they can
+be that small.
 
 ## Platform and tooling, continued
 

--- a/design.md
+++ b/design.md
@@ -140,6 +140,19 @@ A plain index walk rather than `drop` + `find_if`, and a descending one rather t
 position, so it never needed recovering. The reverse form composed two adaptors only to have `distance()`
 undo them.
 
+### the-blit
+
+`word_at<Traits>(c, pos)` is the block-wide word at any position of any storage the trait reads by block:
+the bits `[pos, pos + digits)`, assembled from `block(pos / digits) >> r` and the next block `<< (digits - r)`
+where `r = pos % digits`. Two things make it total where it is called. A shift by `digits` is undefined, so
+an aligned read is the block itself with no second term; and the last block has nothing above it, so the
+read stops there rather than asking for a block past the end. What the word reaches beyond the width is the
+clear tail, and it is the caller's to trim. It is the one primitive under every unaligned read: the sequence
+adaptor's `append_range` from a sequence read by block ([the-range-members](#the-range-members)), and the
+bitset reading's order at unequal widths ([the-ordering-invariant](#the-ordering-invariant)), where each
+operand's top window is read as words at its own alignment and both windows end at their own width, so the
+tail needs no mask.
+
 ## Contracts
 
 ### total-versus-precondition
@@ -396,9 +409,9 @@ boost's own `<` pair for pair over those widths, against `to_string()` compared 
 against `to_ullong()`.
 
 `bitset_adaptor::operator<=>` is `bitset_three_way` at equal widths, and at unequal ones boost's own walk,
-the top `min(size())` positions paired from the top and then the shorter first; the block-wise form of that
-walk needs shifted reads and arrives with the blit. `==` stays width-first, and `<=>` never answers equal at
-unequal widths, so the two agree ([the-hashing-invariant](#the-hashing-invariant)).
+the top `min(size())` positions paired from the top and then the shorter first, a word at a time through
+`word_at` ([the-blit](#the-blit)). `==` stays width-first, and `<=>` never answers equal at unequal widths,
+so the two agree ([the-hashing-invariant](#the-hashing-invariant)).
 
 Where a specialization offers nothing faster, the default is that standard algorithm over the reading's own
 iterators — so the default cannot disagree with the specification, and only an optimization can.
@@ -661,6 +674,28 @@ neither compares nor hashes ([views-follow-their-precedent](#views-follow-their-
 operators and no `fill`: on packed bits those are block-wise, a window's end blocks are shared with what lies
 outside it, and masking them is the work that arrives with the blit. Until then a window is read and written
 one position at a time, which `std::ranges::fill` over its iterators already does.
+
+### the-range-members
+
+`append_range` has two tiers. Where the source is a sequence adaptor of any shape, owner, view or window,
+whose trait reads blocks of the destination's block type, the source's bits are read as words at the source's
+own alignment through `word_at` and appended a word at a time through `block_sequence::append(block)`, which
+splits each word over the destination's own alignment; then the width is trimmed to the count, `resize`
+clearing whatever the last word carried past it. Everything else, a `std::vector<bool>`, an `iota` under a
+`transform`, a sequence over another block type, is packed a word at a time, which is boost's private
+`bit_appender`, and trimmed the same way. A source inside the very storage being appended to is safe: the
+blit reads positions below the old width alone, and no append writes one.
+
+`insert_range`, `insert` in its four shapes, `emplace` and both `erase`s rebuild rather than shift: the head
+through `first(pos)`, the middle, the tail through `subspan(pos)`, into a fresh sequence that is then swapped
+in. Every step runs at the blit's tier, insertion into a packed sequence is linear however it is done, and
+the strong exception guarantee comes free, which is what `std::vector::insert_range` gives on reallocation.
+`subspan` pays for itself here, the head and the tail being exactly windows. In-place block-wise shifting of
+the suffix stays available as a later optimization behind profiling.
+
+`flip()` is `[vector.bool]`'s, a bulk operation like the six operators beside it, so an owner and a whole
+view have it and a window does not; the static `swap(reference, reference)` is the proxies' own swap under
+the name the standard gives it.
 
 ### views-over-owners
 

--- a/design.md
+++ b/design.md
@@ -148,10 +148,16 @@ where `r = pos % digits`. Two things make it total where it is called. A shift b
 an aligned read is the block itself with no second term; and the last block has nothing above it, so the
 read stops there rather than asking for a block past the end. What the word reaches beyond the width is the
 clear tail, and it is the caller's to trim. It is the one primitive under every unaligned read: the sequence
-adaptor's `append_range` from a sequence read by block ([the-range-members](#the-range-members)), and the
-bitset reading's order at unequal widths ([the-ordering-invariant](#the-ordering-invariant)), where each
-operand's top window is read as words at its own alignment and both windows end at their own width, so the
-tail needs no mask.
+adaptor's `append_range` from a sequence read by block ([the-range-members](#the-range-members)), the bulk
+operations on a window ([windows](#windows)), and the bitset reading's order at unequal widths
+([the-ordering-invariant](#the-ordering-invariant)), where each operand's top window is read as words at its
+own alignment and both windows end at their own width, so the tail needs no mask.
+
+`block_sequence::set_word(pos, value, mask)` is its write side, on our storage alone as `set_block` is: the
+bits of `value` under `mask` land at `[pos, pos + digits)`, split over two blocks where `pos` is not aligned,
+the tail kept clear. Every masked write goes through it: boost's ranged `set`, `reset` and `flip`, a window's
+`fill`, and a window's bulk operators, each walking the words a range spans with the mask of what each holds,
+whole words and a partial one at the end.
 
 ## Contracts
 
@@ -670,10 +676,15 @@ view's 8. The offset is applied once, in a private `offset()` that answers zero 
 The three members are [span.sub]'s, on a view and never on an owner, since `std::array` and `std::vector`
 have no subviews either; they assert their preconditions rather than throw, and `std::dynamic_extent` is the
 to-the-end sentinel. A window is a view in `std::ranges`' sense and borrowed like `span`, and like `span` it
-neither compares nor hashes ([views-follow-their-precedent](#views-follow-their-precedent)). It has no bulk
-operators and no `fill`: on packed bits those are block-wise, a window's end blocks are shared with what lies
-outside it, and masking them is the work that arrives with the blit. Until then a window is read and written
-one position at a time, which `std::ranges::fill` over its iterators already does.
+neither compares nor hashes ([views-follow-their-precedent](#views-follow-their-precedent)).
+
+A window's end blocks are shared with what lies outside it, so its bulk operations are masked words: `fill`
+over a window of ours is `block_sequence::set(pos, len, value)`, a word at a time through `set_word`, and one
+position at a time over a window of anything else; `&=`, `|=`, `^=` and `-=` on a window of ours take a source
+of any shape that reads blocks of the same block type, a window at any other alignment included, reading both
+sides through `word_at` and writing through `set_word` masked to the window ([the-blit](#the-blit)). The two
+must be of one size, and must not overlap short of coinciding, `w ^= w` being fine. A window has no shifts:
+shifting within a window is nobody's counterpart.
 
 ### the-range-members
 
@@ -795,7 +806,7 @@ in at both widths, every storage under the wrapper having blocks: `block_type`, 
 with the tail masked rather than trusted, and the block-range constructor at a run-time width, a whole number
 of blocks wide. The rest of boost's surface is there too, at both widths where a width does not preclude it:
 the throwing `at(pos)`, `test_set`, the ranged `set`/`reset`/`flip(pos, len)` behind the one guard on the whole
-range, element-wise until the blit brings the masked block; `max_size()` in bits, the width at a static one and
+range and then a masked word at a time ([the-blit](#the-blit)); `max_size()` in bits, the width at a static one and
 the widest whole number of blocks the blocks and the address space admit at a run-time one; and where the
 storage takes an allocator, `allocator_type`, `get_allocator()` and the allocator arguments on the
 constructors. The name `allocator_type` is an empty base a class either has or has not, a class having no
@@ -960,3 +971,13 @@ Four findings are suppressed because the checker cannot see what makes them righ
   instantiation discards; it sees only that one and asks for a `const` that would stop every other
   instantiation compiling.
 - `misc-redundant-expression` on a reflexivity check, which cannot be written without naming the object twice.
+
+### clang-crashes-on-a-foreign-bulk-source
+
+Asking whether a bulk operator accepts a view over a foreign storage -- `ours &= bit_span(a_std_bitset)`, in
+a `requires`-expression or written out -- crashes clang 18 and clang 20 alike with an internal error, and it
+did so before the windowed operators existed, so the trigger is the whole view's `&=` seeing a foreign
+`sequence_adaptor` as its argument. gcc rejects the expression as it should. The expression is ill-formed
+either way, since bulk on a window takes a source of the destination's own block type and the whole view's
+takes its own type, so nothing in the library or the tests spells it; the crash is recorded here so nobody
+adds the assertion that would.

--- a/include/opt/bitset/sieve.hpp
+++ b/include/opt/bitset/sieve.hpp
@@ -40,7 +40,7 @@ auto sift_primes0(std::size_t n)
         auto primes = generate_candidates<X>(n);
         for (std::size_t p
                 : xstd::bit_set_view(primes)
-                | std::views::take_while([&](std::size_t x) { return x * x < n; })
+                | std::views::take_while([&](std::size_t x) -> bool { return x * x < n; })
         ) {
                 for (auto m = p * p; m < n; m += p) {
                         sift(primes, m);

--- a/include/opt/bitset/sieve.hpp
+++ b/include/opt/bitset/sieve.hpp
@@ -1,86 +1,43 @@
 #ifndef OPT_BITSET_SIEVE_HPP
 #define OPT_BITSET_SIEVE_HPP
 
-//          Copyright Rein Halbersma 2014-2025.
+//          Copyright Rein Halbersma 2014-2026.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <xstd/bits/bit_set_view.hpp>           // bit_set_view
-#include <cstddef>                                 // size_t
-#include <ranges>                                  // take_while
+#include <xstd/bits/bit_set_view.hpp> // bit_set_view
+#include <cstddef>                    // size_t
+#include <ranges>                     // take_while
 
 namespace xstd {
 
-template<class X>
-concept legacy_bitset = requires(X& a, std::size_t pos)
-{
-        a.set();
-        a.reset(pos);
-};
-
-template<class X>
-concept modern_bitset = requires(X& a, std::size_t pos)
-{
-        a.fill();
-        a.erase(pos);
-};
-
+// The sieve over any bitset, ours or another's, through the set reading: one vocabulary, whichever the bitset's own. [design.md#the-sieve]
 // A static width is its own; a run-time one, boost's or ours, is resized to the count.
 template<class X>
-struct generate_empty
+auto generate_candidates(std::size_t n)
 {
-        auto operator()(std::size_t n) const
-        {
-                auto x = X();
-                if constexpr (requires { x.resize(n); }) {
-                        x.resize(n);
-                }
-                return x;
+        auto candidates = X();
+        if constexpr (requires { candidates.resize(n); }) {
+                candidates.resize(n);
         }
-};
-
-template<class X>
-auto fill(X& empty)
-{
-        if constexpr (legacy_bitset<X>) {
-                empty.set();
-        } else if constexpr (modern_bitset<X>) {
-                empty.fill();
-        } else {
-                static_assert(false);
-        }
+        auto const s = xstd::bit_set_view(candidates);
+        s.fill();
+        s.erase(0);
+        s.erase(1);
+        return candidates;
 }
 
 template<class X>
 auto sift(X& primes, std::size_t m)
 {
-        if constexpr (legacy_bitset<X>) {
-                primes.reset(m);
-        } else if constexpr (modern_bitset<X>) {
-                primes.erase(m);
-        } else {
-                static_assert(false);
-        }
+        xstd::bit_set_view(primes).erase(m);
 }
-
-template<class X>
-struct generate_candidates
-{
-        auto operator()(auto n) const
-        {
-                auto candidates = generate_empty<X>()(n);
-                fill(candidates);
-                sift(candidates, 0);
-                sift(candidates, 1);
-                return candidates;
-        }
-};
 
 template<class X>
 auto sift_primes0(std::size_t n)
 {
-        auto primes = generate_candidates<X>()(n);
+        auto primes = generate_candidates<X>(n);
         for (std::size_t p
                 : xstd::bit_set_view(primes)
                 | std::views::take_while([&](std::size_t x) { return x * x < n; })
@@ -95,7 +52,7 @@ auto sift_primes0(std::size_t n)
 template<class X>
 auto sift_primes1(std::size_t n)
 {
-        auto primes = generate_candidates<X>()(n);
+        auto primes = generate_candidates<X>(n);
         for (std::size_t p : xstd::bit_set_view(primes)) {
                 if (std::size_t m = p * p; m < n) {
                         do {

--- a/include/opt/set/sieve.hpp
+++ b/include/opt/set/sieve.hpp
@@ -1,7 +1,7 @@
 #ifndef OPT_SET_SIEVE_HPP
 #define OPT_SET_SIEVE_HPP
 
-//          Copyright Rein Halbersma 2014-2025.
+//          Copyright Rein Halbersma 2014-2026.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
@@ -18,20 +18,18 @@ auto sift(X& primes, std::size_t m)
         primes.erase(m);
 }
 
+// The sieve over any ordered set of integers, std::set's, std::flat_set's or ours. [design.md#the-sieve]
 template<class X>
-struct generate_candidates
+auto generate_candidates(std::size_t n)
 {
-        auto operator()(std::size_t n) const
-        {
-                return std::views::iota(2UZ, n) | std::ranges::to<X>();
-        }
-};
+        return std::views::iota(2UZ, n) | std::ranges::to<X>();
+}
 
 // Iterate a snapshot and guard with contains(): sift() erases, which invalidates a vector-backed X's cached end().
 template<class X>
 auto sift_primes0(std::size_t n)
 {
-        auto primes = generate_candidates<X>()(n);
+        auto primes = generate_candidates<X>(n);
         auto const candidates = primes;
         for (auto p
                 : candidates
@@ -50,7 +48,7 @@ auto sift_primes0(std::size_t n)
 template<class X>
 auto sift_primes1(std::size_t n)
 {
-        auto primes = generate_candidates<X>()(n);
+        auto primes = generate_candidates<X>(n);
         auto const candidates = primes;
         for (auto p : candidates) {
                 if (auto m = p * p; m < n) {

--- a/include/xstd/bits/bit_traits.hpp
+++ b/include/xstd/bits/bit_traits.hpp
@@ -8,6 +8,7 @@
 
 #include <xstd/bits/detail/intrin.hpp>             // countl_zero, countr_zero, popcount
 #include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer
+#include <cassert>                                 // assert
 #include <concepts>                                // convertible_to
 #include <cstddef>                                 // size_t
 #include <limits>                                  // digits
@@ -228,6 +229,24 @@ template<class Traits, class Bits>
                 }
                 return n;
         }
+}
+
+// The block-wide word at any position, aligned or not: the bits [pos, pos + digits) of c, read through the trait, so a source's alignment is the reader's problem and never the writer's. [design.md#the-blit]
+// pos must lie within the blocks; what the word reaches beyond the width is the clear tail, and beyond the last block nothing at all.
+template<class Traits, class Bits>
+[[nodiscard]] constexpr auto word_at(Bits const& c, std::size_t pos) noexcept
+{
+        using block_type = std::remove_cvref_t<decltype(Traits::block(c, 0UZ))>;
+        constexpr auto digits = static_cast<std::size_t>(std::numeric_limits<block_type>::digits);
+        auto const index = pos / digits;
+        auto const offset = pos % digits;
+        assert(index < Traits::num_blocks(c));
+        auto const low = static_cast<block_type>(Traits::block(c, index) >> offset);
+        // No shift by digits, which is undefined: an aligned read is the block itself, and the last block has nothing above it.
+        if (offset == 0UZ or index + 1UZ == Traits::num_blocks(c)) {
+                return low;
+        }
+        return static_cast<block_type>(low | static_cast<block_type>(Traits::block(c, index + 1UZ) << (digits - offset)));
 }
 
 // A zero width answers zero to every question, and says so here, before an entry or a walk is instantiated for it. [design.md#degenerate-widths]

--- a/include/xstd/bits/bitset_adaptor.hpp
+++ b/include/xstd/bits/bitset_adaptor.hpp
@@ -332,14 +332,12 @@ public:
                 return *this;
         }
 
-        // boost's ranged forms, the one guard on the whole range; element-wise until the blit brings the masked block. [design.md#the-one-guard]
+        // boost's ranged forms, the one guard on the whole range, then the storage's own a word at a time. [design.md#the-one-guard]
         constexpr auto set(std::size_t pos, std::size_t len, bool val)
                 -> bitset_adaptor&
         {
                 guard_range(pos, len);
-                for (auto const i : std::views::iota(pos, pos + len)) {
-                        Traits::unchecked_assign(m_bits, i, val);
-                }
+                m_bits.set(pos, len, val);
                 return *this;
         }
 
@@ -353,9 +351,7 @@ public:
                 -> bitset_adaptor&
         {
                 guard_range(pos, len);
-                for (auto const i : std::views::iota(pos, pos + len)) {
-                        Traits::unchecked_assign(m_bits, i, not Traits::at(m_bits, i));
-                }
+                m_bits.flip(pos, len);
                 return *this;
         }
 

--- a/include/xstd/bits/bitset_adaptor.hpp
+++ b/include/xstd/bits/bitset_adaptor.hpp
@@ -9,7 +9,7 @@
 // Bitsets [bitset], Header <bitset> synopsis [bitset.syn]
 
 #include <boost/hash2/hash_append.hpp>            // hash_append_tag
-#include <xstd/bits/bit_traits.hpp>               // bit_storage, bit_traits, block_readable, scan_prev, static_bit_extent, zero_width
+#include <xstd/bits/bit_traits.hpp>               // bit_storage, bit_traits, block_readable, scan_prev, static_bit_extent, word_at, zero_width
 #include <xstd/bits/detail/allocator_typedef.hpp> // allocator_typedef
 #include <xstd/bits/detail/hash.hpp>              // hash_append_bits, std_hash
 #include <xstd/bits/ownership.hpp>                // owned_storage, ownership
@@ -612,13 +612,18 @@ private:
                 }
         }
 
-        // boost's unequal-width order: the highest positions paired first over the common length, then the shorter is less.
+        // boost's unequal-width order, a word at a time: the top min(size()) positions of each paired from the top, read as words at either one's own alignment, then the shorter is less. [design.md#the-blit]
+        // The top word of each window ends at its own width, so what it reads above the common length is the clear tail on both sides and needs no mask.
         [[nodiscard]] constexpr auto top_aligned_three_way(bitset_adaptor const& rhs) const noexcept
                 -> std::strong_ordering
         {
                 auto const m = std::ranges::min(size(), rhs.size());
-                for (auto const i : std::views::iota(0UZ, m)) {
-                        if (auto const cmp = Traits::at(m_bits, size() - 1UZ - i) <=> Traits::at(rhs.m_bits, rhs.size() - 1UZ - i); cmp != std::strong_ordering::equal) {
+                auto const lhs_start = size() - m;
+                auto const rhs_start = rhs.size() - m;
+                for (auto k = (m + bits_per_block - 1UZ) / bits_per_block; k-- != 0UZ;) {
+                        auto const lhs_word = detail::bits::word_at<Traits>(m_bits, lhs_start + (k * bits_per_block));
+                        auto const rhs_word = detail::bits::word_at<Traits>(rhs.m_bits, rhs_start + (k * bits_per_block));
+                        if (auto const cmp = lhs_word <=> rhs_word; cmp != std::strong_ordering::equal) {
                                 return cmp;
                         }
                 }

--- a/include/xstd/bits/block_sequence.hpp
+++ b/include/xstd/bits/block_sequence.hpp
@@ -30,7 +30,7 @@
                                                                // (views::drop_last when P22014R2 is accepted)
 #include <span>                                                // dynamic_extent
 #include <type_traits>                                         // conditional_t, is_const_v, is_nothrow_swappable_v, remove_reference_t
-#include <utility>                                             // pair
+#include <utility>                                             // exchange, move, pair
 #include <vector>                                              // vector
 #include <version>                                             // IWYU pragma: keep; __cpp_lib_inplace_vector
 #ifdef __cpp_lib_inplace_vector
@@ -132,6 +132,25 @@ public:
                 m_size(n),
                 m_blocks(blocks_for(n), alloc)
         {}
+
+        // [container.alloc.reqmts]'s allocator-extended copy and move; the moved-from is left empty whichever way the blocks went.
+        template<class Alloc>
+                requires (not has_static_size) and std::same_as<Alloc, typename Blocks::allocator_type>
+        [[nodiscard]] constexpr block_sequence(block_sequence const& other, Alloc const& alloc)
+        :
+                m_size(other.m_size),
+                m_blocks(other.m_blocks, alloc)
+        {}
+
+        template<class Alloc>
+                requires (not has_static_size) and std::same_as<Alloc, typename Blocks::allocator_type>
+        [[nodiscard]] constexpr block_sequence(block_sequence&& other, Alloc const& alloc)
+        :
+                m_size(std::exchange(other.m_size, 0UZ)),
+                m_blocks(std::move(other.m_blocks), alloc)
+        {
+                other.m_blocks.clear();
+        }
 
         [[nodiscard]] constexpr auto get_allocator() const noexcept
                 requires requires (Blocks const& b) { b.get_allocator(); }

--- a/include/xstd/bits/block_sequence.hpp
+++ b/include/xstd/bits/block_sequence.hpp
@@ -224,10 +224,14 @@ public:
                 auto const [ index, offset ] = index_offset(n);
                 assert(index < num_blocks());
                 auto const bits = static_cast<block_type>(value & mask);
-                m_blocks[index] = static_cast<block_type>((m_blocks[index] & static_cast<block_type>(~static_cast<block_type>(mask << offset))) | static_cast<block_type>(bits << offset));
+
+                // Each step lands back in block_type: a promoted operand feeding the next bitwise operator is what bugprone-signed-bitwise reads. [design.md#block-writes]
+                auto const low_kept = static_cast<block_type>(m_blocks[index] & static_cast<block_type>(~static_cast<block_type>(mask << offset)));
+                m_blocks[index] = static_cast<block_type>(low_kept | static_cast<block_type>(bits << offset));
                 if (offset != 0UZ and index != last_block()) {
                         auto const shift = bits_per_block - offset;
-                        m_blocks[index + 1UZ] = static_cast<block_type>((m_blocks[index + 1UZ] & static_cast<block_type>(~static_cast<block_type>(mask >> shift))) | static_cast<block_type>(bits >> shift));
+                        auto const high_kept = static_cast<block_type>(m_blocks[index + 1UZ] & static_cast<block_type>(~static_cast<block_type>(mask >> shift)));
+                        m_blocks[index + 1UZ] = static_cast<block_type>(high_kept | static_cast<block_type>(bits >> shift));
                 }
                 erase_unused();
         }
@@ -237,7 +241,7 @@ public:
                 -> block_sequence&
         {
                 assert(n + len <= size());
-                for_each_word(n, len, [&](std::size_t pos, block_type mask) { set_word(pos, value ? ones : zero, mask); });
+                for_each_word(n, len, [&](std::size_t pos, block_type mask) -> void { set_word(pos, value ? ones : zero, mask); });
                 return *this;
         }
 
@@ -245,7 +249,7 @@ public:
                 -> block_sequence&
         {
                 assert(n + len <= size());
-                for_each_word(n, len, [&](std::size_t pos, block_type mask) { set_word(pos, static_cast<block_type>(~word_at(pos)), mask); });
+                for_each_word(n, len, [&](std::size_t pos, block_type mask) -> void { set_word(pos, static_cast<block_type>(~word_at(pos)), mask); });
                 return *this;
         }
 

--- a/include/xstd/bits/block_sequence.hpp
+++ b/include/xstd/bits/block_sequence.hpp
@@ -186,6 +186,50 @@ public:
                 erase_unused();
         }
 
+        // A word at any position, aligned or not: the bits [n, n + bits_per_block), the clear tail and nothing beyond the last block. [design.md#the-blit]
+        [[nodiscard]] constexpr auto word_at(std::size_t n) const noexcept
+                -> block_type
+        {
+                auto const [ index, offset ] = index_offset(n);
+                assert(index < num_blocks());
+                auto const low = static_cast<block_type>(m_blocks[index] >> offset);
+                if (offset == 0UZ or index == last_block()) {
+                        return low;
+                }
+                return static_cast<block_type>(low | static_cast<block_type>(m_blocks[index + 1UZ] << (bits_per_block - offset)));
+        }
+
+        // The write side of word_at, masked: the bits of value under mask land at [n, n + bits_per_block), split over two blocks where n is not aligned, and the tail stays clear. [design.md#the-blit]
+        constexpr void set_word(std::size_t n, block_type value, block_type mask) noexcept
+        {
+                auto const [ index, offset ] = index_offset(n);
+                assert(index < num_blocks());
+                auto const bits = static_cast<block_type>(value & mask);
+                m_blocks[index] = static_cast<block_type>((m_blocks[index] & static_cast<block_type>(~static_cast<block_type>(mask << offset))) | static_cast<block_type>(bits << offset));
+                if (offset != 0UZ and index != last_block()) {
+                        auto const shift = bits_per_block - offset;
+                        m_blocks[index + 1UZ] = static_cast<block_type>((m_blocks[index + 1UZ] & static_cast<block_type>(~static_cast<block_type>(mask >> shift))) | static_cast<block_type>(bits >> shift));
+                }
+                erase_unused();
+        }
+
+        // boost's ranged forms, a word at a time through set_word: [n, n + len) set, cleared or flipped, the rest untouched. [design.md#the-blit]
+        constexpr auto set(std::size_t n, std::size_t len, bool value) noexcept
+                -> block_sequence&
+        {
+                assert(n + len <= size());
+                for_each_word(n, len, [&](std::size_t pos, block_type mask) { set_word(pos, value ? ones : zero, mask); });
+                return *this;
+        }
+
+        constexpr auto flip(std::size_t n, std::size_t len) noexcept
+                -> block_sequence&
+        {
+                assert(n + len <= size());
+                for_each_word(n, len, [&](std::size_t pos, block_type mask) { set_word(pos, static_cast<block_type>(~word_at(pos)), mask); });
+                return *this;
+        }
+
         // Memberwise, width first: the unused bits are kept clear, so the blocks compare as the bits do, and a zero width through the one block it still holds. [design.md#block-storage]
         [[nodiscard]] friend constexpr auto operator==(block_sequence const&, block_sequence const&) noexcept -> bool = default;
 
@@ -889,6 +933,16 @@ private:
                 -> std::size_t
         {
                 return num_blocks() - 1UZ;
+        }
+
+        // The words a range of positions spans, each with the mask of what it holds: whole words, and a partial one at the end.
+        template<class F>
+        constexpr void for_each_word(std::size_t n, std::size_t len, F f) const noexcept
+        {
+                for (auto pos = n; pos < n + len; pos += bits_per_block) {
+                        auto const count = std::ranges::min(bits_per_block, n + len - pos);
+                        f(pos, count == bits_per_block ? ones : static_cast<block_type>(static_cast<block_type>(unit << count) - unit));
+                }
         }
 
         // An iterator pair, not views::take, which libc++ 18 cannot form here. [design.md#libcxx-views-take]

--- a/include/xstd/bits/detail/allocator_typedef.hpp
+++ b/include/xstd/bits/detail/allocator_typedef.hpp
@@ -25,6 +25,9 @@ struct allocator_typedef<Storage>
         [[nodiscard]] friend constexpr auto operator==(allocator_typedef const&, allocator_typedef const&) noexcept -> bool = default;
 };
 
+// A view's base in the same position: no typedef, owning nothing, and no comparison, a view being as incomparable as std::span. [design.md#views-follow-their-precedent]
+struct no_typedef {};
+
 }       // namespace xstd::detail::bits
 
 #endif  // XSTD_BITS_DETAIL_ALLOCATOR_TYPEDEF_HPP

--- a/include/xstd/bits/sequence_adaptor.hpp
+++ b/include/xstd/bits/sequence_adaptor.hpp
@@ -37,7 +37,7 @@ namespace xstd {
 template<class S, class Block>
 concept blit_source =
         requires { typename S::subspan_type; typename S::traits_type; typename S::traits_type::bits_type; } and
-        requires (typename S::traits_type::bits_type const& c) {
+        requires (S::traits_type::bits_type const& c) {
                 { S::traits_type::block(c, 0UZ) } -> std::same_as<Block>;
                 { S::traits_type::num_blocks(c) } -> std::convertible_to<std::size_t>;
         };
@@ -108,7 +108,7 @@ class sequence_adaptor : public std::conditional_t<owns(Own), detail::bits::allo
         static constexpr bool blittable = blit_source<S, typename bits_type::block_type>;
 
         // A storage that takes a masked word at any position: ours, which is what a window's bulk operators write through.
-        static constexpr bool word_writable = requires (bits_type& b, typename bits_type::block_type w) { b.set_word(0UZ, w, w); };
+        static constexpr bool word_writable = requires (bits_type& b, bits_type::block_type w) { b.set_word(0UZ, w, w); };
 
         // Either reading's view refers into this owner's storage, and nothing else outside does. [design.md#views-over-owners]
         template<class B, ownership O, bit_storage<B> T>         friend class set_adaptor;
@@ -674,18 +674,18 @@ constexpr void swap(sequence_adaptor<Bits, Own, Windowed, Traits>& x, sequence_a
 // [vector.erasure], over the owner's own erase: the proxies move and swap, so remove_if runs unchanged over the packed bits. [design.md#the-sequence-contract]
 template<class Bits, ownership Own, bool Windowed, class Traits, class Pred>
 constexpr auto erase_if(sequence_adaptor<Bits, Own, Windowed, Traits>& c, Pred pred)
-        -> typename sequence_adaptor<Bits, Own, Windowed, Traits>::size_type
+        -> sequence_adaptor<Bits, Own, Windowed, Traits>::size_type
         requires requires { c.erase(c.cbegin(), c.cend()); }
 {
         auto const [first, last] = std::ranges::remove_if(c, pred);
-        auto const n = static_cast<typename sequence_adaptor<Bits, Own, Windowed, Traits>::size_type>(last - first);
+        auto const n = static_cast<sequence_adaptor<Bits, Own, Windowed, Traits>::size_type>(last - first);
         c.erase(first, last);
         return n;
 }
 
 template<class Bits, ownership Own, bool Windowed, class Traits, class U = bool>
 constexpr auto erase(sequence_adaptor<Bits, Own, Windowed, Traits>& c, U const& value)
-        -> typename sequence_adaptor<Bits, Own, Windowed, Traits>::size_type
+        -> sequence_adaptor<Bits, Own, Windowed, Traits>::size_type
         requires requires { c.erase(c.cbegin(), c.cend()); }
 {
         return xstd::erase_if(c, [&](bool x) { return x == value; });

--- a/include/xstd/bits/sequence_adaptor.hpp
+++ b/include/xstd/bits/sequence_adaptor.hpp
@@ -6,28 +6,29 @@
 #ifndef XSTD_BITS_SEQUENCE_ADAPTOR_HPP
 #define XSTD_BITS_SEQUENCE_ADAPTOR_HPP
 
-#include <boost/container_hash/is_range.hpp> // is_range
-#include <boost/hash2/hash_append.hpp>       // hash_append_tag
-#include <xstd/bits/bit_proxy.hpp>           // bit_sequence_iterator, bit_sequence_reference
-#include <xstd/bits/bit_traits.hpp>          // bit_storage, bit_traits, static_bit_extent, word_at
-#include <xstd/bits/detail/hash.hpp>         // hash_append_bits, std_hash
-#include <xstd/bits/ownership.hpp>           // owned_bits_t, owned_storage, owned_traits_t, owner_of, ownership, owns
-#include <cassert>                           // assert
-#include <compare>                           // strong_ordering
-#include <concepts>                          // constructible_from, convertible_to, same_as, swap, swappable
-#include <cstddef>                           // ptrdiff_t, size_t
-#include <format>                            // format
-#include <functional>                        // hash
-#include <initializer_list>                  // initializer_list
-#include <iterator>                          // input_iterator, make_reverse_iterator, reverse_iterator, sentinel_for
-#include <limits>                            // numeric_limits
-#include <algorithm>                         // min
-#include <ranges>                            // begin, enable_borrowed_range, enable_view, end, from_range_t, input_range, range_reference_t, size, sized_range, subrange
-#include <source_location>                   // source_location
-#include <span>                              // dynamic_extent
-#include <stdexcept>                         // out_of_range
-#include <type_traits>                       // conditional_t, false_type, is_nothrow_swappable_v, remove_const_t, remove_cvref_t, remove_reference_t
-#include <utility>                           // as_const, declval, forward
+#include <boost/container_hash/is_range.hpp>      // is_range
+#include <boost/hash2/hash_append.hpp>            // hash_append_tag
+#include <xstd/bits/bit_proxy.hpp>                // bit_sequence_iterator, bit_sequence_reference
+#include <xstd/bits/bit_traits.hpp>               // bit_storage, bit_traits, static_bit_extent, word_at
+#include <xstd/bits/detail/allocator_typedef.hpp> // allocator_typedef, no_typedef
+#include <xstd/bits/detail/hash.hpp>              // hash_append_bits, std_hash
+#include <xstd/bits/ownership.hpp>                // owned_bits_t, owned_storage, owned_traits_t, owner_of, ownership, owns
+#include <cassert>                                // assert
+#include <compare>                                // strong_ordering
+#include <concepts>                               // constructible_from, convertible_to, same_as, swap, swappable
+#include <cstddef>                                // ptrdiff_t, size_t
+#include <format>                                 // format
+#include <functional>                             // hash
+#include <initializer_list>                       // initializer_list
+#include <iterator>                               // input_iterator, make_reverse_iterator, reverse_iterator, sentinel_for
+#include <limits>                                 // numeric_limits
+#include <algorithm>                              // copy, min, remove_if
+#include <ranges>                                 // begin, enable_borrowed_range, enable_view, end, from_range_t, input_range, range_reference_t, size, sized_range, subrange
+#include <source_location>                        // source_location
+#include <span>                                   // dynamic_extent
+#include <stdexcept>                              // out_of_range
+#include <type_traits>                            // conditional_t, false_type, is_nothrow_swappable_v, remove_const_t, remove_cvref_t, remove_reference_t
+#include <utility>                                // as_const, declval, forward, move
 
 // The sequence reading, [array] over any Bits with a bit_traits specialization, owning it or referring to it. [design.md#the-three-adaptors]
 namespace xstd {
@@ -41,8 +42,9 @@ concept blit_source =
                 { S::traits_type::num_blocks(c) } -> std::convertible_to<std::size_t>;
         };
 
+// An owner names its storage's allocator, as std::vector<bool> names its own; a view names none, owning nothing. [design.md#the-sequence-contract]
 template<class Bits, ownership Own, bool Windowed, bit_storage<Bits> Traits = bit_traits<std::remove_const_t<Bits>>>
-class sequence_adaptor
+class sequence_adaptor : public std::conditional_t<owns(Own), detail::bits::allocator_typedef<std::remove_const_t<Bits>>, detail::bits::no_typedef>
 {
         static constexpr bool is_owner  = owns(Own);
         static constexpr bool is_window = Windowed;
@@ -175,6 +177,87 @@ public:
         :
                 sequence_adaptor(il.begin(), il.end())
         {}
+
+        // std::array's aggregate initialization, as a constructor: what is listed leads and the rest stays false, a longer list being the error it is there. [design.md#the-sequence-contract]
+        constexpr sequence_adaptor(std::initializer_list<value_type> il)
+                requires is_owner and (not can_grow)
+        :
+                m_bits()
+        {
+                assert(il.size() <= size());
+                std::ranges::copy(il, begin());
+        }
+
+        // [vector.bool]'s allocator arguments, where the storage takes one: deduced and matched, so a storage without one has no such constructor. [design.md#the-sequence-contract]
+        template<class Alloc>
+                requires can_grow and std::same_as<Alloc, typename bits_type::allocator_type>
+        [[nodiscard]] constexpr explicit sequence_adaptor(Alloc const& alloc)
+        :
+                m_bits(alloc)
+        {}
+
+        template<class Alloc>
+                requires can_grow and std::same_as<Alloc, typename bits_type::allocator_type>
+        [[nodiscard]] constexpr sequence_adaptor(size_type n, Alloc const& alloc)
+        :
+                m_bits(n, alloc)
+        {}
+
+        template<class Alloc>
+                requires can_grow and std::same_as<Alloc, typename bits_type::allocator_type>
+        [[nodiscard]] constexpr sequence_adaptor(size_type n, value_type const& value, Alloc const& alloc)
+        :
+                m_bits(n, alloc)
+        {
+                if (value) {
+                        Traits::fill(m_bits, true);
+                }
+        }
+
+        template<std::input_iterator I, std::sentinel_for<I> S, class Alloc>
+                requires can_grow and std::constructible_from<value_type, std::iter_reference_t<I>> and std::same_as<Alloc, typename bits_type::allocator_type>
+        [[nodiscard]] constexpr sequence_adaptor(I first, S last, Alloc const& alloc)
+        :
+                m_bits(alloc)
+        {
+                for (; first != last; ++first) {
+                        m_bits.push_back(static_cast<value_type>(*first));
+                }
+        }
+
+        template<std::ranges::input_range R, class Alloc>
+                requires can_grow and std::constructible_from<value_type, std::ranges::range_reference_t<R>> and std::same_as<Alloc, typename bits_type::allocator_type>
+        [[nodiscard]] constexpr sequence_adaptor(std::from_range_t, R&& rg, Alloc const& alloc)
+        :
+                sequence_adaptor(std::ranges::begin(rg), std::ranges::end(rg), alloc)
+        {}
+
+        template<class Alloc>
+                requires can_grow and std::same_as<Alloc, typename bits_type::allocator_type>
+        [[nodiscard]] constexpr sequence_adaptor(sequence_adaptor const& other, Alloc const& alloc)
+        :
+                m_bits(other.m_bits, alloc)
+        {}
+
+        template<class Alloc>
+                requires can_grow and std::same_as<Alloc, typename bits_type::allocator_type>
+        [[nodiscard]] constexpr sequence_adaptor(sequence_adaptor&& other, Alloc const& alloc)
+        :
+                m_bits(std::move(other.m_bits), alloc)
+        {}
+
+        template<class Alloc>
+                requires can_grow and std::same_as<Alloc, typename bits_type::allocator_type>
+        [[nodiscard]] constexpr sequence_adaptor(std::initializer_list<value_type> il, Alloc const& alloc)
+        :
+                sequence_adaptor(il.begin(), il.end(), alloc)
+        {}
+
+        [[nodiscard]] constexpr auto get_allocator() const noexcept
+                requires is_owner and requires (bits_type const& b) { b.get_allocator(); }
+        {
+                return m_bits.get_allocator();
+        }
 
         constexpr auto operator=(std::initializer_list<value_type> il)
                 -> sequence_adaptor&
@@ -441,10 +524,7 @@ public:
         [[nodiscard]] constexpr auto back (this auto&& self) noexcept -> reference_t<decltype(self)> { return { &self.storage(), self.offset() + self.size() - 1UZ }; }
 
         // The owner's alone, following span: a handle declines to say whether it compares its referent or its contents. Defaulted, the storage being the one member. [design.md#views-follow-their-precedent]
-        [[nodiscard]] friend constexpr auto operator==(sequence_adaptor const& x, sequence_adaptor const& y) noexcept
-                -> bool
-                requires is_owner
-        = default;
+        [[nodiscard]] friend constexpr auto operator==(sequence_adaptor const& x, sequence_adaptor const& y) noexcept -> bool requires is_owner = default;
 
         // The trait's entry and nothing else: an owner is over storage of ours, which has one. [design.md#owning-is-ours]
         [[nodiscard]] friend constexpr auto operator<=>(sequence_adaptor const& x, sequence_adaptor const& y) noexcept
@@ -590,6 +670,26 @@ constexpr void swap(sequence_adaptor<Bits, Own, Windowed, Traits>& x, sequence_a
         x.swap(y);
 }
 // NOLINTEND(readability-redundant-parentheses)
+
+// [vector.erasure], over the owner's own erase: the proxies move and swap, so remove_if runs unchanged over the packed bits. [design.md#the-sequence-contract]
+template<class Bits, ownership Own, bool Windowed, class Traits, class Pred>
+constexpr auto erase_if(sequence_adaptor<Bits, Own, Windowed, Traits>& c, Pred pred)
+        -> typename sequence_adaptor<Bits, Own, Windowed, Traits>::size_type
+        requires requires { c.erase(c.cbegin(), c.cend()); }
+{
+        auto const [first, last] = std::ranges::remove_if(c, pred);
+        auto const n = static_cast<typename sequence_adaptor<Bits, Own, Windowed, Traits>::size_type>(last - first);
+        c.erase(first, last);
+        return n;
+}
+
+template<class Bits, ownership Own, bool Windowed, class Traits, class U = bool>
+constexpr auto erase(sequence_adaptor<Bits, Own, Windowed, Traits>& c, U const& value)
+        -> typename sequence_adaptor<Bits, Own, Windowed, Traits>::size_type
+        requires requires { c.erase(c.cbegin(), c.cend()); }
+{
+        return xstd::erase_if(c, [&](bool x) { return x == value; });
+}
 
 }       // namespace xstd
 

--- a/include/xstd/bits/sequence_adaptor.hpp
+++ b/include/xstd/bits/sequence_adaptor.hpp
@@ -9,7 +9,7 @@
 #include <boost/container_hash/is_range.hpp> // is_range
 #include <boost/hash2/hash_append.hpp>       // hash_append_tag
 #include <xstd/bits/bit_proxy.hpp>           // bit_sequence_iterator, bit_sequence_reference
-#include <xstd/bits/bit_traits.hpp>          // bit_storage, bit_traits, static_bit_extent
+#include <xstd/bits/bit_traits.hpp>          // bit_storage, bit_traits, static_bit_extent, word_at
 #include <xstd/bits/detail/hash.hpp>         // hash_append_bits, std_hash
 #include <xstd/bits/ownership.hpp>           // owned_bits_t, owned_storage, owned_traits_t, owner_of, ownership, owns
 #include <cassert>                           // assert
@@ -21,6 +21,7 @@
 #include <initializer_list>                  // initializer_list
 #include <iterator>                          // input_iterator, make_reverse_iterator, reverse_iterator, sentinel_for
 #include <limits>                            // numeric_limits
+#include <algorithm>                         // min
 #include <ranges>                            // begin, enable_borrowed_range, enable_view, end, from_range_t, input_range, range_reference_t, size, sized_range, subrange
 #include <source_location>                   // source_location
 #include <span>                              // dynamic_extent
@@ -30,6 +31,15 @@
 
 // The sequence reading, [array] over any Bits with a bit_traits specialization, owning it or referring to it. [design.md#the-three-adaptors]
 namespace xstd {
+
+// A sequence adaptor of any shape, told by its public typedefs, whose trait reads blocks of the given type: what a blit reads. [design.md#the-blit]
+template<class S, class Block>
+concept blit_source =
+        requires { typename S::subspan_type; typename S::traits_type; typename S::traits_type::bits_type; } and
+        requires (typename S::traits_type::bits_type const& c) {
+                { S::traits_type::block(c, 0UZ) } -> std::same_as<Block>;
+                { S::traits_type::num_blocks(c) } -> std::convertible_to<std::size_t>;
+        };
 
 template<class Bits, ownership Own, bool Windowed, bit_storage<Bits> Traits = bit_traits<std::remove_const_t<Bits>>>
 class sequence_adaptor
@@ -90,6 +100,13 @@ class sequence_adaptor
 
         template<class Self> using iterator_t  = bit_sequence_iterator <storage_t<Self>, Traits>;
         template<class Self> using reference_t = bit_sequence_reference<storage_t<Self>, Traits>;
+
+        // A source the blit can read by block, of this storage's own block type. [design.md#the-blit]
+        template<class S>
+        static constexpr bool blittable = blit_source<S, typename bits_type::block_type>;
+
+        // A storage that takes a masked word at any position: ours, which is what a window's bulk operators write through.
+        static constexpr bool word_writable = requires (bits_type& b, typename bits_type::block_type w) { b.set_word(0UZ, w, w); };
 
         // Either reading's view refers into this owner's storage, and nothing else outside does. [design.md#views-over-owners]
         template<class B, ownership O, bit_storage<B> T>         friend class set_adaptor;
@@ -313,11 +330,19 @@ public:
                 return { &storage(), offset() + off, count == std::dynamic_extent ? size() - off : count };
         }
 
-        // Bulk on a window is the masked-block work that arrives with the blit; until then a window is read and written one position at a time. [design.md#windows]
+        // fill: the trait's entry over the whole, a masked word at a time over a window of ours, one position at a time over a window of anything else. [design.md#windows]
         constexpr void fill(this auto&& self, value_type const& u) noexcept
-                requires (not is_window) and requires { Traits::fill(self.storage(), u); }
+                requires (is_window and requires { Traits::unchecked_assign(self.storage(), 0UZ, u); }) or (not is_window and requires { Traits::fill(self.storage(), u); })
         {
-                Traits::fill(self.storage(), u);
+                if constexpr (not is_window) {
+                        Traits::fill(self.storage(), u);
+                } else if constexpr (requires { self.storage().set(0UZ, 0UZ, u); }) {
+                        self.storage().set(self.offset(), self.size(), u);
+                } else {
+                        for (auto i = self.offset(), last = self.offset() + self.size(); i < last; ++i) {
+                                Traits::unchecked_assign(self.storage(), i, u);
+                        }
+                }
         }
 
         // The storage's own swap through the customization point, std::bitset having no member to call.
@@ -438,17 +463,34 @@ public:
         constexpr auto operator<<=(this auto&& self, std::size_t n) noexcept -> auto& requires (not is_window) and requires { self.storage() <<= n; } { self.storage() <<= n; return self; }
         constexpr auto operator>>=(this auto&& self, std::size_t n) noexcept -> auto& requires (not is_window) and requires { self.storage() >>= n; } { self.storage() >>= n; return self; }
 
+        // Bulk on a window of ours, against a source of any shape read by block: a word at a time at either alignment, through word_at and set_word; equal sizes, and no overlap short of coincidence. [design.md#windows]
+        template<class Other> constexpr auto operator&=(this auto&& self, Other const& other) noexcept -> auto& requires is_window and word_writable and blittable<Other> { self.combine(other, [](auto a, auto b) { return static_cast<decltype(a)>(a & b);  }); return self; }
+        template<class Other> constexpr auto operator|=(this auto&& self, Other const& other) noexcept -> auto& requires is_window and word_writable and blittable<Other> { self.combine(other, [](auto a, auto b) { return static_cast<decltype(a)>(a | b);  }); return self; }
+        template<class Other> constexpr auto operator^=(this auto&& self, Other const& other) noexcept -> auto& requires is_window and word_writable and blittable<Other> { self.combine(other, [](auto a, auto b) { return static_cast<decltype(a)>(a ^ b);  }); return self; }
+        template<class Other> constexpr auto operator-=(this auto&& self, Other const& other) noexcept -> auto& requires is_window and word_writable and blittable<Other> { self.combine(other, [](auto a, auto b) { return static_cast<decltype(a)>(a & ~b); }); return self; }
+
         // [vector.bool]'s two: flip every bit, a bulk operation like the ones above, and swap two proxies, which the proxies' own swap already does.
         constexpr void flip(this auto&& self) noexcept requires (not is_window) and requires { self.storage().flip(); } { self.storage().flip(); }
 
         static constexpr void swap(reference x, reference y) noexcept { bool const t = x; x = y; y = t; }
 
 private:
-        // A source the blit can read by block: a sequence adaptor of any shape whose trait reads blocks of this storage's own block type. [design.md#the-blit]
-        template<class S>
-        static constexpr bool blittable =
-                requires (S const& s) { s.storage(); s.offset(); s.size(); typename S::traits_type; } and
-                requires (S const& s) { { S::traits_type::block(s.storage(), 0UZ) } -> std::same_as<typename bits_type::block_type>; S::traits_type::num_blocks(s.storage()); };
+        // The words of this window against the words of another at its own alignment, each masked to what the window holds.
+        template<class Other, class F>
+        constexpr void combine(this auto&& self, Other const& other, F f) noexcept
+        {
+                using block_type = bits_type::block_type;
+                constexpr auto digits = bits_type::bits_per_block;
+                constexpr auto unit = block_type{1};
+                assert(self.size() == other.size());
+                for (auto k = 0UZ; k < self.size(); k += digits) {
+                        auto const count = std::ranges::min(digits, self.size() - k);
+                        auto const mask = count == digits ? static_cast<block_type>(~block_type{}) : static_cast<block_type>(static_cast<block_type>(unit << count) - unit);
+                        auto const mine   = detail::bits::word_at<Traits>(self.storage(), self.offset() + k);
+                        auto const theirs = detail::bits::word_at<typename Other::traits_type>(other.storage(), other.offset() + k);
+                        self.storage().set_word(self.offset() + k, f(mine, theirs), mask);
+                }
+        }
 
         // Tier one: the source's bits as words at its own alignment, appended a word at a time and trimmed to the count; a source in this very storage reads only below the old width, which no append touches. [design.md#the-blit]
         template<class STraits, class SBits>

--- a/include/xstd/bits/sequence_adaptor.hpp
+++ b/include/xstd/bits/sequence_adaptor.hpp
@@ -14,19 +14,19 @@
 #include <xstd/bits/ownership.hpp>           // owned_bits_t, owned_storage, owned_traits_t, owner_of, ownership, owns
 #include <cassert>                           // assert
 #include <compare>                           // strong_ordering
-#include <concepts>                          // convertible_to, swap, swappable
+#include <concepts>                          // constructible_from, convertible_to, same_as, swap, swappable
 #include <cstddef>                           // ptrdiff_t, size_t
 #include <format>                            // format
 #include <functional>                        // hash
 #include <initializer_list>                  // initializer_list
 #include <iterator>                          // input_iterator, make_reverse_iterator, reverse_iterator, sentinel_for
 #include <limits>                            // numeric_limits
-#include <ranges>                            // begin, enable_borrowed_range, enable_view, end, from_range_t, input_range, range_reference_t
+#include <ranges>                            // begin, enable_borrowed_range, enable_view, end, from_range_t, input_range, range_reference_t, size, sized_range, subrange
 #include <source_location>                   // source_location
 #include <span>                              // dynamic_extent
 #include <stdexcept>                         // out_of_range
-#include <type_traits>                       // conditional_t, false_type, is_nothrow_swappable_v, remove_const_t, remove_reference_t
-#include <utility>                           // as_const, declval
+#include <type_traits>                       // conditional_t, false_type, is_nothrow_swappable_v, remove_const_t, remove_cvref_t, remove_reference_t
+#include <utility>                           // as_const, declval, forward
 
 // The sequence reading, [array] over any Bits with a bit_traits specialization, owning it or referring to it. [design.md#the-three-adaptors]
 namespace xstd {
@@ -189,6 +189,86 @@ public:
                 requires can_grow
         {
                 assign(il.begin(), il.end());
+        }
+
+        // [sequence.reqmts]'s range members, and [vector]'s insert and erase, over a storage that grows. [design.md#the-range-members]
+        template<std::ranges::input_range R>
+                requires can_grow and std::constructible_from<value_type, std::ranges::range_reference_t<R>>
+        constexpr void append_range(R&& rg)
+        {
+                if constexpr (blittable<std::remove_cvref_t<R>>) {
+                        blit<typename std::remove_cvref_t<R>::traits_type>(rg.storage(), rg.offset(), rg.size());
+                } else {
+                        pack(std::forward<R>(rg));
+                }
+        }
+
+        template<std::ranges::input_range R>
+                requires can_grow and std::constructible_from<value_type, std::ranges::range_reference_t<R>>
+        constexpr void assign_range(R&& rg)
+        {
+                m_bits.clear();
+                append_range(std::forward<R>(rg));
+        }
+
+        template<std::ranges::input_range R>
+                requires can_grow and std::constructible_from<value_type, std::ranges::range_reference_t<R>>
+        constexpr auto insert_range(const_iterator position, R&& rg)
+                -> iterator
+        {
+                auto const pos = index_of(position);
+                return rebuild(pos, pos, [&](sequence_adaptor& tmp) { tmp.append_range(std::forward<R>(rg)); });
+        }
+
+        constexpr auto insert(const_iterator position, value_type const& value)
+                -> iterator
+                requires can_grow
+        {
+                return insert(position, 1UZ, value);
+        }
+
+        constexpr auto insert(const_iterator position, size_type n, value_type const& value)
+                -> iterator
+                requires can_grow
+        {
+                auto const pos = index_of(position);
+                return rebuild(pos, pos, [&](sequence_adaptor& tmp) { tmp.m_bits.resize(tmp.size() + n, value); });
+        }
+
+        template<std::input_iterator I, std::sentinel_for<I> S>
+                requires can_grow and std::constructible_from<value_type, std::iter_reference_t<I>>
+        constexpr auto insert(const_iterator position, I first, S last)
+                -> iterator
+        {
+                return insert_range(position, std::ranges::subrange(first, last));
+        }
+
+        constexpr auto insert(const_iterator position, std::initializer_list<value_type> il)
+                -> iterator
+                requires can_grow
+        {
+                return insert(position, il.begin(), il.end());
+        }
+
+        constexpr auto emplace(const_iterator position, value_type const& value)
+                -> iterator
+                requires can_grow
+        {
+                return insert(position, value);
+        }
+
+        constexpr auto erase(const_iterator position)
+                -> iterator
+                requires can_grow
+        {
+                return erase(position, position + 1);
+        }
+
+        constexpr auto erase(const_iterator first, const_iterator last)
+                -> iterator
+                requires can_grow
+        {
+                return rebuild(index_of(first), index_of(last), [](sequence_adaptor&) {});
         }
 
         [[nodiscard]] constexpr explicit sequence_adaptor(Bits& c) noexcept
@@ -358,7 +438,81 @@ public:
         constexpr auto operator<<=(this auto&& self, std::size_t n) noexcept -> auto& requires (not is_window) and requires { self.storage() <<= n; } { self.storage() <<= n; return self; }
         constexpr auto operator>>=(this auto&& self, std::size_t n) noexcept -> auto& requires (not is_window) and requires { self.storage() >>= n; } { self.storage() >>= n; return self; }
 
+        // [vector.bool]'s two: flip every bit, a bulk operation like the ones above, and swap two proxies, which the proxies' own swap already does.
+        constexpr void flip(this auto&& self) noexcept requires (not is_window) and requires { self.storage().flip(); } { self.storage().flip(); }
+
+        static constexpr void swap(reference x, reference y) noexcept { bool const t = x; x = y; y = t; }
+
 private:
+        // A source the blit can read by block: a sequence adaptor of any shape whose trait reads blocks of this storage's own block type. [design.md#the-blit]
+        template<class S>
+        static constexpr bool blittable =
+                requires (S const& s) { s.storage(); s.offset(); s.size(); typename S::traits_type; } and
+                requires (S const& s) { { S::traits_type::block(s.storage(), 0UZ) } -> std::same_as<typename bits_type::block_type>; S::traits_type::num_blocks(s.storage()); };
+
+        // Tier one: the source's bits as words at its own alignment, appended a word at a time and trimmed to the count; a source in this very storage reads only below the old width, which no append touches. [design.md#the-blit]
+        template<class STraits, class SBits>
+        constexpr void blit(SBits const& src, size_type first, size_type count)
+        {
+                constexpr auto digits = bits_type::bits_per_block;
+                auto const old = size();
+                if constexpr (requires (bits_type& b) { b.reserve(0UZ); }) {
+                        m_bits.reserve(old + count);
+                }
+                for (auto pos = first; pos < first + count; pos += digits) {
+                        m_bits.append(detail::bits::word_at<STraits>(src, pos));
+                }
+                m_bits.resize(old + count);
+        }
+
+        // Tier two: the bools packed into words, boost's bit_appender, and the last word trimmed to what it holds.
+        template<std::ranges::input_range R>
+        constexpr void pack(R&& rg)
+        {
+                using block_type = bits_type::block_type;
+                constexpr auto digits = bits_type::bits_per_block;
+                if constexpr (std::ranges::sized_range<R> and requires (bits_type& b) { b.reserve(0UZ); }) {
+                        m_bits.reserve(size() + std::ranges::size(rg));
+                }
+                auto word = block_type{};
+                auto n = 0UZ;
+                for (auto&& e : rg) {
+                        if (static_cast<value_type>(e)) {
+                                word |= static_cast<block_type>(block_type{1} << n);
+                        }
+                        if (++n == digits) {
+                                m_bits.append(word);
+                                word = block_type{};
+                                n = 0UZ;
+                        }
+                }
+                if (n != 0UZ) {
+                        auto const total = size() + n;
+                        m_bits.append(word);
+                        m_bits.resize(total);
+                }
+        }
+
+        // Rebuilt rather than shifted: head, the middle the caller appends, tail, then one swap, so the strong guarantee comes free. [design.md#the-range-members]
+        template<class Middle>
+        constexpr auto rebuild(size_type pos, size_type tail, Middle&& middle)
+                -> iterator
+        {
+                auto const whole = sequence_adaptor<bits_type const, ownership::refers, false, Traits>(std::as_const(storage()));
+                auto tmp = sequence_adaptor();
+                tmp.append_range(whole.first(pos));
+                middle(tmp);
+                tmp.append_range(whole.subspan(tail));
+                swap(tmp);
+                return begin() + static_cast<difference_type>(pos);
+        }
+
+        [[nodiscard]] constexpr auto index_of(const_iterator position) const noexcept
+                -> size_type
+        {
+                return static_cast<size_type>(position - cbegin());
+        }
+
         static constexpr auto out_of_range(std::size_t n, std::size_t size, std::source_location const& loc = std::source_location::current())
         {
                 return std::out_of_range(

--- a/include/xstd/bits/sequence_adaptor.hpp
+++ b/include/xstd/bits/sequence_adaptor.hpp
@@ -317,7 +317,7 @@ public:
                 -> iterator
         {
                 auto const pos = index_of(position);
-                return rebuild(pos, pos, [&](sequence_adaptor& tmp) { tmp.append_range(std::forward<R>(rg)); });
+                return rebuild(pos, pos, [&](sequence_adaptor& tmp) -> void { tmp.append_range(std::forward<R>(rg)); });
         }
 
         constexpr auto insert(const_iterator position, value_type const& value)
@@ -332,7 +332,7 @@ public:
                 requires can_grow
         {
                 auto const pos = index_of(position);
-                return rebuild(pos, pos, [&](sequence_adaptor& tmp) { tmp.m_bits.resize(tmp.size() + n, value); });
+                return rebuild(pos, pos, [&](sequence_adaptor& tmp) -> void { tmp.m_bits.resize(tmp.size() + n, value); });
         }
 
         template<std::input_iterator I, std::sentinel_for<I> S>
@@ -368,7 +368,7 @@ public:
                 -> iterator
                 requires can_grow
         {
-                return rebuild(index_of(first), index_of(last), [](sequence_adaptor&) {});
+                return rebuild(index_of(first), index_of(last), [](sequence_adaptor&) -> void {});
         }
 
         [[nodiscard]] constexpr explicit sequence_adaptor(Bits& c) noexcept
@@ -547,7 +547,7 @@ public:
         template<class Other> constexpr auto operator&=(this auto&& self, Other const& other) noexcept -> auto& requires is_window and word_writable and blittable<Other> { self.combine(other, [](auto a, auto b) { return static_cast<decltype(a)>(a & b);  }); return self; }
         template<class Other> constexpr auto operator|=(this auto&& self, Other const& other) noexcept -> auto& requires is_window and word_writable and blittable<Other> { self.combine(other, [](auto a, auto b) { return static_cast<decltype(a)>(a | b);  }); return self; }
         template<class Other> constexpr auto operator^=(this auto&& self, Other const& other) noexcept -> auto& requires is_window and word_writable and blittable<Other> { self.combine(other, [](auto a, auto b) { return static_cast<decltype(a)>(a ^ b);  }); return self; }
-        template<class Other> constexpr auto operator-=(this auto&& self, Other const& other) noexcept -> auto& requires is_window and word_writable and blittable<Other> { self.combine(other, [](auto a, auto b) { return static_cast<decltype(a)>(a & ~b); }); return self; }
+        template<class Other> constexpr auto operator-=(this auto&& self, Other const& other) noexcept -> auto& requires is_window and word_writable and blittable<Other> { self.combine(other, [](auto a, auto b) { return static_cast<decltype(a)>(a & static_cast<decltype(b)>(~b)); }); return self; }
 
         // [vector.bool]'s two: flip every bit, a bulk operation like the ones above, and swap two proxies, which the proxies' own swap already does.
         constexpr void flip(this auto&& self) noexcept requires (not is_window) and requires { self.storage().flip(); } { self.storage().flip(); }
@@ -688,7 +688,7 @@ constexpr auto erase(sequence_adaptor<Bits, Own, Windowed, Traits>& c, U const& 
         -> sequence_adaptor<Bits, Own, Windowed, Traits>::size_type
         requires requires { c.erase(c.cbegin(), c.cend()); }
 {
-        return xstd::erase_if(c, [&](bool x) { return x == value; });
+        return xstd::erase_if(c, [&](bool x) -> bool { return x == value; });
 }
 
 }       // namespace xstd

--- a/test/include/test/sequence/concepts.hpp
+++ b/test/include/test/sequence/concepts.hpp
@@ -7,9 +7,14 @@
 #define TEST_SEQUENCE_CONCEPTS_HPP
 
 #include <test/value_reference.hpp> // value_reference
-#include <concepts>                 // regular, totally_ordered
+#include <compare>                  // strong_ordering
+#include <concepts>                 // regular, same_as, totally_ordered
+#include <cstddef>                  // size_t
+#include <functional>               // hash
+#include <initializer_list>         // initializer_list
 #include <iterator>                 // random_access_iterator
-#include <ranges>                   // random_access_range
+#include <ranges>                   // from_range, random_access_range
+#include <utility>                  // move
 
 namespace test::sequence {
 
@@ -21,6 +26,122 @@ concept bit_sequence =
     and std::ranges::random_access_range<C>
     and std::random_access_iterator<typename C::iterator>
     and value_reference<typename C::const_reference>;
+
+// The typedefs [container.reqmts] gives every container, pointer and const_pointer aside: packed bits have no address. [design.md#the-sequence-contract]
+template<class C>
+concept container_typedefs = requires {
+        typename C::value_type;
+        typename C::reference;
+        typename C::const_reference;
+        typename C::iterator;
+        typename C::const_iterator;
+        typename C::difference_type;
+        typename C::size_type;
+};
+
+template<class C>
+concept reversible_container_typedefs = container_typedefs<C> and requires {
+        typename C::reverse_iterator;
+        typename C::const_reverse_iterator;
+};
+
+// [container.reqmts] and [container.rev.reqmts]: what any container answers, on a const one and a mutable one.
+template<class C>
+concept container_members = reversible_container_typedefs<C> and requires (C c, C const cc, typename C::size_type n) {
+        { c.begin()    } -> std::same_as<typename C::iterator>;
+        { c.end()      } -> std::same_as<typename C::iterator>;
+        { cc.begin()   } -> std::same_as<typename C::const_iterator>;
+        { cc.end()     } -> std::same_as<typename C::const_iterator>;
+        { c.cbegin()   } -> std::same_as<typename C::const_iterator>;
+        { c.cend()     } -> std::same_as<typename C::const_iterator>;
+        { c.rbegin()   } -> std::same_as<typename C::reverse_iterator>;
+        { c.rend()     } -> std::same_as<typename C::reverse_iterator>;
+        { cc.rbegin()  } -> std::same_as<typename C::const_reverse_iterator>;
+        { cc.rend()    } -> std::same_as<typename C::const_reverse_iterator>;
+        { c.crbegin()  } -> std::same_as<typename C::const_reverse_iterator>;
+        { c.crend()    } -> std::same_as<typename C::const_reverse_iterator>;
+        { cc.empty()   } -> std::same_as<bool>;
+        { cc.size()    } -> std::same_as<typename C::size_type>;
+        { cc.max_size()} -> std::same_as<typename C::size_type>;
+        { c[n]         } -> std::same_as<typename C::reference>;
+        { cc[n]        } -> std::same_as<typename C::const_reference>;
+        { c.at(n)      } -> std::same_as<typename C::reference>;
+        { cc.at(n)     } -> std::same_as<typename C::const_reference>;
+        { c.front()    } -> std::same_as<typename C::reference>;
+        { cc.front()   } -> std::same_as<typename C::const_reference>;
+        { c.back()     } -> std::same_as<typename C::reference>;
+        { cc.back()    } -> std::same_as<typename C::const_reference>;
+        { cc == cc     } -> std::same_as<bool>;
+        { cc <=> cc    } -> std::same_as<std::strong_ordering>;
+        c.swap(c);
+        swap(c, c);
+};
+
+// [array]'s synopsis, data() and the tuple interface aside, as one requires-expression: std::array<bool, N> and the packing both accept every line. [design.md#the-sequence-contract]
+template<class C>
+concept array_bool = container_members<C> and requires (C c, bool b) {
+        C();
+        C{ b, b };
+        c.fill(b);
+};
+
+// [vector.bool]'s synopsis, likewise, with [vector.erasure] and the allocator: std::vector<bool> is the model and the packing answers every line of it.
+template<class C, class A = C::allocator_type>
+concept vector_bool = container_members<C> and requires (C c, C o, C const cc, typename C::size_type n, bool b, A a, std::initializer_list<bool> il, bool const* first, bool const* last, typename C::const_iterator p) {
+        typename C::allocator_type;
+        C();
+        C(a);
+        C(n);
+        C(n, a);
+        C(n, b);
+        C(n, b, a);
+        C(first, last);
+        C(first, last, a);
+        C(cc);
+        C(std::move(o));
+        C(cc, a);
+        C(std::move(o), a);
+        C(il);
+        C(il, a);
+        c = cc;
+        c = std::move(o);
+        c = il;
+        c.assign(first, last);
+        c.assign(n, b);
+        c.assign(il);
+        { cc.get_allocator() } -> std::same_as<A>;
+        { cc.capacity()      } -> std::same_as<typename C::size_type>;
+        c.resize(n);
+        c.resize(n, b);
+        c.reserve(n);
+        c.shrink_to_fit();
+        { c.emplace_back(b)  } -> std::same_as<typename C::reference>;
+        c.push_back(b);
+        c.pop_back();
+        { c.emplace(p, b)             } -> std::same_as<typename C::iterator>;
+        { c.insert(p, b)              } -> std::same_as<typename C::iterator>;
+        { c.insert(p, n, b)           } -> std::same_as<typename C::iterator>;
+        { c.insert(p, first, last)    } -> std::same_as<typename C::iterator>;
+        { c.insert(p, il)             } -> std::same_as<typename C::iterator>;
+        { c.erase(p)                  } -> std::same_as<typename C::iterator>;
+        { c.erase(p, p)               } -> std::same_as<typename C::iterator>;
+        c.clear();
+        c.flip();
+        C::swap(c[n], c[n]);
+        { erase(c, b)                          } -> std::same_as<typename C::size_type>;
+        { erase_if(c, [](bool) { return true; }) } -> std::same_as<typename C::size_type>;
+        { std::hash<C>()(cc) } -> std::same_as<std::size_t>;
+};
+
+// [vector.bool]'s C++23 lines, apart so the model can be held to them where its standard library has them (__cpp_lib_containers_ranges).
+template<class C, class A = C::allocator_type>
+concept vector_bool_ranges = requires (C c, A a, std::initializer_list<bool> il, typename C::const_iterator p) {
+        C(std::from_range, il);
+        C(std::from_range, il, a);
+        c.assign_range(il);
+        { c.insert_range(p, il) } -> std::same_as<typename C::iterator>;
+        c.append_range(il);
+};
 
 } // namespace test::sequence
 

--- a/test/src/bits/bit_array.cpp
+++ b/test/src/bits/bit_array.cpp
@@ -3,15 +3,17 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/test/unit_test.hpp>   // BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
+#include <boost/test/unit_test.hpp>   // BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK
 #include <test/block_types.hpp>       // graded_extents
 #include <test/sequence/concepts.hpp> // bit_sequence
 #include <test/value_reference.hpp>   // value_reference
 #include <xstd/bits/bit_array.hpp>    // bit_array
+#include <algorithm>                  // equal, none_of
+#include <array>                      // array
 #include <concepts>                   // regular, totally_ordered
-#include <functional>                 // hash
+#include <functional>                 // hash, identity
 #include <iterator>                   // random_access_iterator
-#include <ranges>                     // random_access_range
+#include <ranges>                     // drop, random_access_range, take
 
 BOOST_AUTO_TEST_SUITE(BitArray)
 
@@ -60,6 +62,26 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ItHashesAsAnOwner, T, Types)
 BOOST_AUTO_TEST_CASE_TEMPLATE(IsABitSequence, T, Types)
 {
         static_assert(test::sequence::bit_sequence<T>);
+}
+
+// [array]'s synopsis line by line, the model first so the checklist is known to be honest. [design.md#the-sequence-contract]
+static_assert(test::sequence::array_bool<std::array<bool, 5>>);
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(ItAnswersEveryLineOfStdArrayBool, T, Types)
+{
+        static_assert(test::sequence::array_bool<T>);
+}
+
+// std::array's aggregate initialization: what is listed leads and the rest stays false.
+BOOST_AUTO_TEST_CASE_TEMPLATE(ItIsListInitializedLikeAStdArray, T, Types)
+{
+        if constexpr (T().size() >= 3UZ) {
+                auto const a = T{ true, false, true };
+                auto m = std::array<bool, 3>{ true, false, true };
+                BOOST_CHECK(std::ranges::equal(a | std::views::take(3), m));
+                BOOST_CHECK(std::ranges::none_of(a | std::views::drop(3), std::identity()));
+        }
+        BOOST_CHECK(T{} == T());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/bits/bit_subspan.cpp
+++ b/test/src/bits/bit_subspan.cpp
@@ -41,7 +41,9 @@ using Sub    = xstd::bit_subspan<Blocks>;
 // Dependent, so an absent member is a substitution failure rather than a hard error.
 template<class X> constexpr bool has_subspan  = requires (X x) { x.subspan(0UZ); x.first(0UZ); x.last(0UZ); };
 template<class X> constexpr bool can_fill     = requires (X x) { x.fill(true); };
-template<class X> constexpr bool has_bulk_ops = requires (X x) { x &= x; x |= x; x ^= x; x -= x; x <<= 1UZ; x >>= 1UZ; };
+template<class X> constexpr bool has_bulk_ops = requires (X x) { x &= x; x |= x; x ^= x; x -= x; };
+template<class X> constexpr bool has_shifts   = requires (X x) { x <<= 1UZ; x >>= 1UZ; };
+template<class W, class O> constexpr bool combinable = requires (W w, O const& o) { w &= o; };
 
 // Twenty bits of any viewed storage: a static width has them, a run-time one is resized to them, as the sieve does.
 template<class T>
@@ -75,16 +77,18 @@ BOOST_AUTO_TEST_CASE(TheWindowIsTheAdaptorWindowed)
         static_assert(    has_subspan<Sub>);
         static_assert(not has_subspan<Owner>);
 
-        // A view in std::ranges' sense and borrowed like span; like span it neither compares nor hashes, and unlike the whole view it has no bulk operators yet. [design.md#windows]
+        // A view in std::ranges' sense and borrowed like span; like span it neither compares nor hashes. It fills and takes the four bulk operators a word at a time, and has no shifts. [design.md#windows]
         static_assert(std::ranges::view<Sub>);
         static_assert(std::ranges::borrowed_range<Sub>);
         static_assert(std::ranges::random_access_range<Sub>);
         static_assert(not std::equality_comparable<Sub>);
         static_assert(not std::is_default_constructible_v<std::hash<Sub>>);
-        static_assert(not can_fill<Sub>);
-        static_assert(not has_bulk_ops<Sub>);
+        static_assert(    can_fill<Sub>);
+        static_assert(    has_bulk_ops<Sub>);
+        static_assert(not has_shifts<Sub>);
         static_assert(    can_fill<Span>);
         static_assert(    has_bulk_ops<Span>);
+        static_assert(    has_shifts<Span>);
 }
 
 // A window sees its positions and nothing beyond them, reading them from zero. [design.md#windows]
@@ -126,6 +130,116 @@ BOOST_AUTO_TEST_CASE(AWindowWritesThrough)
         std::ranges::fill(w, false);
         BOOST_CHECK(std::ranges::equal(w, std::vector<bool>(6, false)));
         BOOST_CHECK(static_cast<bool>(a[9]));
+}
+
+namespace {
+
+// The bools a range holds, for the checks below.
+template<class R>
+auto bools(R const& r) -> std::vector<bool>
+{
+        return std::vector<bool>(r.begin(), r.end());
+}
+
+}       // namespace
+
+// fill on a window: a masked word at a time over our storage, one position at a time over a foreign one, and never a position outside. [design.md#windows]
+BOOST_AUTO_TEST_CASE_TEMPLATE(AWindowFillsItsPositionsAlone, T, ViewedTypes)
+{
+        for (auto const off : { 0UZ, 1UZ, 7UZ, 8UZ, 9UZ, 15UZ }) {
+                for (auto const count : { 0UZ, 1UZ, 3UZ, 8UZ, 9UZ, 20UZ - off }) {
+                        if (off + count > 20UZ) {
+                                continue;
+                        }
+                        auto bits = twenty<T>();
+                        auto const v = xstd::bit_span(bits);
+                        auto model = std::vector<bool>(20, false);
+                        for (auto const i : { 2UZ, 8UZ, 13UZ, 19UZ }) {
+                                v[i] = true;
+                                model[i] = true;
+                        }
+                        v.subspan(off, count).fill(true);
+                        std::ranges::fill(model.begin() + static_cast<std::ptrdiff_t>(off), model.begin() + static_cast<std::ptrdiff_t>(off + count), true);
+                        BOOST_CHECK(std::ranges::equal(v, model));
+                        v.subspan(off, count).fill(false);
+                        std::ranges::fill(model.begin() + static_cast<std::ptrdiff_t>(off), model.begin() + static_cast<std::ptrdiff_t>(off + count), false);
+                        BOOST_CHECK(std::ranges::equal(v, model));
+                }
+        }
+}
+
+namespace {
+
+// A pattern over n positions from a seed, with a period that never aligns with a block.
+auto pattern(std::size_t n, std::size_t seed) -> std::vector<bool>
+{
+        auto v = std::vector<bool>(n);
+        for (auto i = 0UZ; i < n; ++i) {
+                v[i] = ((i + seed) % 3 == 0) or ((i * seed) % 5 == 1);
+        }
+        return v;
+}
+
+// The four operators by number: on two bools for the model, on a window and a source for the sequence.
+auto model_op(int op, bool a, bool b) -> bool
+{
+        switch (op) {
+        case 0:  return a and b;
+        case 1:  return a or b;
+        case 2:  return a != b;
+        default: return a and not b;
+        }
+}
+
+void window_op(int op, auto const& w, auto const& o)
+{
+        switch (op) {
+        case 0:  w &= o; break;
+        case 1:  w |= o; break;
+        case 2:  w ^= o; break;
+        default: w -= o; break;
+        }
+}
+
+// One combination: a window of the destination at off against a window of the source at other, count wide, against the bool model.
+void check_combination(int op, std::size_t off, std::size_t other, std::size_t count)
+{
+        auto source = xstd::basic_bit_vector<std::uint8_t>(std::from_range, pattern(40, 2));
+        auto dest = xstd::basic_bit_vector<std::uint8_t>(std::from_range, pattern(40, 3));
+        auto model = pattern(40, 3);
+        auto const w = xstd::bit_span(dest).subspan(off, count);
+        auto const theirs = bools(xstd::bit_span(source).subspan(other, count));
+        window_op(op, w, xstd::bit_span(source).subspan(other, count));
+        for (auto i = 0UZ; i < count; ++i) {
+                model[off + i] = model_op(op, model[off + i], theirs[i]);
+        }
+        BOOST_CHECK(std::ranges::equal(dest, model));
+}
+
+}       // namespace
+
+// The four bulk operators on a window of ours against a window at any other alignment: word by word, masked to the window; a source of another block type, a std::bitset's say, is not a source. [design.md#windows]
+BOOST_AUTO_TEST_CASE(AWindowCombinesWithAnotherAtAnyAlignment)
+{
+        for (auto const op : { 0, 1, 2, 3 }) {
+                for (auto const off : { 0UZ, 3UZ, 8UZ, 13UZ }) {
+                        for (auto const other : { 0UZ, 1UZ, 5UZ, 8UZ, 17UZ }) {
+                                for (auto const count : { 0UZ, 1UZ, 7UZ, 8UZ, 9UZ, 20UZ }) {
+                                        check_combination(op, off, other, count);
+                                }
+                        }
+                }
+        }
+
+        // A window against itself, word by word in place. A source of another block type, a std::bitset's say, is not a source; asking clang whether it is crashes the compiler, so no assertion says so here. [design.md#clang-crashes-on-a-foreign-bulk-source]
+        auto self = xstd::basic_bit_vector<std::uint8_t>(std::from_range, pattern(20, 1));
+        auto const outside = bools(xstd::bit_span(self).first(3));
+        auto const w = xstd::bit_span(self).subspan(3, 12);
+        w ^= w;
+        BOOST_CHECK(std::ranges::equal(w, std::vector<bool>(12, false)));
+        BOOST_CHECK(std::ranges::equal(xstd::bit_span(self).first(3), outside));
+        static_assert(combinable<decltype(w), decltype(w)>);
+        static_assert(combinable<decltype(w), decltype(xstd::bit_span(self))>);
 }
 
 // Windows compose: a window of a window offsets once more, first and last are the two ends, and dynamic_extent reaches the end. [design.md#windows]

--- a/test/src/bits/bit_traits.cpp
+++ b/test/src/bits/bit_traits.cpp
@@ -5,9 +5,10 @@
 
 #include <boost/test/unit_test.hpp>      // BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL
 #include <test/block_types.hpp>          // graded_extents
-#include <xstd/bits/bit_traits.hpp>      // bit_storage, bit_traits, block_readable, scan_*, static_bit_extent
+#include <xstd/bits/bit_traits.hpp>      // bit_storage, bit_traits, block_readable, scan_*, static_bit_extent, word_at
 #include <xstd/bits/block_sequence.hpp>  // block_array
 #include <cstddef>                       // size_t
+#include <cstdint>                       // uint8_t
 #include <set>                           // set
 
 // Two adapters over identical storage, differing only in whether they hand their blocks over. [design.md#detection-by-absence]
@@ -167,5 +168,24 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(BlockWiseScansAgreeWithStdSet, T, BlockTypes)
 }
 
 // No ordering case: the trait carries none, the two readings disagreeing. [design.md#two-readings-disagree]
+
+// The word at any position: aligned, straddling two blocks, and in the last block with nothing above it. [design.md#the-blit]
+BOOST_AUTO_TEST_CASE(TheWordAtAPositionReadsAcrossBlocks)
+{
+        using T = xstd::block_array<std::uint8_t, 20>;
+        using traits = xstd::bit_traits<T>;
+        auto c = T();
+        for (auto const i : { 0UZ, 3UZ, 7UZ, 8UZ, 12UZ, 15UZ, 19UZ }) {
+                c.set(i);
+        }
+        // Blocks: 0b1000'1001, 0b1001'0001, 0b0000'1000.
+        BOOST_CHECK_EQUAL(xstd::detail::bits::word_at<traits>(c, 0UZ),  0b1000'1001);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::word_at<traits>(c, 8UZ),  0b1001'0001);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::word_at<traits>(c, 3UZ),  0b0011'0001);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::word_at<traits>(c, 7UZ),  0b0010'0011);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::word_at<traits>(c, 12UZ), 0b1000'1001);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::word_at<traits>(c, 16UZ), 0b0000'1000);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::word_at<traits>(c, 17UZ), 0b0000'0100);
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/bits/bit_vector.cpp
+++ b/test/src/bits/bit_vector.cpp
@@ -19,9 +19,11 @@
 #include <iterator>                          // next
 #include <limits>                            // numeric_limits
 #include <memory>                            // allocator
-#include <ranges>                            // equal, iota, next, transform
+#include <ranges>                            // equal, from_range, iota, next, transform
 #include <type_traits>                       // is_default_constructible_v
+#include <utility>                           // move
 #include <vector>                            // vector
+#include <version>                           // IWYU pragma: keep; __cpp_lib_containers_ranges
 
 BOOST_AUTO_TEST_SUITE(BitVector)
 
@@ -46,6 +48,20 @@ BOOST_AUTO_TEST_CASE(TheDynamicSequenceIsTheSequenceAdaptorOverAHeapOfBlocks)
 }
 
 // [vector]'s constructors, every shape, against std::vector<bool> built the same way.
+// [vector.bool]'s synopsis line by line, the model first so the checklist is known to be honest. [design.md#the-sequence-contract]
+BOOST_AUTO_TEST_CASE(ItAnswersEveryLineOfStdVectorBool)
+{
+        static_assert(test::sequence::vector_bool<std::vector<bool>>);
+        static_assert(test::sequence::vector_bool<T>);
+        static_assert(test::sequence::vector_bool<xstd::bit_vector>);
+#if defined(__cpp_lib_containers_ranges)
+        static_assert(test::sequence::vector_bool_ranges<std::vector<bool>>);
+#endif
+        static_assert(test::sequence::vector_bool_ranges<T>);
+        static_assert(test::sequence::vector_bool_ranges<xstd::bit_vector>);
+        static_assert(std::same_as<T::allocator_type, std::allocator<std::uint8_t>>);
+}
+
 BOOST_AUTO_TEST_CASE(ItIsBuiltLikeAStdVector)
 {
         auto const pattern = std::views::iota(0UZ, 20UZ) | std::views::transform([](auto i) { return i % 3 == 0; });
@@ -68,6 +84,41 @@ BOOST_AUTO_TEST_CASE(ItIsBuiltLikeAStdVector)
         BOOST_CHECK(std::ranges::equal(v, model));
         v.assign({ true });
         BOOST_CHECK(std::ranges::equal(v, std::vector<bool>{ true }));
+}
+
+// The allocator forms, each against the one without: the allocator is a construction argument, never part of the value.
+BOOST_AUTO_TEST_CASE(ItIsBuiltWithAnAllocatorLikeAStdVector)
+{
+        auto const pattern = std::views::iota(0UZ, 20UZ) | std::views::transform([](auto i) { return i % 3 == 0; });
+        auto const alloc = std::allocator<std::uint8_t>();
+        auto const model = T(pattern.begin(), pattern.end());
+
+        BOOST_CHECK(T(alloc).get_allocator() == alloc);
+        BOOST_CHECK(T(alloc).empty());
+        BOOST_CHECK(T(17, alloc) == T(17));
+        BOOST_CHECK(T(5, true, alloc) == T(5, true));
+        BOOST_CHECK(T(5, false, alloc) == T(5, false));
+        BOOST_CHECK(T(pattern.begin(), pattern.end(), alloc) == model);
+        BOOST_CHECK(T(std::from_range, pattern, alloc) == model);
+        BOOST_CHECK(T(model, alloc) == model);
+        BOOST_CHECK(T({ true, false, true }, alloc) == T({ true, false, true }));
+
+        auto source = model;
+        auto const moved = T(std::move(source), alloc);
+        BOOST_CHECK(moved == model);
+        BOOST_CHECK(source.empty());  // NOLINT(bugprone-use-after-move,hicpp-invalid-access-moved): the moved-from is empty by contract, which is the check.
+}
+
+// [vector.erasure] against the model, erasing a value and then a predicate.
+BOOST_AUTO_TEST_CASE(ErasureIsTheStdVectorsOwn)
+{
+        auto v = T{ true, false, true, true, false, false, true };
+        auto m = std::vector<bool>{ true, false, true, true, false, false, true };
+        BOOST_CHECK_EQUAL(erase(v, true), std::erase(m, true));
+        BOOST_CHECK(std::ranges::equal(v, m));
+        BOOST_CHECK_EQUAL(erase_if(v, [](bool x) { return not x; }), std::erase_if(m, [](bool x) { return not x; }));
+        BOOST_CHECK(v.empty());
+        BOOST_CHECK_EQUAL(erase(v, false), 0UZ);
 }
 
 // Growth is the owner's: push, pop, emplace, resize, reserve, shrink and clear, each against the model.

--- a/test/src/bits/bit_vector.cpp
+++ b/test/src/bits/bit_vector.cpp
@@ -9,15 +9,17 @@
 #include <xstd/bits/bit_vector.hpp>          // bit_vector
 #include <xstd/bits/block_sequence.hpp>      // block_vector
 #include <xstd/bits/ownership.hpp>           // ownership
-#include <xstd/bits/bit_span.hpp> // bit_span
-#include <algorithm>                         // equal
+#include <xstd/bits/bit_array.hpp>           // basic_bit_array
+#include <xstd/bits/bit_span.hpp>            // bit_span
+#include <algorithm>                         // copy, equal
 #include <concepts>                          // same_as
 #include <cstddef>                           // size_t
 #include <cstdint>                           // uint8_t
-#include <functional>                         // hash
+#include <functional>                        // hash
+#include <iterator>                          // next
 #include <limits>                            // numeric_limits
 #include <memory>                            // allocator
-#include <ranges>                            // iota, transform
+#include <ranges>                            // equal, iota, next, transform
 #include <type_traits>                       // is_default_constructible_v
 #include <vector>                            // vector
 
@@ -28,6 +30,12 @@ using T = xstd::basic_bit_vector<std::uint8_t>;
 // Dependent, so a constrained-away member is a false rather than a hard error.
 template<class X>
 constexpr bool can_grow = requires (X& x) { x.push_back(true); x.resize(1UZ); };
+
+template<class X>
+constexpr bool can_flip = requires (X x) { x.flip(); };
+
+template<class X>
+constexpr bool has_range_members = requires (X x, std::vector<bool> const& r) { x.append_range(r); x.insert_range(x.cbegin(), r); x.erase(x.cbegin()); };
 
 // std::vector<bool> under its own name: the sequence adaptor over a heap of blocks. [design.md#the-public-names]
 BOOST_AUTO_TEST_CASE(TheDynamicSequenceIsTheSequenceAdaptorOverAHeapOfBlocks)
@@ -96,6 +104,191 @@ BOOST_AUTO_TEST_CASE(ItGrowsLikeAStdVector)
         BOOST_CHECK_EQUAL(v.size(), 0UZ);
 }
 
+namespace {
+
+// A std::vector<bool> holding what a sequence holds, the model every check below compares against.
+template<class R>
+auto model_of(R const& r) -> std::vector<bool>
+{
+        return std::vector<bool>(r.begin(), r.end());
+}
+
+// std::vector<bool>'s append_range and insert_range, spelled through insert for the standard libraries that lack them.
+template<class R>
+void append_to(std::vector<bool>& m, R const& r)
+{
+        m.insert(m.end(), r.begin(), r.end());
+}
+
+// A pattern over n positions with a period that never aligns with a block.
+auto pattern(std::size_t n) -> std::vector<bool>
+{
+        auto v = std::vector<bool>(n);
+        for (auto i = 0UZ; i < n; ++i) {
+                v[i] = (i % 3 == 0) or (i % 7 == 1);
+        }
+        return v;
+}
+
+}       // namespace
+
+// append_range's first tier: another sequence read by block, at every alignment the source and the destination can have. [design.md#the-blit]
+BOOST_AUTO_TEST_CASE(AppendRangeBlitsFromASequenceAtAnyAlignment)
+{
+        auto const source = T(std::from_range, pattern(50));
+        auto const view = xstd::bit_span(source);
+
+        for (auto const start : { 0UZ, 1UZ, 7UZ, 8UZ, 9UZ, 16UZ, 40UZ, 43UZ }) {
+                for (auto const count : { 0UZ, 1UZ, 7UZ, 8UZ, 9UZ, 17UZ, 50UZ - start }) {
+                        if (start + count > 50UZ) {
+                                continue;
+                        }
+                        for (auto const prefix : { 0UZ, 1UZ, 8UZ, 11UZ }) {
+                                auto v = T(std::from_range, pattern(prefix));
+                                auto m = model_of(v);
+                                auto const window = view.subspan(start, count);
+                                v.append_range(window);
+                                append_to(m, model_of(window));
+                                BOOST_CHECK(std::ranges::equal(v, m));
+                                BOOST_CHECK_EQUAL(v.size(), prefix + count);
+                        }
+                }
+        }
+
+        // An owner, a whole view and a static array all blit alike; a source of another block type packs instead.
+        auto fixed = xstd::basic_bit_array<9, std::uint8_t>();
+        std::ranges::copy(pattern(9), fixed.begin());
+        auto v = T();
+        v.append_range(source);
+        v.append_range(view);
+        v.append_range(fixed);
+        v.append_range(xstd::basic_bit_vector<std::uint64_t>(std::from_range, pattern(13)));
+        auto m = std::vector<bool>();
+        append_to(m, pattern(50));
+        append_to(m, pattern(50));
+        append_to(m, pattern(9));
+        append_to(m, pattern(13));
+        BOOST_CHECK(std::ranges::equal(v, m));
+
+        // Itself, through a view: the blit reads only below the old width, which no append touches.
+        auto w = T(std::from_range, pattern(21));
+        w.append_range(xstd::bit_span(w).subspan(3, 15));
+        auto n = pattern(21);
+        append_to(n, std::vector<bool>(n.begin() + 3, n.begin() + 18));
+        BOOST_CHECK(std::ranges::equal(w, n));
+}
+
+// append_range's second tier: any range of bools, packed a word at a time, the last word trimmed. [design.md#the-blit]
+BOOST_AUTO_TEST_CASE(AppendRangePacksAnyRangeOfBools)
+{
+        for (auto const prefix : { 0UZ, 3UZ, 8UZ }) {
+                for (auto const count : { 0UZ, 1UZ, 8UZ, 9UZ, 16UZ, 23UZ }) {
+                        auto v = T(std::from_range, pattern(prefix));
+                        auto m = model_of(v);
+                        auto const more = pattern(count);
+                        v.append_range(more);
+                        append_to(m, more);
+                        BOOST_CHECK(std::ranges::equal(v, m));
+
+                        // An input range with no size to reserve.
+                        auto const lazy = std::views::iota(0UZ, count) | std::views::transform([](auto i) { return i % 2 == 1; });
+                        v.append_range(lazy);
+                        append_to(m, lazy);
+                        BOOST_CHECK(std::ranges::equal(v, m));
+                }
+        }
+
+        auto v = T{ true };
+        v.assign_range(pattern(20));
+        BOOST_CHECK(std::ranges::equal(v, pattern(20)));
+}
+
+namespace {
+
+// The position under test on the sequence and on the model alike.
+template<class C>
+auto at(C const& c, std::size_t pos)
+{
+        return std::ranges::next(c.cbegin(), static_cast<std::ptrdiff_t>(pos));
+}
+
+// The two results first, their offsets after: begin() is taken once the insert has moved everything.
+template<class V, class M>
+auto same_offset_and_contents(V const& v, typename V::iterator vit, M const& m, typename M::iterator mit)
+{
+        BOOST_CHECK_EQUAL(vit - v.begin(), mit - m.begin());
+        BOOST_CHECK(std::ranges::equal(v, m));
+}
+
+}       // namespace
+
+// insert's single-value shapes and emplace, rebuilt around the position, against the model. [design.md#the-range-members]
+BOOST_AUTO_TEST_CASE(InsertingValuesRebuildsAsAStdVectorDoes)
+{
+        for (auto const pos : { 0UZ, 1UZ, 8UZ, 13UZ, 20UZ }) {
+                auto v = T(std::from_range, pattern(20));
+                auto m = pattern(20);
+
+                same_offset_and_contents(v, v.insert(at(v, pos), true), m, m.insert(at(m, pos), true));
+                same_offset_and_contents(v, v.insert(at(v, pos), 3UZ, false), m, m.insert(at(m, pos), 3UZ, false));
+                same_offset_and_contents(v, v.emplace(at(v, pos), false), m, m.emplace(at(m, pos), false));
+        }
+}
+
+// insert's range shapes and insert_range, one of them a window into the sequence itself.
+BOOST_AUTO_TEST_CASE(InsertingRangesRebuildsAsAStdVectorDoes)
+{
+        for (auto const pos : { 0UZ, 1UZ, 8UZ, 13UZ, 20UZ }) {
+                auto v = T(std::from_range, pattern(20));
+                auto m = pattern(20);
+
+                // A range shorter than a word, one of exactly a word, and one that spills into a second: the packing tier's three endings.
+                auto const more = pattern(11);
+                same_offset_and_contents(v, v.insert(at(v, pos), more.begin(), more.end()), m, m.insert(at(m, pos), more.begin(), more.end()));
+                auto const word = pattern(8);
+                same_offset_and_contents(v, v.insert(at(v, pos), word.begin(), word.end()), m, m.insert(at(m, pos), word.begin(), word.end()));
+                same_offset_and_contents(v, v.insert(at(v, pos), { true, true, false }), m, m.insert(at(m, pos), { true, true, false }));
+                same_offset_and_contents(v, v.insert(at(v, pos), { true, false, true, false, true, false, true, false }), m, m.insert(at(m, pos), { true, false, true, false, true, false, true, false }));
+                same_offset_and_contents(v, v.insert(at(v, pos), { true, false, true, false, true, false, true, false, true }), m, m.insert(at(m, pos), { true, false, true, false, true, false, true, false, true }));
+                auto const middle = std::vector<bool>(m.begin() + 2, m.begin() + 11);
+                same_offset_and_contents(v, v.insert_range(at(v, pos), xstd::bit_span(v).subspan(2, 9)), m, m.insert(at(m, pos), middle.begin(), middle.end()));
+        }
+}
+
+// erase in both shapes, an empty range included.
+BOOST_AUTO_TEST_CASE(ErasingRebuildsAsAStdVectorDoes)
+{
+        for (auto const pos : { 0UZ, 1UZ, 8UZ, 13UZ, 19UZ }) {
+                auto v = T(std::from_range, pattern(40));
+                auto m = pattern(40);
+
+                same_offset_and_contents(v, v.erase(at(v, pos)), m, m.erase(at(m, pos)));
+                same_offset_and_contents(v, v.erase(at(v, pos), at(v, pos + 9)), m, m.erase(at(m, pos), at(m, pos + 9)));
+                same_offset_and_contents(v, v.erase(at(v, pos), at(v, pos)), m, m.erase(at(m, pos), at(m, pos)));
+        }
+}
+
+// [vector.bool]'s two: flip every bit, and swap two proxies.
+BOOST_AUTO_TEST_CASE(FlipAndSwapAreStdVectorBools)
+{
+        auto v = T(std::from_range, pattern(20));
+        auto m = pattern(20);
+        v.flip();
+        m.flip();
+        BOOST_CHECK(std::ranges::equal(v, m));
+
+        T::swap(v[0], v[1]);
+        std::vector<bool>::swap(m[0], m[1]);
+        BOOST_CHECK(std::ranges::equal(v, m));
+
+        // A view flips what it views, a window does not. [design.md#windows]
+        xstd::bit_span(v).flip();
+        m.flip();
+        BOOST_CHECK(std::ranges::equal(v, m));
+        static_assert(not can_flip<decltype(xstd::bit_span(v).first(2))>);
+        static_assert(    can_flip<decltype(xstd::bit_span(v))>);
+}
+
 // The owner hashes as std::vector<bool> does, equal values equal; the view over it no more than std::span does. [design.md#the-hashing-invariant]
 BOOST_AUTO_TEST_CASE(TheOwnerHashesAndTheViewDoesNot)
 {
@@ -116,6 +309,8 @@ BOOST_AUTO_TEST_CASE(AViewOverItCannotGrowIt)
 
         static_assert(not can_grow<decltype(s)>);
         static_assert(    can_grow<T>);
+        static_assert(not has_range_members<decltype(s)>);
+        static_assert(    has_range_members<T>);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/bits/bit_vector.cpp
+++ b/test/src/bits/bit_vector.cpp
@@ -328,8 +328,12 @@ BOOST_AUTO_TEST_CASE(FlipAndSwapAreStdVectorBools)
         m.flip();
         BOOST_CHECK(std::ranges::equal(v, m));
 
+        // Ours is [vector.bool]'s static swap, which the clause still has; the model's own is deprecated by C++26
+        // (LWG-3638, P3612R1) and MSVC 2026 says so under /WX, so the model's two bits are exchanged directly.
         T::swap(v[0], v[1]);
-        std::vector<bool>::swap(m[0], m[1]);
+        auto const m0 = static_cast<bool>(m[0]);
+        m[0] = static_cast<bool>(m[1]);
+        m[1] = m0;
         BOOST_CHECK(std::ranges::equal(v, m));
 
         // A view flips what it views, a window does not. [design.md#windows]

--- a/test/src/bits/bit_vector.cpp
+++ b/test/src/bits/bit_vector.cpp
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(ItAnswersEveryLineOfStdVectorBool)
         static_assert(test::sequence::vector_bool<std::vector<bool>>);
         static_assert(test::sequence::vector_bool<T>);
         static_assert(test::sequence::vector_bool<xstd::bit_vector>);
-#if defined(__cpp_lib_containers_ranges)
+#ifdef __cpp_lib_containers_ranges
         static_assert(test::sequence::vector_bool_ranges<std::vector<bool>>);
 #endif
         static_assert(test::sequence::vector_bool_ranges<T>);

--- a/test/src/bits/bit_vector.cpp
+++ b/test/src/bits/bit_vector.cpp
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_CASE(ErasureIsTheStdVectorsOwn)
         auto m = std::vector<bool>{ true, false, true, true, false, false, true };
         BOOST_CHECK_EQUAL(erase(v, true), std::erase(m, true));
         BOOST_CHECK(std::ranges::equal(v, m));
-        BOOST_CHECK_EQUAL(erase_if(v, [](bool x) { return not x; }), std::erase_if(m, [](bool x) { return not x; }));
+        BOOST_CHECK_EQUAL(erase_if(v, [](bool x) -> bool { return not x; }), std::erase_if(m, [](bool x) -> bool { return not x; }));
         BOOST_CHECK(v.empty());
         BOOST_CHECK_EQUAL(erase(v, false), 0UZ);
 }

--- a/test/src/bits/block_sequence.cpp
+++ b/test/src/bits/block_sequence.cpp
@@ -876,23 +876,51 @@ BOOST_AUTO_TEST_CASE(TheAllocatorAndTheMaximumWidth)
         static_assert(A().max_size() == 9UZ);
 }
 
-// A word read and written at any position: aligned, straddling two blocks, in the last block; the ranged forms over it, against a model. [design.md#the-blit]
+// A word read and written at any position, and the ranged forms over it: both at a static width and at a run-time one. [design.md#the-blit]
 using WordTypes = std::tuple<xstd::block_array<std::uint8_t, 20>, xstd::block_vector<std::uint8_t>>;
+
+namespace {
+
+// Twenty bits with a fixed pattern, grown first where the width is a run-time one: the sample both word cases read.
+template<class T>
+auto word_sample() -> T
+{
+        auto b = T();
+        if constexpr (requires { b.resize(20UZ); }) {
+                b.resize(20UZ);
+        }
+        for (auto const i : { 0UZ, 3UZ, 7UZ, 8UZ, 12UZ, 15UZ, 19UZ }) {
+                b.set(i);
+        }
+        return b;
+}
+
+// One start and length through set, flip and reset, each against the model; a function rather than a loop body so the
+// case that sweeps it stays under readability-function-cognitive-complexity's threshold.
+template<class T>
+auto check_ranged_forms(std::size_t n, std::size_t len) -> void
+{
+        auto e = word_sample<T>();
+        auto r = reference(e);
+
+        e.set(n, len, true);
+        for (auto i = n; i < n + len; ++i) { r[i] = true; }
+        BOOST_CHECK(reference(e) == r);
+
+        e.flip(n, len);
+        for (auto i = n; i < n + len; ++i) { r[i] = not r[i]; }
+        BOOST_CHECK(reference(e) == r);
+
+        e.set(n, len, false);
+        for (auto i = n; i < n + len; ++i) { r[i] = false; }
+        BOOST_CHECK(reference(e) == r);
+}
+
+}       // namespace
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(WordsAreReadAndWrittenAtAnyPosition, T, WordTypes)
 {
-        constexpr auto D = 8UZ;
-        auto make = [] {
-                auto b = T();
-                if constexpr (requires { b.resize(20UZ); }) {
-                        b.resize(20UZ);
-                }
-                for (auto const i : { 0UZ, 3UZ, 7UZ, 8UZ, 12UZ, 15UZ, 19UZ }) {
-                        b.set(i);
-                }
-                return b;
-        };
-        auto const c = make();
+        auto const c = word_sample<T>();
         // Blocks: 0b1000'1001, 0b1001'0001, 0b0000'1000.
         BOOST_CHECK_EQUAL(c.word_at(0UZ),  0b1000'1001);
         BOOST_CHECK_EQUAL(c.word_at(8UZ),  0b1001'0001);
@@ -902,7 +930,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(WordsAreReadAndWrittenAtAnyPosition, T, WordTypes)
         BOOST_CHECK_EQUAL(c.word_at(17UZ), 0b0000'0100);
 
         // set_word lands the masked bits and nothing else, across two blocks and into the tail, which stays clear.
-        auto d = make();
+        auto d = word_sample<T>();
         d.set_word(3UZ, 0b1111'1111, 0b0001'1110);
         auto m = reference(c);
         for (auto const i : { 4UZ, 5UZ, 6UZ, 7UZ }) { m[i] = true; }
@@ -914,24 +942,17 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(WordsAreReadAndWrittenAtAnyPosition, T, WordTypes)
         for (auto const i : { 16UZ, 17UZ, 18UZ, 19UZ }) { m[i] = true; }
         BOOST_CHECK(reference(d) == m);
         BOOST_CHECK_EQUAL(d.block(2), 0b0000'1111);
+}
 
-        // The ranged forms: every start and length, whole words and partial ones, against the model.
+// The ranged forms: every start and length, whole words and partial ones, against the model.
+BOOST_AUTO_TEST_CASE_TEMPLATE(TheRangedFormsGoAWordAtATime, T, WordTypes)
+{
+        constexpr auto D = 8UZ;
         for (auto const n : { 0UZ, 1UZ, 7UZ, 8UZ, 9UZ, 15UZ }) {
                 for (auto const len : { 0UZ, 1UZ, D - 1, D, D + 1, 20UZ - n }) {
-                        if (n + len > 20UZ) {
-                                continue;
+                        if (n + len <= 20UZ) {
+                                check_ranged_forms<T>(n, len);
                         }
-                        auto e = make();
-                        auto r = reference(c);
-                        e.set(n, len, true);
-                        for (auto i = n; i < n + len; ++i) { r[i] = true; }
-                        BOOST_CHECK(reference(e) == r);
-                        e.flip(n, len);
-                        for (auto i = n; i < n + len; ++i) { r[i] = not r[i]; }
-                        BOOST_CHECK(reference(e) == r);
-                        e.set(n, len, false);
-                        for (auto i = n; i < n + len; ++i) { r[i] = false; }
-                        BOOST_CHECK(reference(e) == r);
                 }
         }
 }

--- a/test/src/bits/block_sequence.cpp
+++ b/test/src/bits/block_sequence.cpp
@@ -876,4 +876,64 @@ BOOST_AUTO_TEST_CASE(TheAllocatorAndTheMaximumWidth)
         static_assert(A().max_size() == 9UZ);
 }
 
+// A word read and written at any position: aligned, straddling two blocks, in the last block; the ranged forms over it, against a model. [design.md#the-blit]
+using WordTypes = std::tuple<xstd::block_array<std::uint8_t, 20>, xstd::block_vector<std::uint8_t>>;
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(WordsAreReadAndWrittenAtAnyPosition, T, WordTypes)
+{
+        constexpr auto D = 8UZ;
+        auto make = [] {
+                auto b = T();
+                if constexpr (requires { b.resize(20UZ); }) {
+                        b.resize(20UZ);
+                }
+                for (auto const i : { 0UZ, 3UZ, 7UZ, 8UZ, 12UZ, 15UZ, 19UZ }) {
+                        b.set(i);
+                }
+                return b;
+        };
+        auto const c = make();
+        // Blocks: 0b1000'1001, 0b1001'0001, 0b0000'1000.
+        BOOST_CHECK_EQUAL(c.word_at(0UZ),  0b1000'1001);
+        BOOST_CHECK_EQUAL(c.word_at(8UZ),  0b1001'0001);
+        BOOST_CHECK_EQUAL(c.word_at(3UZ),  0b0011'0001);
+        BOOST_CHECK_EQUAL(c.word_at(12UZ), 0b1000'1001);
+        BOOST_CHECK_EQUAL(c.word_at(16UZ), 0b0000'1000);
+        BOOST_CHECK_EQUAL(c.word_at(17UZ), 0b0000'0100);
+
+        // set_word lands the masked bits and nothing else, across two blocks and into the tail, which stays clear.
+        auto d = make();
+        d.set_word(3UZ, 0b1111'1111, 0b0001'1110);
+        auto m = reference(c);
+        for (auto const i : { 4UZ, 5UZ, 6UZ, 7UZ }) { m[i] = true; }
+        BOOST_CHECK(reference(d) == m);
+        d.set_word(5UZ, 0b0000'0000, 0b0111'1000);
+        for (auto const i : { 8UZ, 9UZ, 10UZ, 11UZ }) { m[i] = false; }
+        BOOST_CHECK(reference(d) == m);
+        d.set_word(16UZ, 0b1111'1111, 0b1111'1111);
+        for (auto const i : { 16UZ, 17UZ, 18UZ, 19UZ }) { m[i] = true; }
+        BOOST_CHECK(reference(d) == m);
+        BOOST_CHECK_EQUAL(d.block(2), 0b0000'1111);
+
+        // The ranged forms: every start and length, whole words and partial ones, against the model.
+        for (auto const n : { 0UZ, 1UZ, 7UZ, 8UZ, 9UZ, 15UZ }) {
+                for (auto const len : { 0UZ, 1UZ, D - 1, D, D + 1, 20UZ - n }) {
+                        if (n + len > 20UZ) {
+                                continue;
+                        }
+                        auto e = make();
+                        auto r = reference(c);
+                        e.set(n, len, true);
+                        for (auto i = n; i < n + len; ++i) { r[i] = true; }
+                        BOOST_CHECK(reference(e) == r);
+                        e.flip(n, len);
+                        for (auto i = n; i < n + len; ++i) { r[i] = not r[i]; }
+                        BOOST_CHECK(reference(e) == r);
+                        e.set(n, len, false);
+                        for (auto i = n; i < n + len; ++i) { r[i] = false; }
+                        BOOST_CHECK(reference(e) == r);
+                }
+        }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/bits/dynamic_bitset.cpp
+++ b/test/src/bits/dynamic_bitset.cpp
@@ -108,6 +108,29 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(TheOrderingIsBoosts, T, Dynamic)
                 }
         }
         BOOST_CHECK_EQUAL(disagreements, 0);
+
+        // And across blocks at unequal widths, where the top windows are read a word at a time at either alignment. [design.md#the-blit]
+        using Narrow = xstd::basic_dynamic_bitset<std::uint8_t>;
+        auto wide = 0;
+        for (auto const w : { 0UZ, 3UZ, 8UZ, 9UZ, 16UZ, 17UZ, 25UZ, 70UZ }) {
+                for (auto const u : { 0UZ, 3UZ, 8UZ, 9UZ, 16UZ, 17UZ, 25UZ, 70UZ }) {
+                        for (auto const p : { 0ULL, 1ULL, 0b1010'1010ULL, 0b1'0000'0000ULL, 0xFFFFULL, 0x8001ULL, 0x1F'FFFFULL }) {
+                                for (auto const q : { 0ULL, 1ULL, 0b1010'1010ULL, 0b1'0000'0000ULL, 0xFFFFULL, 0x8001ULL, 0x1F'FFFFULL }) {
+                                        auto x = Narrow(w, p);
+                                        auto y = Narrow(u, q);
+                                        auto bx = boost::dynamic_bitset<std::uint8_t>(w, static_cast<unsigned long>(p));
+                                        auto by = boost::dynamic_bitset<std::uint8_t>(u, static_cast<unsigned long>(q));
+                                        if (w > 64) { x.set(69); bx.set(69); }
+                                        if (u > 64) { y.set(65); by.set(65); }
+                                        auto const cmp = x <=> y;
+                                        wide += static_cast<int>((cmp < 0) != (bx < by));
+                                        wide += static_cast<int>((cmp > 0) != (by < bx));
+                                        wide += static_cast<int>((cmp == 0) != (bx == by));
+                                }
+                        }
+                }
+        }
+        BOOST_CHECK_EQUAL(wide, 0);
 }
 
 // boost's block interface: the block-range constructor, every block out, at most every block in.

--- a/test/src/bits/dynamic_bitset.cpp
+++ b/test/src/bits/dynamic_bitset.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>                              // equal
 #include <array>                                  // array
 #include <concepts>                               // regular, same_as, totally_ordered
+#include <cstddef>                                // size_t
 #include <cstdint>                                // uint8_t, uint64_t
 #include <functional>                             // hash
 #include <iterator>                               // back_inserter
@@ -108,24 +109,44 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(TheOrderingIsBoosts, T, Dynamic)
                 }
         }
         BOOST_CHECK_EQUAL(disagreements, 0);
+}
 
-        // And across blocks at unequal widths, where the top windows are read a word at a time at either alignment. [design.md#the-blit]
+namespace {
+
+// One pair of narrow bitsets against boost's own, at two widths and two patterns; a function rather than a loop body
+// so the case that sweeps it stays under readability-function-cognitive-complexity's threshold.
+auto disagreements_against_boost(std::size_t w, std::size_t u, unsigned long long p, unsigned long long q) -> int
+{
         using Narrow = xstd::basic_dynamic_bitset<std::uint8_t>;
+        auto x  = Narrow(w, p);
+        auto y  = Narrow(u, q);
+        auto bx = boost::dynamic_bitset<std::uint8_t>(w, static_cast<unsigned long>(p));
+        auto by = boost::dynamic_bitset<std::uint8_t>(u, static_cast<unsigned long>(q));
+
+        // Past the sixty-four bits a constructor takes, so the comparison has blocks above them to walk.
+        if (w > 64) { x.set(69); bx.set(69); }
+        if (u > 64) { y.set(65); by.set(65); }
+
+        auto const cmp = x <=> y;
+        return static_cast<int>((cmp <  0) != (bx <  by))
+             + static_cast<int>((cmp >  0) != (by <  bx))
+             + static_cast<int>((cmp == 0) != (bx == by));
+}
+
+}       // namespace
+
+// And across blocks at unequal widths, where the top windows are read a word at a time at either alignment. [design.md#the-blit]
+BOOST_AUTO_TEST_CASE(TheOrderingIsBoostsAcrossBlocksAtUnequalWidths)
+{
+        constexpr auto widths   = std::array{ 0UZ, 3UZ, 8UZ, 9UZ, 16UZ, 17UZ, 25UZ, 70UZ };
+        constexpr auto patterns = std::array{ 0ULL, 1ULL, 0b1010'1010ULL, 0b1'0000'0000ULL, 0xFFFFULL, 0x8001ULL, 0x1F'FFFFULL };
+
         auto wide = 0;
-        for (auto const w : { 0UZ, 3UZ, 8UZ, 9UZ, 16UZ, 17UZ, 25UZ, 70UZ }) {
-                for (auto const u : { 0UZ, 3UZ, 8UZ, 9UZ, 16UZ, 17UZ, 25UZ, 70UZ }) {
-                        for (auto const p : { 0ULL, 1ULL, 0b1010'1010ULL, 0b1'0000'0000ULL, 0xFFFFULL, 0x8001ULL, 0x1F'FFFFULL }) {
-                                for (auto const q : { 0ULL, 1ULL, 0b1010'1010ULL, 0b1'0000'0000ULL, 0xFFFFULL, 0x8001ULL, 0x1F'FFFFULL }) {
-                                        auto x = Narrow(w, p);
-                                        auto y = Narrow(u, q);
-                                        auto bx = boost::dynamic_bitset<std::uint8_t>(w, static_cast<unsigned long>(p));
-                                        auto by = boost::dynamic_bitset<std::uint8_t>(u, static_cast<unsigned long>(q));
-                                        if (w > 64) { x.set(69); bx.set(69); }
-                                        if (u > 64) { y.set(65); by.set(65); }
-                                        auto const cmp = x <=> y;
-                                        wide += static_cast<int>((cmp < 0) != (bx < by));
-                                        wide += static_cast<int>((cmp > 0) != (by < bx));
-                                        wide += static_cast<int>((cmp == 0) != (bx == by));
+        for (auto const w : widths) {
+                for (auto const u : widths) {
+                        for (auto const p : patterns) {
+                                for (auto const q : patterns) {
+                                        wide += disagreements_against_boost(w, u, p, q);
                                 }
                         }
                 }

--- a/test/src/bits/std_bitset/sieve.cpp
+++ b/test/src/bits/std_bitset/sieve.cpp
@@ -1,4 +1,4 @@
-//          Copyright Rein Halbersma 2014-2025.
+//          Copyright Rein Halbersma 2014-2026.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
@@ -12,8 +12,7 @@
 #include <xstd/bits/dynamic_bitset.hpp>           // dynamic_bitset
 #include <xstd/bits/ext/boost/dynamic_bitset.hpp> // dynamic_bitset
 #include <xstd/bits/ext/std/bitset.hpp>           // bitset
-#include <xstd/bits/ext/xstd/bitset.hpp>          // bitset
-#include <xstd/bits/bit_set_view.hpp>          // bit_set_view
+#include <xstd/bits/bit_set_view.hpp>             // bit_set_view
 #include <bitset>                                 // bitset
 #include <cstddef>                                // size_t
 #include <tuple>                                  // tuple
@@ -52,10 +51,16 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(TheSiftedPrimesAndTwinsFormatAsExpected, T, Types)
         );
 }
 
-BOOST_AUTO_TEST_CASE(ATwoBitSieveSiftsToNothing)
+// A two-bit sieve leaves nothing, so sift_primes1 runs its loop to exhaustion; only a run-time width can be that small.
+using Dynamic = std::tuple
+<       boost::dynamic_bitset<>
+,        xstd::basic_dynamic_bitset<std::size_t>
+>;
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(ATwoBitSieveSiftsToNothing, T, Dynamic)
 {
-        // A two-bit sieve leaves nothing, so sift_primes1 runs its loop to exhaustion; only dynamic_bitset can be that small.
-        BOOST_CHECK(xstd::sift_primes1<boost::dynamic_bitset<>>(2).none());
+        auto const primes = xstd::sift_primes1<T>(2);
+        BOOST_CHECK(xstd::bit_set_view(primes).empty());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/bits/std_set/sieve.cpp
+++ b/test/src/bits/std_set/sieve.cpp
@@ -1,4 +1,4 @@
-//          Copyright Rein Halbersma 2014-2025.
+//          Copyright Rein Halbersma 2014-2026.
 // Distributed under the Boost Software License, Version 1.0.
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
@@ -8,6 +8,7 @@
 #include <fmt/ranges.h>                 // IWYU pragma: keep; the range formatters
 #include <opt/set/sieve.hpp>            // filter_twins, sift_primes0, sift_primes1
 #include <test/flat_set.hpp>            // IWYU pragma: keep; TEST_HAS_FLAT_SET
+#include <xstd/bits/bit_set.hpp>        // bit_set
 #include <xstd/bits/bit_static_set.hpp> // bit_static_set
 #include <cstddef>                      // size_t
 #include <set>                          // set
@@ -24,6 +25,7 @@ using Types = std::tuple
 ,       std::flat_set<std::size_t>
 #endif
 ,       xstd::bit_static_set<N>
+,       xstd::bit_set
 >;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(TheSiftedPrimesAndTwinsFormatAsExpected, T, Types)


### PR DESCRIPTION
Step 7d of #80, the range members, in its four parts; closes #84.

## What

- **The blit** (i). `word_at<Traits>(c, pos)` is the block-wide word at any position of any storage the trait reads by block, the one primitive under every unaligned read. `append_range` has two tiers over it: a sequence adaptor of any shape whose trait reads blocks of the destination's block type is read as words at its own alignment and appended a word at a time; anything else is packed a word at a time, boost's `bit_appender`. `insert_range`, `insert` in its four shapes, `emplace` and both `erase`s rebuild head, middle and tail through `first` and `subspan` into a fresh sequence swapped in, so every step runs at the blit's tier and the strong guarantee comes free. `flip()` and the static `swap(reference, reference)` are `[vector.bool]`'s. The bitset order at unequal widths reads its top windows through `word_at` where it walked position by position.
- **Masked words on windows** (ii). `block_sequence::set_word(pos, value, mask)` is the write side of `word_at`; behind it, boost's ranged `set`/`reset`/`flip(pos, len)` go a word at a time, and a window gains `fill` and `&=`, `|=`, `^=`, `-=` from a source of any shape at any alignment, masked over our storage and one position at a time over anything else. A window has no shifts.
- **The sequence contract** (iii). `bit_vector` answers every line of `[vector.bool]`'s synopsis and `bit_array<N>` every line of `[array]`'s, and the test says so as a checklist, asserted on `std::vector<bool>` and `std::array<bool, N>` first so it is known to be honest. The sweep found and added: the allocator on the sequence owner (`allocator_type`, `get_allocator`, the allocator-extended constructors, copy and move included, which `block_sequence` gains beneath), `[vector.erasure]`'s `erase`/`erase_if`, and `std::array`'s list-initialization on the static owner. A view now derives from a comparison-free base, so it stays as incomparable as `std::span`. Not offered: `data()`, the pointer typedefs, the tuple interface; packed bits have no address.
- **The sieve** (iv), #84. Each sieve speaks one vocabulary: the set sieve over any ordered set of integers, the bitset sieve over any bitset through `bit_set_view`; the `legacy_bitset`/`modern_bitset` ladders and `generate_empty` are gone with the absence they papered over. The benches hold dynamic containers only: `bit_set` on the set bench beside `std::set` and `std::flat_set`, `dynamic_bitset` on the bitset bench beside boost's. The tests keep the static types.

One pre-existing crash is recorded rather than fixed: clang 18 and 20 crash on `ours &= foreign_view` inside a requires-expression touching a private accessor, so the source probe is a namespace-scope concept over public typedefs and no test asks the crashing question (design.md `clang-crashes-on-a-foreign-bulk-source`).

## Tests

`bit_vector.cpp`: the blit at every alignment including another block type and the sequence itself, the packing tier, every insert and erase shape, flip and swap, the allocator forms, erasure, and the `[vector.bool]` checklist; `bit_array.cpp`: the `[array]` checklist and list-initialization at every extent; `bit_traits.cpp`: `word_at`; `block_sequence.cpp`: words read and written at every position and the ranged forms against a model; `bit_subspan.cpp`: `fill` over every viewed storage and the combinations at every alignment against a bool model; `dynamic_bitset.cpp`: order across blocks at unequal widths against boost; the two sieve tests over the dynamic types. design.md: `the-blit`, `the-range-members`, `windows`, `the-sequence-contract`, `the-sieve`.

## Validation

The full suite on clang 18, gcc 15 coverage with every touched header at every line and branch, clang-tidy 20 over the headers, libc++ and clang 20 builds of the touched tests, the two benchmarks compile-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v8urscUNYsTMatTSnKb16

---
_Generated by [Claude Code](https://claude.ai/code/session_016v8urscUNYsTMatTSnKb16)_