### PR TITLE
The inplace column: step 7e of #80

### DIFF
--- a/design.md
+++ b/design.md
@@ -767,10 +767,58 @@ to fix.
 
 One header per restricted name, holding its `basic_` form beside it, each over one storage: `bit_set`,
 `bit_vector` and `dynamic_bitset` over `block_vector<Block, Allocator>`, beside `bit_static_set`, `bit_array` and
-`bitset` over `block_array<Block, N>`. The header is the name's home and the only place it is spelled; `bits.hpp`
-includes them all. Each static name has an `aligned` form in the namespace of that name, in both layers, its
-width rounded up to whole blocks so that no block carries an unused tail: `aligned::bitset<9>` is `bitset<64>`
-and `aligned::basic_bitset<9, std::uint8_t>` is `basic_bitset<16, std::uint8_t>`.
+`bitset` over `block_array<Block, N>`, and `bit_inplace_set`, `bit_inplace_vector` and `inplace_bitset` over
+`block_inplace_vector<Block, N>` ([the-inplace-column](#the-inplace-column)). The header is the name's home and
+the only place it is spelled; `bits.hpp` includes them all. Each static name has an `aligned` form in the
+namespace of that name, in both layers, its width rounded up to whole blocks so that no block carries an unused
+tail: `aligned::bitset<9>` is `bitset<64>` and `aligned::basic_bitset<9, std::uint8_t>` is
+`basic_bitset<16, std::uint8_t>`. The inplace column has no `aligned` form, its `N` being a capacity the storage
+already rounds up rather than a width to round.
+
+### the-inplace-column
+
+The third storage point gets public names, one per reading and each an alias like every other name below the
+adaptors: `basic_bit_inplace_set<N, Block>`, `basic_bit_inplace_vector<N, Block>` and
+`basic_inplace_bitset<N, Block>` over `block_inplace_vector<Block, N>`, with `bit_inplace_set<N>`,
+`bit_inplace_vector<N>` and `inplace_bitset<N>` at the machine word. `inplace_bitset` takes no `bit_` prefix
+because `bitset` already carries the word, and `inplace` is one storage word down each column rather than a
+second vocabulary for the same thing.
+
+`N` is a **capacity** in bits here, where the static column's `N` is a width. The names carry that and the
+parameter lists do not, which is the same hazard `bit_static_set<N, Block>` and `bit_inplace_set<N, Block>`
+share by shape. The capacity is rounded up to whole blocks by `block_inplace_vector` itself, so
+`basic_bit_inplace_vector<9, std::uint8_t>` holds sixteen bits; the width under it is a run-time one and carries
+an unused tail like any other.
+
+The whole column sits behind `__cpp_lib_inplace_vector`, in practice libstdc++ >= 16, which the matrix carries on
+gcc 16 and 17-SVN. An alias adds no capability, so the guard withholds a name rather than a feature, and each
+header's includes sit inside the guard too: on a library without the storage the header is its include guard and
+nothing else. Growth past the capacity throws `std::bad_alloc`, which is `std::inplace_vector`'s own answer
+reaching the caller unchanged; on the set reading that is where `insert` stops being total.
+
+P0843 declined to repeat `vector<bool>`, so there is no `std::inplace_vector<bool>` to check a packed sequence
+against. `test::sequence::inplace_vector_bool` is `[vector.bool]`'s checklist minus the lines the allocator
+reaches, and `std::vector<bool>` answers every line of it, so it is asserted on the model first exactly as
+`vector_bool` is ([the-sequence-contract](#the-sequence-contract)).
+
+`max_size()` splits by reading here, visibly rather than newly. The set and sequence readings report what a
+growing width can reach -- `numeric_limits<size_t>::max() - 1` and `numeric_limits<size_t>::max()`, the address
+space rather than any storage -- which is what their own tests pin at a run-time width and what the heap-backed
+pair report too. The bitset reading forwards to `block_sequence::max_size()`, which asks the blocks, because
+`boost::dynamic_bitset::max_size()` is a member a strict extension owes ([a-strict-extension](#a-strict-extension)).
+So `inplace_bitset<24>` answers 24 and `bit_inplace_vector<24>` answers the address space, and the capacity is
+`capacity()` on the sequence and bitset readings. The set reading has neither, `std::set` having no `capacity()`
+and a set growing by `insert` ([growth](#growth)), so there a capacity is only ever felt at the throw.
+
+The column is not swept over `xstd::uint128`, and that is the storage's property rather than the names': a
+16-byte-aligned block after `block_sequence`'s `std::size_t` width pads the class, which `-Wpadded` reports and
+`-Werror` rejects. Neither other column reaches it -- a static width carries no width member at all, and
+`std::vector`'s alignment is a pointer's -- so the combination is `block_inplace_vector<xstd::uint128, N>`'s and
+predates these aliases. The tests grade the column over the machine word, where the arithmetic that is its own
+follows `digits` and not the carrier.
+
+Every leg without the storage compiles each of the three tests' `#else` arm, one case asserting the absence,
+because a Boost.Test module whose test tree is empty is a setup error rather than a pass.
 
 ### width-is-capacity
 

--- a/design.md
+++ b/design.md
@@ -46,6 +46,21 @@ padding where in truth the sole block is all of it — and it gets a selection i
 answers C4293, *shift count too big*, on the arm it discards. `used_bits()` is the same two cases at a
 run-time width.
 
+The width member takes the blocks' alignment where they out-align a `std::size_t`:
+
+```cpp
+using width_type = std::conditional_t<(alignof(std::size_t) >= alignof(Blocks)), std::size_t, block_type>;
+```
+
+Only a storage holding its blocks inline out-aligns a `size_t`, and it does so by the blocks' own alignment, so
+`block_type` is both wide enough to hold any width and exactly the size of the gap it fills -- `block_sequence`
+is then its two members and nothing else, at the same size the padding cost. `std::array` reaches none of this,
+a static width carrying no member at all, and neither does `std::vector`, whose alignment is a pointer's whatever
+it holds; `block_inplace_vector<xstd::uint128, N>` is the one cell that does. The `static_assert` beside the
+alias holds the two facts that make `block_type` the right carrier, so a storage over-aligned for some other
+reason fails loudly rather than truncating a width. Every reader goes through `size()`, which converts once, so
+the arithmetic stays a `size_t`'s.
+
 ### default-construction
 
 A defaulted default constructor plus an NSDMI, rather than two constructors constrained on the extent:
@@ -810,12 +825,11 @@ So `inplace_bitset<24>` answers 24 and `bit_inplace_vector<24>` answers the addr
 `capacity()` on the sequence and bitset readings. The set reading has neither, `std::set` having no `capacity()`
 and a set growing by `insert` ([growth](#growth)), so there a capacity is only ever felt at the throw.
 
-The column is not swept over `xstd::uint128`, and that is the storage's property rather than the names': a
-16-byte-aligned block after `block_sequence`'s `std::size_t` width pads the class, which `-Wpadded` reports and
-`-Werror` rejects. Neither other column reaches it -- a static width carries no width member at all, and
-`std::vector`'s alignment is a pointer's -- so the combination is `block_inplace_vector<xstd::uint128, N>`'s and
-predates these aliases. The tests grade the column over the machine word, where the arithmetic that is its own
-follows `digits` and not the carrier.
+The column is graded over every block the other two are, `xstd::uint128` included, which it can be because the
+width member now carries its own alignment ([padding](#padding)). Before that, a 16-byte-aligned block after a
+`std::size_t` width padded the class, and `-Wpadded` under `-Werror` rejected it; the inplace column was the only
+cell that could reach it, a static width carrying no width member at all and `std::vector`'s alignment being a
+pointer's whatever it holds.
 
 Every leg without the storage compiles each of the three tests' `#else` arm, one case asserting the absence,
 because a Boost.Test module whose test tree is empty is a setup error rather than a pass.

--- a/include/xstd/bits.hpp
+++ b/include/xstd/bits.hpp
@@ -7,20 +7,23 @@
 #define XSTD_BITS_HPP
 
 // The umbrella over every container; not the ext adaptors, which would put Boost on every consumer path.
-#include <xstd/bits/sequence_adaptor.hpp> // IWYU pragma: export; sequence_adaptor
-#include <xstd/bits/set_adaptor.hpp>      // IWYU pragma: export; set_adaptor
-#include <xstd/bits/bitset_adaptor.hpp>   // IWYU pragma: export; bitset_adaptor, has_bitops
-#include <xstd/bits/bit_array.hpp>        // IWYU pragma: export; bit_array
-#include <xstd/bits/bit_proxy.hpp>        // IWYU pragma: export; bit_set_iterator, bit_set_reference, bit_sequence_iterator, bit_sequence_reference
-#include <xstd/bits/bit_set.hpp>          // IWYU pragma: export; bit_set
-#include <xstd/bits/bit_set_view.hpp>     // IWYU pragma: export; bit_set_view
-#include <xstd/bits/bit_span.hpp>         // IWYU pragma: export; bit_span
-#include <xstd/bits/bit_static_set.hpp>   // IWYU pragma: export; bit_static_set
-#include <xstd/bits/bit_subspan.hpp>      // IWYU pragma: export; bit_subspan
-#include <xstd/bits/bit_vector.hpp>       // IWYU pragma: export; bit_vector
-#include <xstd/bits/bitset.hpp>           // IWYU pragma: export; bitset
-#include <xstd/bits/block_sequence.hpp>   // IWYU pragma: export; block_sequence, block_array, block_inplace_vector, block_vector
-#include <xstd/bits/dynamic_bitset.hpp>   // IWYU pragma: export; dynamic_bitset
-#include <xstd/bits/ownership.hpp>        // IWYU pragma: export; ownership
+#include <xstd/bits/sequence_adaptor.hpp>   // IWYU pragma: export; sequence_adaptor
+#include <xstd/bits/set_adaptor.hpp>        // IWYU pragma: export; set_adaptor
+#include <xstd/bits/bitset_adaptor.hpp>     // IWYU pragma: export; bitset_adaptor, has_bitops
+#include <xstd/bits/bit_array.hpp>          // IWYU pragma: export; bit_array
+#include <xstd/bits/bit_inplace_set.hpp>    // IWYU pragma: export; bit_inplace_set
+#include <xstd/bits/bit_inplace_vector.hpp> // IWYU pragma: export; bit_inplace_vector
+#include <xstd/bits/bit_proxy.hpp>          // IWYU pragma: export; bit_set_iterator, bit_set_reference, bit_sequence_iterator, bit_sequence_reference
+#include <xstd/bits/bit_set.hpp>            // IWYU pragma: export; bit_set
+#include <xstd/bits/bit_set_view.hpp>       // IWYU pragma: export; bit_set_view
+#include <xstd/bits/bit_span.hpp>           // IWYU pragma: export; bit_span
+#include <xstd/bits/bit_static_set.hpp>     // IWYU pragma: export; bit_static_set
+#include <xstd/bits/bit_subspan.hpp>        // IWYU pragma: export; bit_subspan
+#include <xstd/bits/bit_vector.hpp>         // IWYU pragma: export; bit_vector
+#include <xstd/bits/bitset.hpp>             // IWYU pragma: export; bitset
+#include <xstd/bits/block_sequence.hpp>     // IWYU pragma: export; block_sequence, block_array, block_inplace_vector, block_vector
+#include <xstd/bits/dynamic_bitset.hpp>     // IWYU pragma: export; dynamic_bitset
+#include <xstd/bits/inplace_bitset.hpp>     // IWYU pragma: export; inplace_bitset
+#include <xstd/bits/ownership.hpp>          // IWYU pragma: export; ownership
 
 #endif // XSTD_BITS_HPP

--- a/include/xstd/bits/bit_inplace_set.hpp
+++ b/include/xstd/bits/bit_inplace_set.hpp
@@ -1,0 +1,32 @@
+//          Copyright Rein Halbersma 2014-2026.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef XSTD_BITS_BIT_INPLACE_SET_HPP
+#define XSTD_BITS_BIT_INPLACE_SET_HPP
+
+#include <version>                                         // IWYU pragma: keep; __cpp_lib_inplace_vector
+
+// The column comes and goes with its storage, and an alias withholds a name rather than a capability. [design.md#the-inplace-column]
+#ifdef __cpp_lib_inplace_vector
+#include <xstd/bits/set_adaptor.hpp>                       // set_adaptor
+#include <xstd/bits/block_sequence.hpp>                    // block_inplace_vector
+#include <xstd/bits/ownership.hpp>                         // ownership
+#include <xstd/ints/concepts/unsigned_integer.hpp>         // unsigned_integer
+#include <cstddef>                                         // size_t
+
+namespace xstd {
+
+// The set reading over a run-time width under a compile-time capacity: inplace names where the storage lives. [design.md#the-public-names]
+template<std::size_t N, xstd::unsigned_integer Block>
+using basic_bit_inplace_set = set_adaptor<block_inplace_vector<Block, N>, ownership::owns>;
+
+template<std::size_t N>
+using bit_inplace_set = basic_bit_inplace_set<N, std::size_t>;
+
+}       // namespace xstd
+
+#endif  // __cpp_lib_inplace_vector
+
+#endif  // XSTD_BITS_BIT_INPLACE_SET_HPP

--- a/include/xstd/bits/bit_inplace_vector.hpp
+++ b/include/xstd/bits/bit_inplace_vector.hpp
@@ -1,0 +1,32 @@
+//          Copyright Rein Halbersma 2014-2026.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef XSTD_BITS_BIT_INPLACE_VECTOR_HPP
+#define XSTD_BITS_BIT_INPLACE_VECTOR_HPP
+
+#include <version>                                         // IWYU pragma: keep; __cpp_lib_inplace_vector
+
+// The column comes and goes with its storage, and an alias withholds a name rather than a capability. [design.md#the-inplace-column]
+#ifdef __cpp_lib_inplace_vector
+#include <xstd/bits/sequence_adaptor.hpp>                  // sequence_adaptor
+#include <xstd/bits/block_sequence.hpp>                    // block_inplace_vector
+#include <xstd/bits/ownership.hpp>                         // ownership
+#include <xstd/ints/concepts/unsigned_integer.hpp>         // unsigned_integer
+#include <cstddef>                                         // size_t
+
+namespace xstd {
+
+// The packed std::inplace_vector<bool, N> that P0843 declined to write, named after the container it packs. [design.md#the-public-names]
+template<std::size_t N, xstd::unsigned_integer Block>
+using basic_bit_inplace_vector = sequence_adaptor<block_inplace_vector<Block, N>, ownership::owns, false>;
+
+template<std::size_t N>
+using bit_inplace_vector = basic_bit_inplace_vector<N, std::size_t>;
+
+}       // namespace xstd
+
+#endif  // __cpp_lib_inplace_vector
+
+#endif  // XSTD_BITS_BIT_INPLACE_VECTOR_HPP

--- a/include/xstd/bits/block_sequence.hpp
+++ b/include/xstd/bits/block_sequence.hpp
@@ -76,6 +76,13 @@ private:
         static constexpr auto zero     = static_cast<block_type>( 0);
         static constexpr auto ones     = static_cast<block_type>(-1);
 
+        // The width is a size_t, unless the blocks out-align one: then it is a block, which fills what would
+        // otherwise be padding in front of them. Only a storage holding its blocks inline out-aligns a size_t,
+        // and it does so by their alignment, so a block is both wide enough to hold any width and exactly the
+        // size the gap is. [design.md#padding]
+        using width_type = std::conditional_t<(alignof(std::size_t) >= alignof(Blocks)), std::size_t, block_type>;
+        static_assert(sizeof(width_type) >= sizeof(std::size_t) and alignof(width_type) >= alignof(Blocks));
+
         // Width zero named, not computed: MSVC folds both ?: arms and answers C4293. [design.md#padding]
         static constexpr auto static_num_unused_bits = has_static_size ? static_num_bits - N : 0UZ;
         static constexpr auto static_used_bits       = has_static_size and N == 0 ? zero : static_cast<block_type>(ones >> static_num_unused_bits);
@@ -102,7 +109,7 @@ private:
         // Dynamic widths only; the tag keeps the absent member distinct from any other in an enclosing layout.
         // Declared first, so the defaulted == rejects on the width before it reads a block. [design.md#block-storage]
         [[XSTD_NO_UNIQUE_ADDRESS]]
-        conditional_data_member_t<not has_static_size, std::size_t, struct size_tag> m_size{};
+        conditional_data_member_t<not has_static_size, width_type, struct size_tag> m_size{};
 
         Blocks m_blocks = make_blocks(0UZ);
 
@@ -175,7 +182,7 @@ public:
                 if constexpr (has_static_size) {
                         return N;
                 } else {
-                        return m_size;
+                        return static_cast<std::size_t>(m_size);
                 }
         }
 
@@ -626,7 +633,7 @@ public:
                 requires (not has_static_size)
         {
                 // Growing with ones: the tail above size() in the last block is clear by the invariant, and becomes the first new bits.
-                if (value and n > m_size) {
+                if (value and n > size()) {
                         m_blocks[last_block()] |= static_cast<block_type>(~used_bits());
                 }
                 m_blocks.resize(blocks_for(n), value ? ones : zero);
@@ -644,25 +651,25 @@ public:
         constexpr void push_back(bool value)
                 requires (not has_static_size)
         {
-                resize(m_size + 1UZ, value);
+                resize(size() + 1UZ, value);
         }
 
         constexpr void pop_back()
                 requires (not has_static_size)
         {
-                assert(m_size != 0UZ);
-                resize(m_size - 1UZ);
+                assert(size() != 0UZ);
+                resize(size() - 1UZ);
         }
 
         // Boost's append: the block's bits become the positions [size(), size() + bits_per_block), split over two blocks where size() is not aligned.
         constexpr void append(block_type value)
                 requires (not has_static_size)
         {
-                auto const offset = m_size % bits_per_block;
+                auto const offset = size() % bits_per_block;
                 if (offset != 0UZ) {
                         m_blocks[last_block()] |= static_cast<block_type>(value << offset);
                         m_blocks.push_back(static_cast<block_type>(value >> (bits_per_block - offset)));
-                } else if (m_size != 0UZ) {
+                } else if (size() != 0UZ) {
                         m_blocks.push_back(value);
                 } else {
                         // The floor block is the fresh one.
@@ -677,7 +684,7 @@ public:
                 requires (not has_static_size)
         {
                 if constexpr (std::forward_iterator<I> and requires (Blocks& b) { b.reserve(0UZ); }) {
-                        reserve(m_size + (static_cast<std::size_t>(std::ranges::distance(first, last)) * bits_per_block));
+                        reserve(size() + (static_cast<std::size_t>(std::ranges::distance(first, last)) * bits_per_block));
                 }
                 for (; first != last; ++first) {
                         append(*first);

--- a/include/xstd/bits/inplace_bitset.hpp
+++ b/include/xstd/bits/inplace_bitset.hpp
@@ -1,0 +1,31 @@
+//          Copyright Rein Halbersma 2014-2026.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef XSTD_BITS_INPLACE_BITSET_HPP
+#define XSTD_BITS_INPLACE_BITSET_HPP
+
+#include <version>                                         // IWYU pragma: keep; __cpp_lib_inplace_vector
+
+// The column comes and goes with its storage, and an alias withholds a name rather than a capability. [design.md#the-inplace-column]
+#ifdef __cpp_lib_inplace_vector
+#include <xstd/bits/bitset_adaptor.hpp>                    // bitset_adaptor
+#include <xstd/bits/block_sequence.hpp>                    // block_inplace_vector
+#include <xstd/ints/concepts/unsigned_integer.hpp>         // unsigned_integer
+#include <cstddef>                                         // size_t
+
+namespace xstd {
+
+// A resizable bitset that never allocates, which is what embedded code asks for; no bit_ prefix, bitset already carrying the word. [design.md#the-public-names]
+template<std::size_t N, xstd::unsigned_integer Block>
+using basic_inplace_bitset = bitset_adaptor<block_inplace_vector<Block, N>>;
+
+template<std::size_t N>
+using inplace_bitset = basic_inplace_bitset<N, std::size_t>;
+
+}       // namespace xstd
+
+#endif  // __cpp_lib_inplace_vector
+
+#endif  // XSTD_BITS_INPLACE_BITSET_HPP

--- a/test/include/test/sequence/concepts.hpp
+++ b/test/include/test/sequence/concepts.hpp
@@ -133,11 +133,60 @@ concept vector_bool = container_members<C> and requires (C c, C o, C const cc, t
         { std::hash<C>()(cc) } -> std::same_as<std::size_t>;
 };
 
+// [vector.bool] minus the allocator, which is every line a fixed-capacity sequence can answer. P0843 declined a bool
+// specialization, so this checklist has no inplace model of its own and std::vector<bool> stands in for the lines it shares.
+template<class C>
+concept inplace_vector_bool = container_members<C> and requires (C c, C o, C const cc, typename C::size_type n, bool b, std::initializer_list<bool> il, bool const* first, bool const* last, typename C::const_iterator p) {
+        C();
+        C(n);
+        C(n, b);
+        C(first, last);
+        C(cc);
+        C(std::move(o));
+        C(il);
+        c = cc;
+        c = std::move(o);
+        c = il;
+        c.assign(first, last);
+        c.assign(n, b);
+        c.assign(il);
+        { cc.capacity()      } -> std::same_as<typename C::size_type>;
+        c.resize(n);
+        c.resize(n, b);
+        c.reserve(n);
+        c.shrink_to_fit();
+        { c.emplace_back(b)  } -> std::same_as<typename C::reference>;
+        c.push_back(b);
+        c.pop_back();
+        { c.emplace(p, b)             } -> std::same_as<typename C::iterator>;
+        { c.insert(p, b)              } -> std::same_as<typename C::iterator>;
+        { c.insert(p, n, b)           } -> std::same_as<typename C::iterator>;
+        { c.insert(p, first, last)    } -> std::same_as<typename C::iterator>;
+        { c.insert(p, il)             } -> std::same_as<typename C::iterator>;
+        { c.erase(p)                  } -> std::same_as<typename C::iterator>;
+        { c.erase(p, p)               } -> std::same_as<typename C::iterator>;
+        c.clear();
+        c.flip();
+        C::swap(c[n], c[n]);
+        { erase(c, b)                          } -> std::same_as<typename C::size_type>;
+        { erase_if(c, [](bool) { return true; }) } -> std::same_as<typename C::size_type>;
+        { std::hash<C>()(cc) } -> std::same_as<std::size_t>;
+};
+
 // [vector.bool]'s C++23 lines, apart so the model can be held to them where its standard library has them (__cpp_lib_containers_ranges).
 template<class C, class A = C::allocator_type>
 concept vector_bool_ranges = requires (C c, A a, std::initializer_list<bool> il, typename C::const_iterator p) {
         C(std::from_range, il);
         C(std::from_range, il, a);
+        c.assign_range(il);
+        { c.insert_range(p, il) } -> std::same_as<typename C::iterator>;
+        c.append_range(il);
+};
+
+// The same lines without the allocator-extended constructor, for the column that has no allocator to extend them with.
+template<class C>
+concept inplace_vector_bool_ranges = requires (C c, std::initializer_list<bool> il, typename C::const_iterator p) {
+        C(std::from_range, il);
         c.assign_range(il);
         { c.insert_range(p, il) } -> std::same_as<typename C::iterator>;
         c.append_range(il);

--- a/test/src/bits.cpp
+++ b/test/src/bits.cpp
@@ -6,6 +6,7 @@
 #include <boost/test/unit_test.hpp>   // BOOST_AUTO_TEST_CASE
 #include <test/block_types.hpp>       // graded_extents
 #include <test/flat_set.hpp>          // IWYU pragma: keep; TEST_HAS_FLAT_SET
+#include <test/inplace_vector.hpp>    // IWYU pragma: keep; TEST_HAS_INPLACE_VECTOR
 #include <test/sequence/concepts.hpp> // bit_sequence
 #include <test/set/concepts.hpp>      // bit_set
 #include <xstd/bits.hpp>              // the whole bits surface
@@ -52,7 +53,17 @@ BOOST_AUTO_TEST_CASE(EveryContainerArrivesThroughTheUmbrella)
         static_assert(std::same_as<xstd::bit_vector,     xstd::basic_bit_vector<std::size_t, std::allocator<std::size_t>>>);
         static_assert(std::same_as<xstd::dynamic_bitset, xstd::basic_dynamic_bitset<std::size_t, std::allocator<std::size_t>>>);
 
-        // Every static name has an aligned form in both layers, its width rounded up to whole blocks. [design.md#the-public-names]
+#ifdef TEST_HAS_INPLACE_VECTOR
+        // The inplace column, the third storage point, one name per reading and every one of them an alias like the rest. [design.md#the-inplace-column]
+        static_assert(std::ranges::bidirectional_range<xstd::basic_bit_inplace_set<8, std::uint8_t>>);
+        static_assert(std::ranges::random_access_range<xstd::basic_bit_inplace_vector<8, std::uint8_t>>);
+        static_assert(not std::ranges::range<xstd::basic_inplace_bitset<8, std::uint8_t>>);
+        static_assert(std::same_as<xstd::bit_inplace_set<8>,    xstd::basic_bit_inplace_set<8, std::size_t>>);
+        static_assert(std::same_as<xstd::bit_inplace_vector<8>, xstd::basic_bit_inplace_vector<8, std::size_t>>);
+        static_assert(std::same_as<xstd::inplace_bitset<8>,     xstd::basic_inplace_bitset<8, std::size_t>>);
+#endif
+
+        // Every static name has an aligned form in both layers, its width rounded up to whole blocks; the inplace column has none, its capacity already being whole blocks. [design.md#the-public-names]
         static_assert(std::same_as<xstd::aligned::bit_static_set<9>, xstd::bit_static_set<std::numeric_limits<std::size_t>::digits>>);
         static_assert(std::same_as<xstd::aligned::bit_array<9>,      xstd::bit_array<std::numeric_limits<std::size_t>::digits>>);
         static_assert(std::same_as<xstd::aligned::bitset<9>,         xstd::bitset<std::numeric_limits<std::size_t>::digits>>);

--- a/test/src/bits.cpp
+++ b/test/src/bits.cpp
@@ -87,6 +87,14 @@ BOOST_AUTO_TEST_CASE(APackedArrayIsTheArrayItPacks)
         [] <std::size_t... I> (std::index_sequence<I...>) {
                 static_assert((bit_sequence<std::tuple_element_t<I, packed>> and ...));
         }(std::make_index_sequence<std::tuple_size_v<packed>>{});
+
+#ifdef TEST_HAS_INPLACE_VECTOR
+        // Storage is the second dimension of the grading: the same claim over the same extents, read as capacities. [design.md#the-inplace-column]
+        using inplace = test::graded_extents<xstd::basic_bit_inplace_vector>;
+        [] <std::size_t... I> (std::index_sequence<I...>) {
+                static_assert((bit_sequence<std::tuple_element_t<I, inplace>> and ...));
+        }(std::make_index_sequence<std::tuple_size_v<inplace>>{});
+#endif
 }
 
 // The same claim on the other reading: a set of keys and a sequence of bools are different interfaces.
@@ -104,4 +112,12 @@ BOOST_AUTO_TEST_CASE(APackedSetIsTheSetItPacks)
         [] <std::size_t... I> (std::index_sequence<I...>) {
                 static_assert((bit_set<std::tuple_element_t<I, packed>> and ...));
         }(std::make_index_sequence<std::tuple_size_v<packed>>{});
+
+#ifdef TEST_HAS_INPLACE_VECTOR
+        // And the same second dimension on this reading. [design.md#the-inplace-column]
+        using inplace = test::graded_extents<xstd::basic_bit_inplace_set>;
+        [] <std::size_t... I> (std::index_sequence<I...>) {
+                static_assert((bit_set<std::tuple_element_t<I, inplace>> and ...));
+        }(std::make_index_sequence<std::tuple_size_v<inplace>>{});
+#endif
 }

--- a/test/src/bits/bit_inplace_set.cpp
+++ b/test/src/bits/bit_inplace_set.cpp
@@ -1,0 +1,111 @@
+//          Copyright Rein Halbersma 2014-2026.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/test/unit_test.hpp>              // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL, BOOST_CHECK_THROW
+#include <test/inplace_vector.hpp>               // IWYU pragma: keep; TEST_HAS_INPLACE_VECTOR, has_inplace_vector
+#ifdef TEST_HAS_INPLACE_VECTOR
+#include <test/set/concepts.hpp>                 // bit_set
+#include <xstd/bits/set_adaptor.hpp>             // set_adaptor
+#include <xstd/bits/bit_inplace_set.hpp>         // basic_bit_inplace_set, bit_inplace_set
+#include <xstd/bits/block_sequence.hpp>          // block_inplace_vector
+#include <xstd/bits/ownership.hpp>               // ownership
+#include <algorithm>                             // equal
+#include <concepts>                              // same_as
+#include <cstddef>                               // size_t
+#include <cstdint>                               // uint8_t
+#include <limits>                                // numeric_limits
+#include <new>                                   // bad_alloc
+#include <ranges>                                // iota, to
+#include <set>                                   // set
+#endif
+
+BOOST_AUTO_TEST_SUITE(BitInplaceSet)
+
+#ifdef TEST_HAS_INPLACE_VECTOR
+
+// A capacity of three whole blocks, so a key can sit past the width and still inside the capacity.
+using T = xstd::basic_bit_inplace_set<24, std::uint8_t>;
+
+// Dependent, so an absent member is a false rather than a hard error.
+template<class X>
+constexpr bool has_capacity = requires (X const& x) { x.capacity(); };
+
+// The set reading over a run-time width under a compile-time capacity, an alias and nothing more. [design.md#the-public-names]
+BOOST_AUTO_TEST_CASE(TheInplaceSetIsTheSetAdaptorOverAnInplaceVectorOfBlocks)
+{
+        static_assert(std::same_as<T, xstd::set_adaptor<xstd::block_inplace_vector<std::uint8_t, 24>, xstd::ownership::owns>>);
+        static_assert(std::same_as<xstd::bit_inplace_set<24>, xstd::basic_bit_inplace_set<24, std::size_t>>);
+        static_assert(test::set::bit_set<T>);
+}
+
+// Built from a range as std::set is, and ordered as std::set is.
+BOOST_AUTO_TEST_CASE(ItIsBuiltAndOrderedLikeAStdSet)
+{
+        auto const s = std::views::iota(0UZ, 24UZ) | std::views::filter([](auto i) { return i % 5 == 0; }) | std::ranges::to<T>();
+        auto const k = std::views::iota(0UZ, 24UZ) | std::views::filter([](auto i) { return i % 5 == 0; }) | std::ranges::to<std::set<std::size_t>>();
+        BOOST_CHECK(std::ranges::equal(s, k));
+        BOOST_CHECK_EQUAL(s.size(), k.size());
+}
+
+// A key past the width grows the width, exactly as the heap-backed set does, until the capacity stops it. [design.md#asking-is-total]
+BOOST_AUTO_TEST_CASE(InsertingPastTheWidthGrowsItUpToTheCapacity)
+{
+        auto s = T();
+        BOOST_CHECK(s.empty());
+
+        auto const [ where, inserted ] = s.insert(20);
+        BOOST_CHECK(inserted);
+        BOOST_CHECK(*where == 20UZ);
+        BOOST_CHECK(s.contains(20));
+        BOOST_CHECK_EQUAL(s.size(), 1UZ);
+
+        // Below the capacity but above the width, lookups stay total and answer no.
+        BOOST_CHECK(not s.contains(23));
+        BOOST_CHECK_EQUAL(s.erase(23), 0UZ);
+}
+
+// Past the capacity there is nowhere to grow, and the storage's bad_alloc reaches the caller. [design.md#growth]
+BOOST_AUTO_TEST_CASE(InsertingPastTheCapacityThrowsBadAlloc)
+{
+        auto s = T();
+
+        // max_size() is the key domain a growing width admits, as it is on the heap-backed set; the capacity is
+        // felt at the throw below rather than reported. [design.md#the-inplace-column]
+        BOOST_CHECK_EQUAL(T::max_size(), std::numeric_limits<std::size_t>::max() - 1UZ);
+        static_assert(not has_capacity<T>);
+        BOOST_CHECK_THROW(s.insert(24), std::bad_alloc);
+
+        // The failed insert left the set empty, and a key past the capacity is still answerable.
+        BOOST_CHECK(s.empty());
+        BOOST_CHECK(not s.contains(24));
+        BOOST_CHECK(s.find(24) == s.end());  // NOLINT(readability-container-contains)
+}
+
+// Width is capacity here as it is on the heap: two sets holding the same keys are equal whatever their widths. [design.md#width-is-capacity]
+BOOST_AUTO_TEST_CASE(EqualSetsCompareEqualAtUnequalWidths)
+{
+        auto narrow = T();
+        auto wide   = T();
+
+        narrow.insert(3);
+        wide.insert(20);
+        wide.erase(20);
+        wide.insert(3);
+
+        BOOST_CHECK(narrow == wide);
+        BOOST_CHECK(not (narrow < wide) and not (wide < narrow));
+}
+
+#else
+
+// The column is its storage's: without std::inplace_vector there is no name to test, and saying so keeps the source from being empty. [design.md#the-inplace-column]
+BOOST_AUTO_TEST_CASE(TheColumnIsAbsentWithItsStorage)
+{
+        static_assert(not test::has_inplace_vector);
+}
+
+#endif
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/bits/bit_inplace_vector.cpp
+++ b/test/src/bits/bit_inplace_vector.cpp
@@ -1,0 +1,110 @@
+//          Copyright Rein Halbersma 2014-2026.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/test/unit_test.hpp>              // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL, BOOST_CHECK_THROW
+#include <test/inplace_vector.hpp>               // IWYU pragma: keep; TEST_HAS_INPLACE_VECTOR, has_inplace_vector
+#ifdef TEST_HAS_INPLACE_VECTOR
+#include <test/sequence/concepts.hpp>            // bit_sequence, inplace_vector_bool, inplace_vector_bool_ranges
+#include <xstd/bits/sequence_adaptor.hpp>        // sequence_adaptor
+#include <xstd/bits/bit_inplace_vector.hpp>      // basic_bit_inplace_vector, bit_inplace_vector
+#include <xstd/bits/block_sequence.hpp>          // block_inplace_vector
+#include <xstd/bits/ownership.hpp>               // ownership
+#include <algorithm>                             // equal
+#include <concepts>                              // same_as
+#include <cstddef>                               // size_t
+#include <cstdint>                               // uint8_t
+#include <limits>                                // numeric_limits
+#include <new>                                   // bad_alloc
+#include <ranges>                                // count, iota, to, transform
+#include <vector>                                // vector
+#endif
+
+BOOST_AUTO_TEST_SUITE(BitInplaceVector)
+
+#ifdef TEST_HAS_INPLACE_VECTOR
+
+// A capacity of three whole blocks, so the width can straddle a boundary and still stop short of the capacity.
+using T = xstd::basic_bit_inplace_vector<24, std::uint8_t>;
+
+// Dependent, so an absent typedef is a false rather than a hard error.
+template<class X>
+constexpr bool has_allocator = requires { typename X::allocator_type; };
+
+// The sequence reading over a run-time width under a compile-time capacity, an alias and nothing more. [design.md#the-public-names]
+BOOST_AUTO_TEST_CASE(TheInplaceSequenceIsTheSequenceAdaptorOverAnInplaceVectorOfBlocks)
+{
+        static_assert(std::same_as<T, xstd::sequence_adaptor<xstd::block_inplace_vector<std::uint8_t, 24>, xstd::ownership::owns, false>>);
+        static_assert(std::same_as<xstd::bit_inplace_vector<24>, xstd::basic_bit_inplace_vector<24, std::size_t>>);
+        static_assert(test::sequence::bit_sequence<T>);
+}
+
+// Every line of [vector.bool] the allocator does not reach, the model first so the checklist is known to be honest. [design.md#the-inplace-column]
+BOOST_AUTO_TEST_CASE(ItAnswersEveryLineOfStdVectorBoolButTheAllocator)
+{
+        static_assert(test::sequence::inplace_vector_bool<std::vector<bool>>);
+        static_assert(test::sequence::inplace_vector_bool<T>);
+        static_assert(test::sequence::inplace_vector_bool<xstd::bit_inplace_vector<24>>);
+        static_assert(test::sequence::inplace_vector_bool_ranges<T>);
+
+        // The allocator is the storage's, and this storage has none: the checklist that asks for one does not apply.
+        static_assert(has_allocator<std::vector<bool>>);
+        static_assert(not has_allocator<T>);
+}
+
+// The blocks are whole, so the capacity is the requested one rounded up, and the width moves under it. [design.md#the-inplace-column]
+BOOST_AUTO_TEST_CASE(TheCapacityIsTheRequestedOneRoundedUpToWholeBlocks)
+{
+        static_assert(xstd::basic_bit_inplace_vector<9, std::uint8_t>().capacity() == 16UZ);
+
+        auto v = T();
+        BOOST_CHECK_EQUAL(v.capacity(), 24UZ);
+        BOOST_CHECK(v.empty());
+
+        // max_size() is the address space's wherever a width grows, as it is on the heap-backed sequence; the capacity
+        // is capacity(), and where it bites is the throw below. [design.md#the-inplace-column]
+        BOOST_CHECK_EQUAL(v.max_size(), std::numeric_limits<std::size_t>::max());
+
+        v.resize(17, true);
+        BOOST_CHECK_EQUAL(v.size(), 17UZ);
+        BOOST_CHECK_EQUAL(v.capacity(), 24UZ);
+        BOOST_CHECK(std::ranges::equal(v, std::vector<bool>(17, true)));
+
+        v.reserve(24);
+        v.shrink_to_fit();
+        BOOST_CHECK_EQUAL(v.size(), 17UZ);
+}
+
+// Past the capacity the storage throws, as [inplace.vector] specifies, and the sequence forwards that unchanged. [design.md#growth]
+BOOST_AUTO_TEST_CASE(GrowingPastTheCapacityThrowsBadAlloc)
+{
+        auto v = std::views::iota(0UZ, 24UZ) | std::views::transform([](auto i) { return i % 2 == 0; }) | std::ranges::to<T>();
+        BOOST_CHECK_EQUAL(v.size(), 24UZ);
+        BOOST_CHECK_EQUAL(std::ranges::count(v, true), 12);
+
+        BOOST_CHECK_THROW(v.push_back(true), std::bad_alloc);
+        BOOST_CHECK_THROW(v.resize(25),      std::bad_alloc);
+        BOOST_CHECK_THROW(v.reserve(25),     std::bad_alloc);
+
+        // The failed growth left the value alone, which is what the strong guarantee buys.
+        BOOST_CHECK_EQUAL(v.size(), 24UZ);
+        BOOST_CHECK_EQUAL(std::ranges::count(v, true), 12);
+
+        v.pop_back();
+        v.push_back(true);
+        BOOST_CHECK_EQUAL(v.size(), 24UZ);
+        BOOST_CHECK(static_cast<bool>(v.back()));
+}
+
+#else
+
+// The column is its storage's: without std::inplace_vector there is no name to test, and saying so keeps the source from being empty. [design.md#the-inplace-column]
+BOOST_AUTO_TEST_CASE(TheColumnIsAbsentWithItsStorage)
+{
+        static_assert(not test::has_inplace_vector);
+}
+
+#endif
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/bits/block_sequence.cpp
+++ b/test/src/bits/block_sequence.cpp
@@ -6,6 +6,7 @@
 #include <boost/test/unit_test.hpp>    // BOOST_CHECK_EQUAL, BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
 #include <test/block_types.hpp>        // digits_v, graded_extents, word_types
 #include <test/inplace_vector.hpp>     // IWYU pragma: keep; TEST_HAS_INPLACE_VECTOR
+#include <test/uint128.hpp>            // IWYU pragma: keep; TEST_HAS_UINT128, uint128
 #include <xstd/bits/bit_traits.hpp>    // bit_storage, bit_traits, block_readable, static_bit_extent
 #include <xstd/bits/block_sequence.hpp> // block_array, block_inplace_vector, block_sequence, block_storage, block_vector
 #include <algorithm>                   // count, lexicographical_compare_three_way, min
@@ -607,6 +608,31 @@ BOOST_AUTO_TEST_CASE(AStaticWidthDoesNotGrow)
 }
 
 #ifdef TEST_HAS_INPLACE_VECTOR
+// No hole in front of the blocks at any alignment: the width takes theirs where they out-align a size_t, so the
+// class is its two members and nothing else, which is what -Wpadded asks of it. [design.md#padding]
+BOOST_AUTO_TEST_CASE(TheWidthFillsWhatWouldOtherwisePadTheBlocks)
+{
+        // The width slot is a size_t, or the blocks' alignment where that is wider.
+        constexpr auto tiles = [](std::size_t whole, std::size_t blocks, std::size_t block_align) {
+                return whole == blocks + std::ranges::max(sizeof(std::size_t), block_align);
+        };
+
+        static_assert(tiles(sizeof(xstd::block_inplace_vector<std::uint8_t, 24>), sizeof(std::inplace_vector<std::uint8_t, 3>), alignof(std::inplace_vector<std::uint8_t, 3>)));
+        static_assert(tiles(sizeof(xstd::block_vector<std::uint8_t>), sizeof(std::vector<std::uint8_t>), alignof(std::vector<std::uint8_t>)));
+
+        // A static width carries no width member at all, so the class is its blocks exactly.
+        static_assert(sizeof(xstd::block_array<std::uint8_t, 24>) == sizeof(std::array<std::uint8_t, 3>));
+
+#ifdef TEST_HAS_UINT128
+        // The one cell that reaches an over-aligned storage: the width is a block there, and pays nothing for it.
+        static_assert(tiles(sizeof(xstd::block_inplace_vector<xstd::uint128, 384>), sizeof(std::inplace_vector<xstd::uint128, 3>), alignof(std::inplace_vector<xstd::uint128, 3>)));
+        static_assert(alignof(std::inplace_vector<xstd::uint128, 3>) > alignof(std::size_t));
+
+        // The heap column never reaches it: a vector is a pointer's alignment whatever it holds.
+        static_assert(sizeof(xstd::block_vector<xstd::uint128>) == sizeof(xstd::block_vector<std::uint64_t>));
+#endif
+}
+
 // The third storage: a run-time width under a compile-time capacity, the sweep unchanged over it, and growth past the capacity a bad_alloc. [design.md#growth]
 BOOST_AUTO_TEST_CASE(AnInplaceVectorIsARunTimeWidthUnderAStaticCapacity)
 {

--- a/test/src/bits/inplace_bitset.cpp
+++ b/test/src/bits/inplace_bitset.cpp
@@ -1,0 +1,96 @@
+//          Copyright Rein Halbersma 2014-2026.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/test/unit_test.hpp>              // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL, BOOST_CHECK_THROW
+#include <test/inplace_vector.hpp>               // IWYU pragma: keep; TEST_HAS_INPLACE_VECTOR, has_inplace_vector
+#ifdef TEST_HAS_INPLACE_VECTOR
+#include <xstd/bits/bitset_adaptor.hpp>          // bitset_adaptor
+#include <xstd/bits/inplace_bitset.hpp>          // basic_inplace_bitset, inplace_bitset
+#include <xstd/bits/block_sequence.hpp>          // block_inplace_vector
+#include <xstd/bits/bit_set_view.hpp>            // bit_set_view
+#include <concepts>                              // regular, same_as, totally_ordered
+#include <cstddef>                               // size_t
+#include <cstdint>                               // uint8_t
+#include <new>                                   // bad_alloc
+#include <string>                                // string
+#include <utility>                               // declval
+#endif
+
+BOOST_AUTO_TEST_SUITE(InplaceBitset)
+
+#ifdef TEST_HAS_INPLACE_VECTOR
+
+// A capacity of three whole blocks, so a resize can straddle a boundary and still stop short of the capacity.
+using T = xstd::basic_inplace_bitset<24, std::uint8_t>;
+
+// The bitset reading over a run-time width under a compile-time capacity, an alias and nothing more. [design.md#the-public-names]
+BOOST_AUTO_TEST_CASE(TheInplaceBitsetIsTheBitsetAdaptorOverAnInplaceVectorOfBlocks)
+{
+        static_assert(std::same_as<T, xstd::bitset_adaptor<xstd::block_inplace_vector<std::uint8_t, 24>>>);
+        static_assert(std::same_as<xstd::inplace_bitset<24>, xstd::basic_inplace_bitset<24, std::size_t>>);
+        static_assert(std::regular<T>);
+}
+
+// Two orderings at every width: its own is the bit string's, boost's, and the set reading's is reached through the view. [design.md#the-ordering-invariant]
+BOOST_AUTO_TEST_CASE(OrderedInfixAndThroughTheView)
+{
+        static_assert(std::totally_ordered<T>);
+        static_assert(std::totally_ordered<decltype(xstd::bit_set_view(std::declval<T&>()))>);
+}
+
+// boost::dynamic_bitset's growth, over storage that never allocates: the width moves, the capacity does not. [design.md#a-strict-extension]
+BOOST_AUTO_TEST_CASE(ItIsBoostsBitsetAtARunTimeWidthUnderAStaticCapacity)
+{
+        auto b = T();
+        BOOST_CHECK(b.empty());
+        BOOST_CHECK_EQUAL(b.max_size(), 24UZ);
+
+        b.resize(9);
+        BOOST_CHECK_EQUAL(b.size(), 9UZ);
+        BOOST_CHECK_EQUAL(b.capacity(), 24UZ);
+        BOOST_CHECK(b.none());
+
+        b.set(2);
+        b.set(8);
+        BOOST_CHECK_EQUAL(b.count(), 2UZ);
+        BOOST_CHECK(b.test(2) and b.test(8));
+        BOOST_CHECK_EQUAL(b.to_string(), std::string("100000100"));
+
+        b.flip();
+        BOOST_CHECK_EQUAL(b.count(), 7UZ);
+        b.reset();
+        BOOST_CHECK(b.none());
+
+        b.push_back(true);
+        BOOST_CHECK_EQUAL(b.size(), 10UZ);
+        BOOST_CHECK(b.test(9));
+}
+
+// Past the capacity the storage throws, as [inplace.vector] specifies, and the bitset forwards that unchanged. [design.md#growth]
+BOOST_AUTO_TEST_CASE(GrowingPastTheCapacityThrowsBadAlloc)
+{
+        auto b = T();
+        b.resize(24, true);
+        BOOST_CHECK(b.all());
+        BOOST_CHECK_EQUAL(b.count(), 24UZ);
+
+        BOOST_CHECK_THROW(b.resize(25),    std::bad_alloc);
+        BOOST_CHECK_THROW(b.push_back(true), std::bad_alloc);
+
+        BOOST_CHECK_EQUAL(b.size(), 24UZ);
+        BOOST_CHECK(b.all());
+}
+
+#else
+
+// The column is its storage's: without std::inplace_vector there is no name to test, and saying so keeps the source from being empty. [design.md#the-inplace-column]
+BOOST_AUTO_TEST_CASE(TheColumnIsAbsentWithItsStorage)
+{
+        static_assert(not test::has_inplace_vector);
+}
+
+#endif
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Step 7e of #80, the last step in the sequencing: the third storage point gets its public names. Rebased onto `main` now that #110 has merged, so the diff is 7e alone.

## What

Three aliases, one per reading, over `block_inplace_vector<Block, N>`:

```cpp
basic_bit_inplace_set<N, Block>    = set_adaptor     <block_inplace_vector<Block, N>, owns>
basic_bit_inplace_vector<N, Block> = sequence_adaptor<block_inplace_vector<Block, N>, owns, false>
basic_inplace_bitset<N, Block>     = bitset_adaptor  <block_inplace_vector<Block, N>>
```

with `bit_inplace_set<N>`, `bit_inplace_vector<N>` and `inplace_bitset<N>` at the machine word. One header per restricted name, holding its `basic_` form beside it, as the other two columns have; `bits.hpp` includes all three.

- **The guard is the whole column.** Everything sits behind `__cpp_lib_inplace_vector` (libstdc++ >= 16, which the matrix carries on gcc 16 and 17-SVN), each header's includes inside the guard as well, so on a library without the storage the header is its include guard and nothing else. An alias adds no capability, so the guard withholds a name rather than a feature.
- **No `aligned` form.** `aligned` rounds a *width* up so no block carries an unused tail; here `N` is a capacity that `block_inplace_vector` already rounds up, and the width under it is a run-time one that carries a tail like any other. `basic_bit_inplace_vector<9, std::uint8_t>` holds sixteen bits.
- **Growth past the capacity throws `std::bad_alloc`**, which is `std::inplace_vector`'s own answer reaching the caller unchanged; on the set reading that is where `insert` stops being total.

## The one library change: the width member takes the blocks' alignment

`block_sequence`'s width sat in front of its blocks as a `std::size_t`. Where the blocks out-align one — which only a storage holding its blocks inline can do, so only this column — that left an 8-byte hole, and `-Wpadded` under `-Werror` rejected it. The width now takes the blocks' alignment instead:

```cpp
using width_type = std::conditional_t<(alignof(std::size_t) >= alignof(Blocks)), std::size_t, block_type>;
static_assert(sizeof(width_type) >= sizeof(std::size_t) and alignof(width_type) >= alignof(Blocks));
```

`block_type` is the right carrier because `xstd::unsigned_integer` already guarantees what the width needs: a storage over-aligns only by its blocks' own alignment, so the block is exactly the size of the gap and, at `>= 128` digits there, wide enough to hold any width. The `static_assert` holds both facts rather than a comment claiming them, so a storage over-aligned for some other reason fails loudly instead of truncating a width. Every reader goes through `size()`, which converts once, so the arithmetic stays a `size_t`'s.

Measured, nothing pays for it:

| | before | after |
|---|---|---|
| `block_inplace_vector<uint128, 384>` | 80, `-Wpadded` | **80, clean** |
| `block_vector<uint128>` | 32 | 32 |
| `block_array<uint128, 384>` | 48 | 48 |
| `block_inplace_vector<uint64, 192>` | 40 | 40 |

The 8 bytes were spent either way; they now carry the width. `design.md#padding` records it, and the column is graded over `xstd::uint128` alongside every other block as a result.

## Tests

Three mirrored sources, each with its alias identity, the checklist or concept for its reading, and the behaviour that is the column's own — the capacity rounded up to whole blocks, and the throw past it.

P0843 declined to repeat `vector<bool>`, so a packed inplace sequence has no model to be checked against. `test::sequence::inplace_vector_bool` is `[vector.bool]`'s checklist minus the lines the allocator reaches, which `std::vector<bool>` answers in full and is asserted on first exactly as `vector_bool` is; `inplace_vector_bool_ranges` is the same for the C++23 lines. `bits.cpp` gains the column's row and grades both readings over it. `block_sequence.cpp` gains `TheWidthFillsWhatWouldOtherwisePadTheBlocks`, which asserts the class is its two members exactly at every alignment.

Every leg without the storage compiles each source's `#else` arm, one case asserting the absence: a Boost.Test module whose test tree is empty is a setup error rather than a pass, so the guarded sources cannot simply be empty.

## One thing recorded rather than changed

`max_size()` splits by reading. The set and sequence readings answer what a growing width can reach — `numeric_limits<size_t>::max() - 1` and `numeric_limits<size_t>::max()`, the address space rather than any storage — which is what `bit_set.cpp`, `bit_vector.cpp` and `sequence_adaptor.cpp` already pin. The bitset reading forwards to `block_sequence::max_size()`, which asks the blocks, because `boost::dynamic_bitset::max_size()` is a member a strict extension owes. So `inplace_bitset<24>` answers 24 and `bit_inplace_vector<24>` answers the address space. Left alone: both answers are tested behaviour, and changing either is a ruling above an alias. The capacity is `capacity()` where a reading has one, and where a capacity bites is the throw.

## Validation

`std::inplace_vector` is in no library available to this session, which is why this step was sequenced last. The guarded arm was exercised against a local stand-in header (not in the repo, not committed): the full suite twice, once with the guard off and once with it defined, on clang 18 with `-Weverything -Werror` — which is what actually checks the `-Wpadded` claim — plus clang-tidy 21 over all 27 header units and 38 test sources. Known local failures, unchanged and unrelated: `std_set/o1.cpp` and `o2.cpp` do not build against libstdc++ 14, which has no `from_range` on `std::set`. The real `<inplace_vector>` legs are gcc 16 and 17-SVN in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX4mpbwXNZwbQ75xHm4nYf