### PR TITLE
Open with Shaw: the adapters are the unreasonable ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > in trying to adapt the world to himself. Therefore all progress depends on the
 > unreasonable man."
 >
-> -- George Bernard Shaw, *Man and Superman* (1903), "Maxims for Revolutionists"
+> — George Bernard Shaw, *Man and Superman* (1903), "Maxims for Revolutionists"
 
 [![Language](https://img.shields.io/badge/language-C++-blue.svg)](https://isocpp.org/)
 [![Standard](https://img.shields.io/badge/c%2B%2B-23-blue.svg)](https://en.wikipedia.org/wiki/C%2B%2B#Standardization)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Rebooting the bits franchise
 
+> "The reasonable man adapts himself to the world: the unreasonable one persists
+> in trying to adapt the world to himself. Therefore all progress depends on the
+> unreasonable man."
+>
+> -- George Bernard Shaw, *Man and Superman* (1903), "Maxims for Revolutionists"
+
 [![Language](https://img.shields.io/badge/language-C++-blue.svg)](https://isocpp.org/)
 [![Standard](https://img.shields.io/badge/c%2B%2B-23-blue.svg)](https://en.wikipedia.org/wiki/C%2B%2B#Standardization)
 [![License](https://img.shields.io/badge/license-Boost-blue.svg)](https://opensource.org/licenses/BSL-1.0)


### PR DESCRIPTION
Adds an epigraph to `README.md`, in the same format the sibling repositories already use (`xstd-ints`, `xstd-misc`): the quote as a blockquote directly under the title, then an attribution line `— Author, *Title* (year), "Section"`, then the badges.

The quote:

> "The reasonable man adapts himself to the world: the unreasonable one persists in trying to adapt the world to himself. Therefore all progress depends on the unreasonable man."
>
> — George Bernard Shaw, *Man and Superman* (1903), "Maxims for Revolutionists"

It fits what this library actually is. Every owning container here is an adaptor — nine aliases over a single `block_sequence`, each declining to take the storage's own shape and insisting on a set, a sequence or a bitset reading instead.

Wording checked against Project Gutenberg ebook 26107 ("Maxims for Revolutionists", section "REASON"); note Shaw punctuates with a colon after "world", not a semicolon. Ebook 3328 is the play alone and does not contain the Maxims.

The second commit sets the attribution dash as a real em dash (U+2014) rather than `--`. GitHub renders Markdown with cmark-gfm and does not enable the smart-punctuation option, so two hyphens stay two literal hyphens. `rhalbersma/xstd-misc#7` makes the same change there, where the Carroll quote already used real em dashes inside the verse while its attribution line did not. `xstd-ints` is deliberately left alone: its source line is `Proverbs 6:6, King James Version`, a locator rather than an attribution to a speaker, and carries no dash to upgrade.

Documentation only — no code, build, or test files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX4mpbwXNZwbQ75xHm4nYf