### PR TITLE
max_size is the positions there are to hold, on every reading

### DIFF
--- a/design.md
+++ b/design.md
@@ -816,14 +816,11 @@ against. `test::sequence::inplace_vector_bool` is `[vector.bool]`'s checklist mi
 reaches, and `std::vector<bool>` answers every line of it, so it is asserted on the model first exactly as
 `vector_bool` is ([the-sequence-contract](#the-sequence-contract)).
 
-`max_size()` splits by reading here, visibly rather than newly. The set and sequence readings report what a
-growing width can reach -- `numeric_limits<size_t>::max() - 1` and `numeric_limits<size_t>::max()`, the address
-space rather than any storage -- which is what their own tests pin at a run-time width and what the heap-backed
-pair report too. The bitset reading forwards to `block_sequence::max_size()`, which asks the blocks, because
-`boost::dynamic_bitset::max_size()` is a member a strict extension owes ([a-strict-extension](#a-strict-extension)).
-So `inplace_bitset<24>` answers 24 and `bit_inplace_vector<24>` answers the address space, and the capacity is
-`capacity()` on the sequence and bitset readings. The set reading has neither, `std::set` having no `capacity()`
-and a set growing by `insert` ([growth](#growth)), so there a capacity is only ever felt at the throw.
+`max_size()` is 24 on all three names over `<24, std::uint8_t>`, this column being where the three readings
+first disagreed about it and the reason they no longer do ([max-size-is-the-bits](#max-size-is-the-bits)).
+`capacity()` is the sequence and bitset readings'; the set has neither, `std::set` having no `capacity()` and a
+set growing by `insert` ([growth](#growth)), so there a capacity is felt at the throw and reported by
+`max_size()`.
 
 The column is graded over every block the other two are, `xstd::uint128` included, which it can be because the
 width member now carries its own alignment ([padding](#padding)). Before that, a 16-byte-aligned block after a
@@ -833,6 +830,32 @@ pointer's whatever it holds.
 
 Every leg without the storage compiles each of the three tests' `#else` arm, one case asserting the absence,
 because a Boost.Test module whose test tree is empty is a setup error rather than a pass.
+
+### max-size-is-the-bits
+
+`[container.reqmts]/56` asks for `distance(begin(), end())` for the largest possible container, and under every
+reading of bits that is one number: **the positions there are to hold**. The set reading iterates the positions
+it holds, so its largest is every position set; the sequence reading iterates one `bool` per position; the
+bitset reading owes boost the same answer. There is no per-reading meaning of `max_size()` and no separate key
+domain -- a set over `[0, W)` holds at most `W` elements because there are `W` positions, which is the same `W`.
+
+So all three ask the same question of the same place, and only the answer's source differs by what can grow:
+
+| | `max_size()` |
+|---|---|
+| a width in the type | `Traits::extent` |
+| an owner over growing storage | the storage's `max_size()`, in bits |
+| a view, a window, a static owner | its own width, which it cannot grow |
+
+`block_sequence::max_size()` is where the real limit lives, and it is not `SIZE_MAX`: a width rounds up to whole
+blocks, so the largest addressable one is `min(blocks.max_size(), SIZE_MAX / bits_per_block) * bits_per_block`
+-- `SIZE_MAX - 63` at a `size_t` block, and `N` rounded up at an inplace one. Nothing above it needs to restate
+that arithmetic, and nothing above it should: a constant at the adaptor drifts from the storage the moment the
+storage learns something, which is how `set_adaptor` came to answer `SIZE_MAX - 1` while `dynamic_bitset`
+answered `SIZE_MAX - 63` over the same blocks.
+
+That the set's is not `static` follows: an owner must ask its storage and a view must ask what it views, neither
+of which a static member can reach. `std::set::max_size()` is not static either.
 
 ### width-is-capacity
 
@@ -947,9 +970,8 @@ out of bounds.
 `insert` carries no `noexcept`, for the reason `std::set::insert` carries none: growing a dynamic extent
 allocates. It is the one operation a set can be unable to satisfy, and only a **static** extent ever is — a
 fixed capacity cannot come to hold a position outside it, so that is the precondition violation. A dynamic
-extent grows to hold it, `[set]` giving `insert` no way to fail. Growing has a limit of its own: `n + 1` must
-be a width the container can address, and `dynamic_bitset::max_size()` being `SIZE_MAX`, the one position
-ruled out is the one whose successor wraps to zero.
+extent grows to hold it, `[set]` giving `insert` no way to fail. Growing has a limit of its own, and it is the
+storage's rather than the address space's: `max_size()` ([max-size-is-the-bits](#max-size-is-the-bits)).
 
 Erasing stays total like `contains`: removing what is not there is the no-op returning zero that
 `std::set::erase` is.

--- a/include/xstd/bits/sequence_adaptor.hpp
+++ b/include/xstd/bits/sequence_adaptor.hpp
@@ -21,7 +21,6 @@
 #include <functional>                             // hash
 #include <initializer_list>                       // initializer_list
 #include <iterator>                               // input_iterator, make_reverse_iterator, reverse_iterator, sentinel_for
-#include <limits>                                 // numeric_limits
 #include <algorithm>                              // copy, min, remove_if
 #include <ranges>                                 // begin, enable_borrowed_range, enable_view, end, from_range_t, input_range, range_reference_t, size, sized_range, subrange
 #include <source_location>                        // source_location
@@ -446,7 +445,8 @@ public:
         [[nodiscard]] constexpr auto crbegin() const noexcept -> const_reverse_iterator { return std::make_reverse_iterator(cend());   }
         [[nodiscard]] constexpr auto crend()   const noexcept -> const_reverse_iterator { return std::make_reverse_iterator(cbegin()); }
 
-        // capacity; a static width is its own max_size, a growing one has the address space's, a window its own count.
+        // capacity; max_size() is the positions there are to hold: a growing one what its storage can address, and a
+        // static width, a view or a window their own, none of them able to grow. [design.md#max-size-is-the-bits]
         [[nodiscard]] constexpr auto empty() const noexcept -> bool { return size() == 0UZ; }
 
         [[nodiscard]] constexpr auto size() const noexcept
@@ -463,7 +463,7 @@ public:
                 -> size_type
         {
                 if constexpr (can_grow) {
-                        return std::numeric_limits<size_type>::max();
+                        return m_bits.max_size();
                 } else {
                         return size();
                 }

--- a/include/xstd/bits/set_adaptor.hpp
+++ b/include/xstd/bits/set_adaptor.hpp
@@ -20,7 +20,6 @@
 #include <functional>                        // hash, less
 #include <initializer_list>                  // initializer_list
 #include <iterator>                          // input_iterator, iter_reference_t, make_reverse_iterator, reverse_iterator, sentinel_for
-#include <limits>                            // numeric_limits
 #include <ranges>                            // begin, enable_borrowed_range, enable_view, end, input_range, range_reference_t, from_range_t, swap
 #include <type_traits>                       // conditional_t, false_type, is_nothrow_swappable_v, remove_const_t, remove_reference_t
 #include <utility>                           // forward, pair
@@ -164,20 +163,24 @@ public:
         [[nodiscard]] constexpr auto crbegin() const noexcept -> const_reverse_iterator { return rbegin(); }
         [[nodiscard]] constexpr auto crend()   const noexcept -> const_reverse_iterator { return rend();   }
 
-        // capacity; a bitset's count() is a set's size(), and a static width is the set's max_size(), a dynamic one grows to the last addressable position.
+        // capacity; a bitset's count() is a set's size(), and max_size() is the positions there are to hold. [design.md#max-size-is-the-bits]
         [[nodiscard]] constexpr auto empty() const noexcept -> bool { return begin() == end(); }
         [[nodiscard]] constexpr auto full()  const noexcept -> bool { return size() == max_size(); }
 
         [[nodiscard]] constexpr auto size() const noexcept -> size_type { return detail::bits::count<Traits>(storage()); }
 
-        [[nodiscard]] static constexpr auto max_size() noexcept
+        // [container.reqmts]/56, distance(begin(), end()) for the largest possible container: every position set, so the
+        // width. A width in the type is that width, an owner grows to what its storage can address, and a view cannot
+        // grow what it views, so it is that storage's width now. [design.md#max-size-is-the-bits]
+        [[nodiscard]] constexpr auto max_size() const noexcept
                 -> size_type
         {
                 if constexpr (static_bit_extent<Traits, bits_type>) {
                         return Traits::extent;
+                } else if constexpr (owns(Own)) {
+                        return storage().max_size();
                 } else {
-                        // n + 1 must be addressable: the one position ruled out is the one whose successor wraps to zero. [design.md#asking-is-total]
-                        return std::numeric_limits<size_type>::max() - 1UZ;
+                        return Traits::size(storage());
                 }
         }
 

--- a/test/include/test/set/composable.hpp
+++ b/test/include/test/set/composable.hpp
@@ -76,7 +76,7 @@ struct increment_modulo
         auto operator()(const X& a, std::size_t n) const
         {
                 if constexpr (requires { a << n; }) {
-                        constexpr auto N = X::max_size();
+                        auto const N = a.max_size();
                         BOOST_CHECK(
                                 (a << n) == (a
                                         | std::views::transform([=](auto x) { return x + n; })
@@ -94,7 +94,7 @@ struct decrement_modulo
         auto operator()(const X& a, std::size_t n) const
         {
                 if constexpr (requires { a >> n; }) {
-                        constexpr auto N = X::max_size();
+                        auto const N = a.max_size();
                         BOOST_CHECK(
                                 (a >> n) == (a
                                         | std::views::filter   ([=](auto x) { return x >= n; })

--- a/test/include/test/set/composable.hpp
+++ b/test/include/test/set/composable.hpp
@@ -80,7 +80,7 @@ struct increment_modulo
                         BOOST_CHECK(
                                 (a << n) == (a
                                         | std::views::transform([=](auto x) { return x + n; })
-                                        | std::views::filter   ([ ](auto x) { return x < N; })
+                                        | std::views::filter   ([=](auto x) { return x < N; })
                                         | std::ranges::to<X>()
                                 )
                         );
@@ -99,7 +99,7 @@ struct decrement_modulo
                                 (a >> n) == (a
                                         | std::views::filter   ([=](auto x) { return x >= n; })
                                         | std::views::transform([=](auto x) { return x - n; })
-                                        | std::views::filter   ([ ](auto x) { return x < N; })
+                                        | std::views::filter   ([=](auto x) { return x < N; })
                                         | std::ranges::to<X>()
                                 )
                         );

--- a/test/include/test/set/exhaustive.hpp
+++ b/test/include/test/set/exhaustive.hpp
@@ -33,7 +33,7 @@ concept static_width = requires { typename xstd::owned_storage<X>::bits_type; } 
 template<class X, std::size_t Limit>
 inline constexpr auto limit_v = []() {
         if constexpr (static_width<X>) {
-                return X::max_size();
+                return X().max_size();
         } else {
                 return Limit;
         }

--- a/test/src/bits/bit_inplace_set.cpp
+++ b/test/src/bits/bit_inplace_set.cpp
@@ -71,9 +71,9 @@ BOOST_AUTO_TEST_CASE(InsertingPastTheCapacityThrowsBadAlloc)
 {
         auto s = T();
 
-        // max_size() is the key domain a growing width admits, as it is on the heap-backed set; the capacity is
-        // felt at the throw below rather than reported. [design.md#the-inplace-column]
-        BOOST_CHECK_EQUAL(T::max_size(), std::numeric_limits<std::size_t>::max() - 1UZ);
+        // max_size() is the positions there are to hold, which under a static capacity is that capacity, the same
+        // answer the other two readings give over this storage. [design.md#max-size-is-the-bits]
+        BOOST_CHECK_EQUAL(s.max_size(), 24UZ);
         static_assert(not has_capacity<T>);
         BOOST_CHECK_THROW(s.insert(24), std::bad_alloc);
 

--- a/test/src/bits/bit_inplace_set.cpp
+++ b/test/src/bits/bit_inplace_set.cpp
@@ -15,7 +15,6 @@
 #include <concepts>                              // same_as
 #include <cstddef>                               // size_t
 #include <cstdint>                               // uint8_t
-#include <limits>                                // numeric_limits
 #include <new>                                   // bad_alloc
 #include <ranges>                                // iota, to
 #include <set>                                   // set

--- a/test/src/bits/bit_inplace_vector.cpp
+++ b/test/src/bits/bit_inplace_vector.cpp
@@ -15,7 +15,6 @@
 #include <concepts>                              // same_as
 #include <cstddef>                               // size_t
 #include <cstdint>                               // uint8_t
-#include <limits>                                // numeric_limits
 #include <new>                                   // bad_alloc
 #include <ranges>                                // count, iota, to, transform
 #include <vector>                                // vector

--- a/test/src/bits/bit_inplace_vector.cpp
+++ b/test/src/bits/bit_inplace_vector.cpp
@@ -62,9 +62,8 @@ BOOST_AUTO_TEST_CASE(TheCapacityIsTheRequestedOneRoundedUpToWholeBlocks)
         BOOST_CHECK_EQUAL(v.capacity(), 24UZ);
         BOOST_CHECK(v.empty());
 
-        // max_size() is the address space's wherever a width grows, as it is on the heap-backed sequence; the capacity
-        // is capacity(), and where it bites is the throw below. [design.md#the-inplace-column]
-        BOOST_CHECK_EQUAL(v.max_size(), std::numeric_limits<std::size_t>::max());
+        // max_size() is the positions there are to hold, which under a static capacity is that capacity. [design.md#max-size-is-the-bits]
+        BOOST_CHECK_EQUAL(v.max_size(), 24UZ);
 
         v.resize(17, true);
         BOOST_CHECK_EQUAL(v.size(), 17UZ);

--- a/test/src/bits/bit_set.cpp
+++ b/test/src/bits/bit_set.cpp
@@ -15,7 +15,6 @@
 #include <cstddef>                      // size_t
 #include <cstdint>                      // uint8_t
 #include <functional>                   // hash
-#include <limits>                       // numeric_limits
 #include <memory>                       // allocator
 #include <ranges>                       // iota, to
 #include <set>                          // set

--- a/test/src/bits/bit_set.cpp
+++ b/test/src/bits/bit_set.cpp
@@ -37,7 +37,7 @@ BOOST_AUTO_TEST_CASE(InsertingPastTheWidthGrowsIt)
 {
         auto s = T();
         BOOST_CHECK(s.empty());
-        BOOST_CHECK_EQUAL(T::max_size(), std::numeric_limits<std::size_t>::max() - 1UZ);
+        BOOST_CHECK_EQUAL(s.max_size(), xstd::block_vector<std::uint8_t>().max_size());
 
         auto const [ where, inserted ] = s.insert(100);
         BOOST_CHECK(inserted);

--- a/test/src/bits/bit_static_set.cpp
+++ b/test/src/bits/bit_static_set.cpp
@@ -73,7 +73,7 @@ auto check_key_outside_the_domain(X a, std::size_t x) -> void
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(LookupIsTotalOverKeyType, T, Types)
 {
-        auto const N = T::max_size();
+        auto const N = T().max_size();
         auto const full = std::views::iota(0UZ, N) | std::ranges::to<T>();
 
         // Just past the end, past the last block, and the value that would wrap any n + 1.

--- a/test/src/bits/bit_vector.cpp
+++ b/test/src/bits/bit_vector.cpp
@@ -17,7 +17,6 @@
 #include <cstdint>                           // uint8_t
 #include <functional>                        // hash
 #include <iterator>                          // next
-#include <limits>                            // numeric_limits
 #include <memory>                            // allocator
 #include <ranges>                            // equal, from_range, iota, next, transform
 #include <type_traits>                       // is_default_constructible_v

--- a/test/src/bits/bit_vector.cpp
+++ b/test/src/bits/bit_vector.cpp
@@ -148,7 +148,7 @@ BOOST_AUTO_TEST_CASE(ItGrowsLikeAStdVector)
         v.shrink_to_fit();
         BOOST_CHECK_GE(v.capacity(), v.size());
 
-        BOOST_CHECK_EQUAL(v.max_size(), std::numeric_limits<std::size_t>::max());
+        BOOST_CHECK_EQUAL(v.max_size(), xstd::block_vector<std::uint8_t>().max_size());
 
         v.clear();
         BOOST_CHECK(v.empty());

--- a/test/src/bits/sequence_adaptor.cpp
+++ b/test/src/bits/sequence_adaptor.cpp
@@ -200,7 +200,8 @@ BOOST_AUTO_TEST_CASE(GrowthIsTheOwnersOverStorageThatGrows)
         d.push_back(false);
         BOOST_CHECK_EQUAL(d.size(), 4UZ);
         BOOST_CHECK(std::ranges::equal(d, std::vector<bool>{ true, true, true, false }));
-        BOOST_CHECK_EQUAL(d.max_size(), std::numeric_limits<std::size_t>::max());
+        BOOST_CHECK_EQUAL(d.max_size(), xstd::block_vector<std::uint64_t>().max_size());
+        BOOST_CHECK_LT(d.max_size(), std::numeric_limits<std::size_t>::max());
         BOOST_CHECK_EQUAL(Owner().max_size(), 100UZ);
 }
 

--- a/test/src/bits/set_adaptor.cpp
+++ b/test/src/bits/set_adaptor.cpp
@@ -191,20 +191,32 @@ BOOST_AUTO_TEST_CASE(TheViewsAnswerEveryReadOverEveryStorage)
         }
 }
 
-// max_size is the width where the type carries one, and the last addressable position where it does not.
-BOOST_AUTO_TEST_CASE(MaxSizeIsStaticWhereTheWidthIs)
+// max_size is the positions there are to hold: the width in the type, what an owner's storage can address, or what a
+// view is looking at, none of which is the address space. [design.md#max-size-is-the-bits]
+BOOST_AUTO_TEST_CASE(MaxSizeIsThePositionsThereAreToHold)
 {
-        static_assert(Owner::max_size() == 100UZ);
-        static_assert(View::max_size() == 100UZ);
-        static_assert(xstd::set_adaptor<xstd::block_vector<std::size_t>, xstd::ownership::refers>::max_size() == std::numeric_limits<std::size_t>::max() - 1UZ);
-        static_assert(xstd::set_adaptor<boost::dynamic_bitset<>, xstd::ownership::refers>::max_size() == std::numeric_limits<std::size_t>::max() - 1UZ);
+        auto storage = Storage();
+        static_assert(Owner().max_size() == 100UZ);
+        BOOST_CHECK_EQUAL(View(storage).max_size(), 100UZ);
 
+        // An owner grows to what its storage can address, which is whole blocks of it and never the address space.
+        using Heap = xstd::set_adaptor<xstd::block_vector<std::uint64_t>, xstd::ownership::owns>;
+        BOOST_CHECK_EQUAL(Heap().max_size(), xstd::block_vector<std::uint64_t>().max_size());
+        BOOST_CHECK_LT(Heap().max_size(), std::numeric_limits<std::size_t>::max());
+
+        // A view cannot grow what it views, so its max_size is that width -- and filling it is what full() means.
         auto v = xstd::block_vector<std::uint64_t>(10UZ);
         auto const view = xstd::set_adaptor<xstd::block_vector<std::uint64_t>, xstd::ownership::refers>(v);
+        BOOST_CHECK_EQUAL(view.max_size(), 10UZ);
         BOOST_CHECK(not view.full());
         view.fill();
-        BOOST_CHECK(not view.full());
+        BOOST_CHECK(view.full());
         BOOST_CHECK_EQUAL(view.size(), 10UZ);
+
+        // Boost's own width, read through the view over it.
+        using Boost = xstd::set_adaptor<boost::dynamic_bitset<>, xstd::ownership::refers>;
+        auto b = boost::dynamic_bitset<>(9UZ);
+        BOOST_CHECK_EQUAL(Boost(b).max_size(), 9UZ);
 }
 
 // The set operations use the storage's members where it has them, and its bulk operators where it has not.


### PR DESCRIPTION
Closes the one call #80 left open after 7e, and it turned out to be a defect rather than a taste question.

## What was wrong

`[container.reqmts]/56` asks for `distance(begin(), end())` for the largest possible container. Under every reading of bits that is one number — **the positions there are to hold**. The set reading's largest is every position set, the sequence reading's is one `bool` per position, and the bitset reading owes `boost::dynamic_bitset` the same answer. There is no per-reading meaning and no separate key domain.

Measured on `main`, over one and the same `block_vector<size_t>`:

```
SIZE_MAX                        18446744073709551615
bit_set::max_size()             ...614   (SIZE_MAX - 1)
bit_vector().max_size()         ...615   (SIZE_MAX)
dynamic_bitset().max_size()     ...552   (SIZE_MAX - 63)
block_vector<size_t>.max_size() ...552   (SIZE_MAX - 63)
```

Three answers, and only the last is true. `set_adaptor::max_size()` returned a constant with a comment deriving the `- 1` from "`n + 1` must be addressable … `dynamic_bitset::max_size()` being `SIZE_MAX`". That premise stopped holding at #109, which gave `block_sequence` a real `max_size()`: a width rounds up to whole blocks, so the largest addressable one is `min(blocks.max_size(), SIZE_MAX / bits_per_block) * bits_per_block`. The adaptors were restating arithmetic the storage already owns, and drifted from it the moment it learned something.

## What it is now

All three ask the same place, and only the source differs by what can grow:

| | `max_size()` |
|---|---|
| a width in the type | `Traits::extent` |
| an owner over growing storage | the storage's, in bits |
| a view, a window, a static owner | its own width, which it cannot grow |

```cpp
// set_adaptor
if constexpr (static_bit_extent<Traits, bits_type>) return Traits::extent;
else if constexpr (owns(Own))                       return storage().max_size();
else                                                return Traits::size(storage());

// sequence_adaptor
if constexpr (can_grow) return m_bits.max_size();
else                    return size();
```

`bitset_adaptor` is unchanged — it already forwarded, which is why it was the only one telling the truth.

## Three consequences worth reviewing

- **`set_adaptor::max_size()` is no longer `static`.** An owner has to ask its storage and a view what it views, neither of which a static member can reach. `std::set::max_size()` is not static either, so this moves toward the counterpart. Three harness sites read it off the type; two of them — `composable.hpp`'s shift bounds — now read it off the object, which is more correct for a dynamic set, whose bound is not a fact about its type.
- **`full()` now works on views.** A set view over a 10-bit storage reports `max_size() == 10`, so filling it makes `full()` true. `set_adaptor.cpp` asserted `not full()` after `fill()`; that was measuring the old constant rather than a property, and the case now asserts the width alongside it.
- **`<limits>` leaves both headers.** With no invented number left to spell, neither uses `numeric_limits` at all.

The inplace column is where the disagreement first showed, and all three of its names now answer 24 over `<24, std::uint8_t>`.

## Docs

`design.md#max-size-is-the-bits` states the rule and the three sources. `asking-is-total` loses the wrap paragraph that justified the `- 1`; `the-inplace-column` loses the split it recorded as accepted.

## Validation

Full suite twice, guard off and guard on, on clang 18 with `-Weverything -Werror`: 39 sources each, the only failures being `std_set/o1.cpp` and `o2.cpp`, which do not build against libstdc++ 14 for want of `from_range` on `std::set` and are unrelated. clang-tidy 21 clean over both changed headers in both arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX4mpbwXNZwbQ75xHm4nYf

---
_Generated by [Claude Code](https://claude.ai/code/session_01LX4mpbwXNZwbQ75xHm4nYf)_