### PR TITLE
Work through the backlog: nine issues, and a README table that named types which do not exist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ target_sources(
         include/xstd/bits/detail/hash.hpp
         include/xstd/bits/detail/intrin.hpp
         include/xstd/bits/dynamic_bitset.hpp
+        include/xstd/bits/format.hpp
         include/xstd/bits/detail/pred.hpp
         include/xstd/bits/ext/boost.hpp
         include/xstd/bits/ext/boost/dynamic_bitset.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,10 +15,15 @@ project(
 
 include(GNUInstallDirs)
 
+# The project's own name, spelled once. TOUPPER alone leaves XSTD-BITS, which no cache option can be called;
+# MAKE_C_IDENTIFIER alone leaves the lowercase form. Both, in this order, and test/ and benchmark/ inherit them.
+string(MAKE_C_IDENTIFIER ${PROJECT_NAME} project_id)            # xstd_bits
+string(TOUPPER ${project_id} project_option_prefix)             # XSTD_BITS
+
 # Warnings are errors while this library is being developed, which is what the presets ask for.
 # Declared here rather than under test/, as xstd and tabula do, because benchmark/ carries its
 # own warning set and has to be gated by the same switch.
-option(XSTD_BITS_WARNINGS_AS_ERRORS "Treat warnings as errors in xstd-bits tests and benchmarks" ${PROJECT_IS_TOP_LEVEL})
+option(${project_option_prefix}_WARNINGS_AS_ERRORS "Treat warnings as errors in ${PROJECT_NAME} tests and benchmarks" ${PROJECT_IS_TOP_LEVEL})
 
 # Prefer an installed xstd-ints so install(EXPORT) can record it as a dependency; a FetchContent build tree cannot be exported.
 find_package(xstd-ints 0.1.0 CONFIG QUIET)
@@ -120,21 +125,29 @@ if(PROJECT_IS_TOP_LEVEL)
         # nine cells compile to nothing and are never tested. Raising the standard here rather than in the
         # INTERFACE keeps the requirement a consumer sees at 23 while letting a leg of the matrix build the whole
         # matrix. [design.md#the-inplace-column]
-        set(XSTD_BITS_CXX_STANDARD 23 CACHE STRING "C++ standard for the tests and benchmarks: 23, or 26 to reach the inplace column")
-        set_property(CACHE XSTD_BITS_CXX_STANDARD PROPERTY STRINGS 23 26)
+        set(${project_option_prefix}_CXX_STANDARD 23 CACHE STRING "C++ standard for the tests and benchmarks: 23, or 26 to reach the inplace column")
+        set_property(CACHE ${project_option_prefix}_CXX_STANDARD PROPERTY STRINGS 23 26)
 
         # Asking for a standard CMake cannot spell for this compiler fails deep inside a try_compile, with a
         # message blaming the compiler. CMAKE_CXX_COMPILE_FEATURES is what CMake actually knows, so ask it.
-        if(NOT "cxx_std_${XSTD_BITS_CXX_STANDARD}" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+        if(NOT "cxx_std_${${project_option_prefix}_CXX_STANDARD}" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
             message(FATAL_ERROR
-                "XSTD_BITS_CXX_STANDARD=${XSTD_BITS_CXX_STANDARD} is not something CMake ${CMAKE_VERSION} can ask "
+                "${project_option_prefix}_CXX_STANDARD=${${project_option_prefix}_CXX_STANDARD} is not something CMake ${CMAKE_VERSION} can ask "
                 "${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION} for. CMake 3.28 knows no C++26 for GCC or "
                 "Clang at all; a newer CMake does. The inplace column needs it, the other six cells do not."
             )
         endif()
 
-        set(CMAKE_CXX_STANDARD ${XSTD_BITS_CXX_STANDARD})
+        set(CMAKE_CXX_STANDARD ${${project_option_prefix}_CXX_STANDARD})
         set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+        # Left ON, which is CMake's default, so the matrix compiles as gnu++23 where xstd and tabula compile as
+        # c++23. Stated rather than omitted, because the reason is specific and the difference is deliberate:
+        # <bit>'s functions take std::unsigned_integral alone, and libstdc++ and libc++ carry xstd::uint128 into
+        # that concept only outside __STRICT_ANSI__. Turning extensions off would drop the widest Block from
+        # every instantiation list rather than fail, which is the worse of the two outcomes.
+        # [design.md#uint128-support]
+        set(CMAKE_CXX_EXTENSIONS ON)
 
         add_subdirectory(benchmark)
         add_subdirectory(test)

--- a/README.md
+++ b/README.md
@@ -219,6 +219,20 @@ What makes this work for a foreign container is `xstd::bit_traits`, a trait the 
 
 This is why ownership is not a fourth column of the table above: a view is not a fourth kind of container, it is the same three readings pointed at storage someone else owns.
 
+### Printing
+
+The snippets above use `fmt::format`, which finds the proxies through fmt's own `format_as`. `std::format` and `std::print` work too, by including one header:
+
+```cpp
+#include <xstd/bits/format.hpp>
+
+std::print("{}\n", primes);   // {2, 3, 5, 7, 11, ...}   the set reading, in braces
+std::print("{}\n", flags);    // [false, true, ...]      the sequence reading, in brackets
+std::print("{::#x}\n", primes);
+```
+
+It specializes `std::formatter` for the two proxy references and nothing else: every container over them is already a range, so [`[format.range.formatter]`](https://eel.is/c++draft/format.range.formatter) formats it once its reference is formattable. The braces-versus-brackets split is the standard's, not ours — `[format.range.fmtkind]` picks `range_format::set` for a range with a `key_type` — so each reading prints in its own vocabulary without being told to. The header is deliberately outside `<xstd/bits.hpp>`, which keeps `<format>` off the include path of consumers who do not format.
+
 ## Data-parallelism
 
 The `filter_twins` above walks the primes one at a time, because that is all `std::set` can do. A dense container can answer the same question a **word at a time**, without iterating at all. A prime is a twin exactly when it has a neighbour two away, so shifting the whole set by two in each direction and intersecting gives every twin in a handful of instructions per block:

--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ Notes:
 
 The aforementioned issues with the current `bit` landscape can be resolved by implementing a single-purpose container for each cell of the design space. With three readings and three storages, that is nine — **and this library implements all nine**.
 
-|                              | static width                     | run-time width, static capacity     | dynamic                             |
-| :--------------------------- | :------------------------------- | :---------------------------------- | :---------------------------------- |
-| **ordered set of `int`**     | `xstd::bit_static_set<N, Block>` | `xstd::bit_inplace_set<N, Block>`   | `xstd::bit_set<Block, Allocator>`   |
-| **sequence of `bool`**       | `xstd::bit_array<N, Block>`      | `xstd::bit_inplace_vector<N, Block>`| `xstd::bit_vector<Block, Allocator>`|
-| **both readings (`bitset`)** | `xstd::bitset<N, Block>`         | `xstd::inplace_bitset<N, Block>`    | `xstd::dynamic_bitset<Block, Allocator>` |
+|                              | static width               | run-time width, static capacity | dynamic                  |
+| :--------------------------- | :------------------------- | :------------------------------ | :----------------------- |
+| **ordered set of `int`**     | `xstd::bit_static_set<N>`  | `xstd::bit_inplace_set<N>`      | `xstd::bit_set`          |
+| **sequence of `bool`**       | `xstd::bit_array<N>`       | `xstd::bit_inplace_vector<N>`   | `xstd::bit_vector`       |
+| **both readings (`bitset`)** | `xstd::bitset<N>`          | `xstd::inplace_bitset<N>`       | `xstd::dynamic_bitset`   |
 
 The columns are the three storages the one underlying vehicle is parameterized on — `std::array`, `std::inplace_vector` and `std::vector` — so a cell is a reading crossed with a storage, and nothing else.
 
@@ -75,7 +75,7 @@ Notes:
 2. The third row is the point the old two-by-two could not express. `std::bitset` and `boost::dynamic_bitset` are faulted above for being unclear about which interface they offer; the answer here is not to abolish the hybrid but to **name** it. A `bitset` row that offers both readings deliberately sits beside two rows that each offer exactly one, and `xstd::bitset<N>` is a strict extension of `std::bitset<N>` while `xstd::dynamic_bitset` is one of `boost::dynamic_bitset<>` — every expression valid on the counterpart is valid here, with the same result.
 3. The variable-size sequence of `bool` is named `xstd::bit_vector` and decoupled from the general `std::vector` class template.
 4. All containers use a dense (single bit per element) representation. Variable-size sparse sets of `int` can be provided by `flat_set`, either in [Boost](https://www.boost.org/doc/libs/1_80_0/doc/html/boost/container/flat_set.html) or in [C++ 23](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p1222r4.pdf).
-5. All containers allow storage configuration through their `Block` template parameter. The short name above defaults it to `std::size_t`; a `basic_` form of each (e.g. `xstd::basic_bit_static_set<N, Block>`) requires it explicitly.
+5. The names above are the short ones, which fix `Block` to `std::size_t` and so take only the width, or nothing at all in the dynamic column where there is no width to give. Each has a `basic_` form that leaves the block open: `xstd::basic_bit_static_set<N, Block>`, `xstd::basic_bit_array<N, Block>`, `xstd::basic_bitset<N, Block>` and their inplace siblings, and `xstd::basic_bit_set<Block, Allocator>`, `xstd::basic_bit_vector<Block, Allocator>`, `xstd::basic_dynamic_bitset<Block, Allocator>` down the dynamic column. So `xstd::bit_set` is an alias, not a template, and `xstd::basic_bit_set<std::uint8_t>` is how a block is chosen.
 6. Each static-width name has an `aligned` form in a nested namespace, its width rounded up to whole blocks so that no block carries an unused tail: `xstd::aligned::bitset<120>` is `xstd::bitset<128>`. That costs nothing in storage at a width already spanning whole blocks, and removes the tail-restoring mask from `fill`, `flip` and the left shift.
 
 The **middle column** is what allocates nothing and yet carries a run-time width. It depends on `std::inplace_vector`, so those three names exist only where the standard library provides it (`__cpp_lib_inplace_vector`); an alias withholds a name rather than a capability.
@@ -277,7 +277,7 @@ The **full** interface of `xstd::bit_static_set` is `constexpr`.
 `xstd::bit_static_set<N>` is a fixed-size ordered set of integers, providing conceptually the same functionality as `std::set<int, std::less<int>, Allocator>`, where `Allocator` statically allocates memory to store `N` integers. In particular, `xstd::bit_static_set<N>` has:
 
 - **No customized key comparison**: `xstd::bit_static_set` uses `std::less<int>` as its fixed comparator (accessible through its nested types `key_compare` and `value_compare`). In particular, the `xstd::bit_static_set` constructors do not take a comparator argument.
-- **No allocators**: `xstd::bit_static_set` is a fixed-size set of non-negative integers and does not dynamically allocate memory. In particular, `xstd::bit_static_set` does **not provide** a `get_allocator()` member function and its constructors do not take an allocator argument. Its allocating counterpart `xstd::bit_set<Block, Allocator>` does provide both — the allocator follows the storage column, not the set reading.
+- **No allocators**: `xstd::bit_static_set` is a fixed-size set of non-negative integers and does not dynamically allocate memory. In particular, `xstd::bit_static_set` does **not provide** a `get_allocator()` member function and its constructors do not take an allocator argument. Its allocating counterpart `xstd::bit_set` does provide both — the allocator follows the storage column, not the set reading.
 - **No splicing**: `xstd::bit_static_set` is **not a node-based container**, and does not provide the splicing operations as defined in [p0083r3](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0083r3.pdf). In particular, `xstd::bit_static_set` does **not provide** the nested types `node_type` and `insert_return_type`, the `extract()` or `merge()` member functions, or the `insert()` overloads taking a node handle.
 
 Minor **semantic differences** between common functionality in `xstd::bit_static_set<N>` and `std::set<int>` are:
@@ -426,7 +426,7 @@ auto b = a
 **A**: The least significant bit of the last array word maps onto set value `N - 1`.
 
 **Q**: I'm visually oriented, can you draw a diagram?  
-**A**: Sure, it looks like this for `bit_static_set<16, uint8_t>`:
+**A**: Sure, it looks like this for `basic_bit_static_set<16, std::uint8_t>`:
 
 |value |01234567|89ABCDEF|
 |:---- |-------:|-------:|
@@ -437,7 +437,7 @@ auto b = a
 **A**: To be able to use **data-parallelism** for `(a < b) == std::ranges::lexicographical_compare(a, b)`.
 
 **Q**: How is efficient set comparison connected to the bit-ordering within words?  
-**A**: Take `bit_static_set<8, uint8_t>` and consider when `sL < sR` for ordered sets of integers `sL` and `sR`.
+**A**: Take `basic_bit_static_set<8, std::uint8_t>` and consider when `sL < sR` for ordered sets of integers `sL` and `sR`.
 
 **Q**: Ah, lexicographical set comparison corresponds to bit comparison from most to least significant?  
 **A**: Indeed, and this is equivalent to doing the integer comparison `wL > wR` on the underlying words `wL` and `wR`.

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -10,9 +10,9 @@ find_package(fmt REQUIRED)
 
 # clang-cl reports CXX_COMPILER_ID Clang but understands only MSVC-style driver flags.
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
-    set(xstd_bits_is_clang_cl ON)
+    set(${project_id}_is_clang_cl ON)
 else()
-    set(xstd_bits_is_clang_cl OFF)
+    set(${project_id}_is_clang_cl OFF)
 endif()
 
 set(cxx_compile_definitions
@@ -29,7 +29,7 @@ set(cxx_compile_options_warnings
         /W4
         /permissive-
     >
-    $<$<AND:$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>,$<NOT:$<BOOL:${xstd_bits_is_clang_cl}>>>:
+    $<$<AND:$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>,$<NOT:$<BOOL:${${project_id}_is_clang_cl}>>>:
         -pedantic-errors
     >
     $<$<CXX_COMPILER_ID:Clang>:
@@ -64,8 +64,8 @@ set(cxx_compile_options_warnings
         -Wno-array-bounds                   # triggered by Boost.DynamicBitset for gcc >= 12 in Release mode
         -Wno-stringop-overflow              # triggered by Boost.DynamicBitset for gcc >= 12 in Release mode
     >
-    $<$<AND:$<BOOL:${XSTD_BITS_WARNINGS_AS_ERRORS}>,$<CXX_COMPILER_ID:MSVC>>:/WX>
-    $<$<AND:$<BOOL:${XSTD_BITS_WARNINGS_AS_ERRORS}>,$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>>:-Werror>
+    $<$<AND:$<BOOL:${${project_option_prefix}_WARNINGS_AS_ERRORS}>,$<CXX_COMPILER_ID:MSVC>>:/WX>
+    $<$<AND:$<BOOL:${${project_option_prefix}_WARNINGS_AS_ERRORS}>,$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>>:-Werror>
 )
 
 set(cxx_compile_options_optimization
@@ -78,7 +78,7 @@ set(cxx_compile_options_optimization
     >
 )
 
-get_property(xstd_bits_is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+get_property(${project_id}_is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 
 # Load-bearing in every configuration: without it two of three MinGW rungs cannot assemble these objects at all (#47).
 set(cxx_compile_options_mbig_obj
@@ -102,7 +102,7 @@ foreach(t ${targets})
 
     target_link_libraries(
         ${target_id} PRIVATE
-        ${CMAKE_PROJECT_NAME}
+        xstd::bits
         Boost::headers
         benchmark::benchmark
         fmt::fmt
@@ -126,7 +126,7 @@ foreach(t ${targets})
     set(bench_smoke_args --benchmark_min_time=1x)
 
     # Release only, and by CONFIGURATIONS rather than if(): neither spelling alone works on both generator kinds (#32).
-    if(xstd_bits_is_multi_config)
+    if(${project_id}_is_multi_config)
         add_test(NAME ${target_id} CONFIGURATIONS Release COMMAND ${target_id} ${bench_smoke_args})
     elseif(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
         add_test(NAME ${target_id} COMMAND ${target_id} ${bench_smoke_args})

--- a/design.md
+++ b/design.md
@@ -1068,6 +1068,45 @@ declarations the earlier views needed (*"Clang requires it, GCC does not"*) have
 The pointer is to the **storage** an owner wraps, never to the owner: `bit_static_set` hands out
 `bit_set_iterator<block_array<B, N>>`, which is why no owning type ever needs a `bit_traits` of its own.
 
+### the-set-for-each
+
+`for_each(f)` and `for_each_reverse(f)` on the set reading walk blocks where the iterator walks positions, and
+the difference is not word-parallelism -- the functor still sees every set position, one at a time. It is
+where the loop's state may live.
+
+`operator++` is **flat**. It has to re-derive the word from `(pointer, position)` on every step, because an
+iterator stays copyable and restartable and therefore cannot keep a partially consumed block between two
+increments. A loop has somewhere to put one. So `find_next` loads a block, masks off what is at or below the
+cursor, tests, possibly scans forward and takes a `countr_zero`, once per position; the walk loads once per
+block and then spends two instructions per position, `tzcnt` for the position and `blsr` to drop it.
+
+Measured against the range-for at 4.08x to 5.05x, on GCC 15 and clang 22, and the same on a two-word bitboard
+carrying twenty pieces as at 2^22 with 40% density. That stability is itself the point: `find_next` is
+inherently serial, no vectorizer engages on either side, and the answer does not move with the compiler --
+unlike the sequence reading, where the same question gives answers ranging from 1.24x ahead to 11.4x ahead
+depending on which one is asked ([the-sequence-ladder](#the-sequence-ladder)).
+
+Three decisions the shape forced:
+
+**A functor may return `bool` to mean "keep going".** A `void` one always continues. That is what a move
+generator wants once it has found its answer, and it is one `if constexpr` on `is_invocable_r_v<bool, F&,
+size_t>`. Nothing else is accepted: a functor returning something else is a caller error rather than a value
+to discard quietly.
+
+**The descending walk clears the bit it just reported.** `w & (w - 1)` drops the lowest set bit and has no
+descending twin, so `for_each_reverse` takes `digits - 1 - countl_zero(w)` for the position and clears exactly
+that bit. The set reading iterates both ways and so does this.
+
+**A storage with no block access takes the iterator.** `boost::dynamic_bitset` is the one, and there the walk
+falls back to the range-for it was written to beat, which is still correct and still the same answer. The
+same three tiers `fill` uses ([windows](#windows)).
+
+What is *not* here is a fat iterator carrying the residual word. It was measured -- 2.56x to 3.80x, against
+the walk's 4.00x to 5.27x -- so it is both slower than the member and the only one of the two that changes a
+contract: an iterator that caches a block stops observing an erase that lands ahead of it, where a closed loop
+caching the same block is unobservable. The member is the faster half and the safer half at once, which is
+rare enough to record.
+
 ### read-only-set-proxy
 
 The set reading's proxy is read-only whatever the qualification of `Bits`, because a key is nothing to write

--- a/design.md
+++ b/design.md
@@ -787,7 +787,7 @@ container, same interface, different representation — and the prefix is what s
 first. `static_bit_set` would read as a qualified `bit_set`; `bit_static_set` is `bit_` applied to a
 `static_set`, the way `flat_set` is `flat_` applied to a `set`.
 
-**Why `static` and not `finite`.** `finite` selects nothing: `bit_set<Block, Allocator>` is a finite set of
+**Why `static` and not `finite`.** `finite` selects nothing: `bit_set` is a finite set of
 positions too, as every bit set is. What separates them is that `N` is a compile-time constant, which is
 *static*, and static-versus-dynamic is one of the two axes the whole design is built on — so the name reads off
 the design rather than off a true-but-non-distinguishing adjective. Recorded against it: P0843 renamed
@@ -846,7 +846,7 @@ because `bitset` already carries the word, and `inplace` is one storage word dow
 second vocabulary for the same thing.
 
 `N` is a **capacity** in bits here, where the static column's `N` is a width. The names carry that and the
-parameter lists do not, which is the same hazard `bit_static_set<N, Block>` and `bit_inplace_set<N, Block>`
+parameter lists do not, which is the same hazard `basic_bit_static_set<N, Block>` and `basic_bit_inplace_set<N, Block>`
 share by shape. The capacity is rounded up to whole blocks by `block_inplace_vector` itself, so
 `basic_bit_inplace_vector<9, std::uint8_t>` holds sixteen bits; the width under it is a run-time one and carries
 an unused tail like any other.

--- a/design.md
+++ b/design.md
@@ -1088,6 +1088,36 @@ still built on `std::iter_swap`. `format_as` is fmt's protocol in the same sense
 The sequence proxy borrows nothing else from `[bitset.refs]`: no `flip()` and no `operator~`. Those belong to
 the bitset reading, whose `reference` is its own class.
 
+### formatting-the-proxies
+
+`std::format` over the containers needs nothing said about the containers. Every owner and view here is a
+range, so `[format.range.formatter]` would format each one already, except that it requires
+`formattable<ranges::range_reference_t<R>>` and a reference of ours is a proxy. So `xstd/bits/format.hpp`
+specializes `std::formatter` for the two proxies and stops there: `bit_set`, `bit_static_set`, `bit_vector`,
+`bit_array`, the views, the windows and the inplace column all follow from that, none of them mentioned.
+
+This is the same shape the proxies already had for fmt, in fmt's spelling. `format_as` is fmt's generic
+per-type hook: define it for one type and every range over that type formats, which is why the proxies carry
+it and no container does. `std::formatter` is the standard's hook for the same job. So each library gets one
+hook per proxy -- a hidden friend for fmt, a specialization for the standard -- and in both the containers
+follow for free. Nothing here is a special case for formatting; it is the general mechanism used twice.
+
+The readings then separate themselves. `[format.range.fmtkind]` picks `range_format::set` for a range with a
+`key_type` and `range_format::sequence` otherwise, so the set reading prints `{1, 3, 5}` and the sequence
+reading `[false, true, false, false]` -- the same split `format_as` arrives at for fmt, reached here through
+the standard's own machinery rather than by our choosing
+([two-readings-disagree](#two-readings-disagree)).
+
+Each specialization derives from `std::formatter<size_t>` or `std::formatter<bool>` instead of writing a
+`parse`, which is what keeps the whole spec: a width and a fill on a single proxy, and the nested spec a range
+formatter forwards, so `{::#x}` over the set reading and `{::d}` over the sequence reading reach the
+underlying formatter intact.
+
+The header is not in `xstd/bits.hpp`. The umbrella keeps `<format>` off every consumer path for the reason it
+keeps the `ext/` adaptors and Boost off it; a consumer who formats says so by including the header. Issue #20
+had this waiting on P3070R0, which is not what blocked it: the proxy's formattability was, and that is ours to
+fix.
+
 ### total-lookups-on-the-container
 
 Every `bit_static_set` lookup is total over `key_type`, because `std::set`'s is: a key outside `[0, N)` names

--- a/design.md
+++ b/design.md
@@ -1116,6 +1116,19 @@ lets `*it` initialize a strong index type in one step, where the two user-define
 `size_t` would be one too many. A type with an explicit constructor takes the `size_t` route, `index(*it)`,
 and the proxy offers no explicit conversion of its own: MSVC cannot resolve one beside that constructor.
 
+### the-proxy-copies-the-handle
+
+Both proxies declare their copy constructor, and for opposite-looking reasons that are the same reason. The
+set proxy is `= default` beside a deleted `operator=`, because a reference to a key is a value: copyable,
+never assignable. The sequence proxy is `= default` beside two `operator=`s that write *through* the handle
+to the bit. That second pairing is exactly the case `[-Wdeprecated-copy-with-user-provided-copy]` names: a
+user-provided copy assignment makes the implicit copy constructor deprecated, because the compiler can no
+longer assume the two agree -- and here they genuinely do not, which is the whole point of a proxy. So the
+copy constructor is said out loud rather than inherited by default.
+
+Nothing else copy-constructs a proxy in this library, which is why nothing caught it until `<format>` arrived:
+`std::formatter`'s dispatch takes the element by value, and that first copy is where the deprecation lands.
+
 ### the-one-adl-exception
 
 The sequence iterator's `iter_move` and `iter_swap` are hidden friends found by ADL, and they stay under the
@@ -1328,7 +1341,7 @@ ever wrong.
 
 ### clang-tidy-false-positives
 
-Four findings are suppressed because the checker cannot see what makes them right:
+Five findings are suppressed because the checker cannot see what makes them right:
 
 - `bugprone-unhandled-self-assignment` on the bitset proxy's `operator=`, which owns no storage: `b[i] = b[i]`
   reads the bit and writes it back.
@@ -1338,6 +1351,10 @@ Four findings are suppressed because the checker cannot see what makes them righ
   instantiation discards; it sees only that one and asks for a `const` that would stop every other
   instantiation compiling.
 - `misc-redundant-expression` on a reflexivity check, which cannot be written without naming the object twice.
+- `bugprone-std-namespace-modification` on the two `std::formatter` specializations, which is precisely the
+  modification `[namespace.std]/2` allows: a specialization of a standard library template for a
+  program-defined type. clang-tidy 22 and 23 read the qualified definition as modifying the namespace; 24 no
+  longer does, and the suppression stays until the whole ladder is past 23.
 
 ### clang-crashes-on-a-foreign-bulk-source
 

--- a/design.md
+++ b/design.md
@@ -1356,6 +1356,12 @@ Five findings are suppressed because the checker cannot see what makes them righ
   program-defined type. clang-tidy 22 and 23 read the qualified definition as modifying the namespace; 24 no
   longer does, and the suppression stays until the whole ladder is past 23.
 
+A sixth had a fix rather than a suppression. `modernize-use-nullptr` reads the `0` in `(a <=> b) < 0` as a
+null pointer constant, which is the same false positive `-Wno-zero-as-null-pointer-constant` already covers on
+the compiler side. Every site in the test sources says `std::is_lt`, `std::is_gt` or `std::is_eq` instead --
+the standard's own names for those three questions, which are clearer than the comparison against a literal
+and leave the check on to catch a real one. Do not spell them back.
+
 ### clang-crashes-on-a-foreign-bulk-source
 
 Asking whether a bulk operator accepts a view over a foreign storage -- `ours &= bit_span(a_std_bitset)`, in

--- a/include/xstd/bits/bit_proxy.hpp
+++ b/include/xstd/bits/bit_proxy.hpp
@@ -112,6 +112,7 @@ public:
         }
 
         // A value, not a handle to rebind: trivially copyable, never assignable, as a reference to a key is.
+        // [design.md#the-proxy-copies-the-handle]
         constexpr bit_set_reference(bit_set_reference const&) noexcept = default;
         constexpr auto operator=(bit_set_reference const&) -> bit_set_reference& = delete;
 
@@ -262,6 +263,11 @@ public:
         {
                 assert(m_ptr != nullptr);
         }
+
+        // Said out loud, because the assignments below are user-provided and that deprecates the implicit copy
+        // constructor: a copy duplicates the handle, where an assignment writes through it. The two do different
+        // things here, which is exactly why the compiler stops guessing. [design.md#the-proxy-copies-the-handle]
+        constexpr bit_sequence_reference(bit_sequence_reference const&) noexcept = default;
 
         [[nodiscard]] constexpr auto operator&() const noexcept
                 -> iterator

--- a/include/xstd/bits/block_sequence.hpp
+++ b/include/xstd/bits/block_sequence.hpp
@@ -853,44 +853,14 @@ public:
                 }
         }
 
-        [[nodiscard]] constexpr auto is_proper_subset_of(block_sequence const& other [[maybe_unused]]) const noexcept
+        // A proper subset is a subset that differs, and both halves are already here: the unrolled arms are
+        // is_subset_of's, and != is the defaulted memberwise comparison. Nothing is left to walk by hand.
+        // [design.md#the-cheapest-contract]
+        [[nodiscard]] constexpr auto is_proper_subset_of(block_sequence const& other) const noexcept
                 -> bool
         {
                 assert(this->size() == other.size());
-                if constexpr (has_static_size and N == 0) {
-                        return false;
-                } else if constexpr (has_static_size and static_num_blocks == 1) {
-                        return
-                                detail::bits::is_subset_of (this->m_blocks[0], other.m_blocks[0]) and
-                                detail::bits::not_equal_to(this->m_blocks[0], other.m_blocks[0])
-                        ;
-                } else if constexpr (has_static_size and static_num_blocks == 2) {
-                        if (not detail::bits::is_subset_of(this->m_blocks[0], other.m_blocks[0])) {
-                                return false;
-                        }
-                        if (detail::bits::not_equal_to(this->m_blocks[0], other.m_blocks[0])) {
-                                return detail::bits::is_subset_of(this->m_blocks[1], other.m_blocks[1]);
-                        }
-                        return
-                                detail::bits::is_subset_of (this->m_blocks[1], other.m_blocks[1]) and
-                                detail::bits::not_equal_to(this->m_blocks[1], other.m_blocks[1])
-                        ;
-                } else {
-                        auto i = 0UZ;
-                        while (i < num_blocks()) {
-                                if (not detail::bits::is_subset_of(this->m_blocks[i], other.m_blocks[i])) {
-                                        return false;
-                                }
-                                if (    detail::bits::not_equal_to(this->m_blocks[i], other.m_blocks[i])) {
-                                        break;
-                                }
-                                ++i;
-                        }
-                        return (i == num_blocks()) ? false : std::ranges::all_of(
-                                std::views::zip(this->m_blocks, other.m_blocks) | std::views::drop(i), [](auto&& _) { auto&& [ lhs, rhs ] = _;
-                                return detail::bits::is_subset_of(lhs, rhs);
-                        });
-                }
+                return is_subset_of(other) and *this != other;
         }
 
         [[nodiscard]] constexpr auto intersects(block_sequence const& other [[maybe_unused]]) const noexcept

--- a/include/xstd/bits/ext/xstd/bitset.hpp
+++ b/include/xstd/bits/ext/xstd/bitset.hpp
@@ -14,7 +14,17 @@
 #include <iterator>                     // make_reverse_iterator
 #include <ranges>                       // begin, end, rbegin, rend
 
-// The set reading's iterators over a bitset, found by ADL: a set view over it is borrowed, so the iterators outlive the temporary that made them.
+// The set reading's iterators over a bitset, found by ADL: a set view over it is borrowed, so the iterators outlive
+// the temporary that made them.
+//
+// Non-member on purpose, and not a leftover of the member-iterator refactor that gave every container a
+// begin(this auto&& self). A bitset_adaptor must not become a range: xstd::bitset is a strict extension of
+// std::bitset, and a range is the one addition a strict extension cannot make, because it changes what generic
+// code already written against std::bitset does with it -- fmt would format it as a sequence, std::ranges::to
+// would consume it. So iteration over the bitset reading is reachable by name and only by name, which is what
+// a free function found by ADL is and what a member could never be. The two sibling headers adapt foreign
+// bitsets and need none of this: they are bit_traits specializations, and the views carry the readings.
+// [design.md#a-strict-extension]
 namespace xstd {
 
 template<class Bits, class Traits> [[nodiscard]] constexpr auto begin  (      bitset_adaptor<Bits, Traits>& c) noexcept { return set_adaptor(c).begin(); }

--- a/include/xstd/bits/format.hpp
+++ b/include/xstd/bits/format.hpp
@@ -33,8 +33,11 @@
 // Not in <xstd/bits.hpp>: the umbrella keeps <format> off every consumer path for the same reason it keeps the
 // ext/ adaptors and Boost off it. A consumer who formats says so by including this header.
 
-// [namespace.std]/2 allows a specialization of a standard library template for a program-defined type.
+// [namespace.std]/2 allows a specialization of a standard library template for a program-defined type, which is
+// what these two are and all they are. clang-tidy 22 and 23 read the qualified definition as modifying namespace
+// std anyway; 24 no longer does. [design.md#clang-tidy-false-positives]
 template<class Bits, class Traits, class CharT>
+// NOLINTNEXTLINE(bugprone-std-namespace-modification)
 struct std::formatter<xstd::bit_set_reference<Bits, Traits>, CharT>
 :
         std::formatter<std::size_t, CharT>
@@ -47,6 +50,7 @@ struct std::formatter<xstd::bit_set_reference<Bits, Traits>, CharT>
 };
 
 template<class Bits, class Traits, class CharT>
+// NOLINTNEXTLINE(bugprone-std-namespace-modification)
 struct std::formatter<xstd::bit_sequence_reference<Bits, Traits>, CharT>
 :
         std::formatter<bool, CharT>

--- a/include/xstd/bits/format.hpp
+++ b/include/xstd/bits/format.hpp
@@ -1,0 +1,61 @@
+//          Copyright Rein Halbersma 2014-2026.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef XSTD_BITS_FORMAT_HPP
+#define XSTD_BITS_FORMAT_HPP
+
+#include <xstd/bits/bit_proxy.hpp>  // bit_sequence_reference, bit_set_reference
+#include <cstddef>                  // size_t
+#include <format>                   // formatter
+
+// std::format over the containers, which needs nothing said about the containers themselves. [design.md#formatting-the-proxies]
+//
+// Every owner and view here is already a range, so [format.range.formatter] would format it -- except that the
+// range formatter requires formattable<range_reference_t<R>>, and a reference of ours is a proxy. So the two
+// proxies are what get a formatter, and every container over them follows: bit_set, bit_static_set, bit_vector,
+// bit_array, the views, the windows, and the inplace column with them.
+//
+// Which is the shape the proxies already had for fmt. format_as is fmt's generic per-type hook -- define it for
+// one type and every range over that type formats -- so the proxies carry it and no container does. This is the
+// standard's hook for the same job, used the same way: one per proxy, containers for free.
+//
+// The readings then format in their own vocabulary without being asked to. [format.range.fmtkind] picks
+// range_format::set for a range with a key_type and range_format::sequence otherwise, so the set reading prints
+// {1, 3, 5} and the sequence reading [false, true, false, false] -- the same split fmt's format_as arrives at,
+// reached through the standard's own machinery. [design.md#two-readings-disagree]
+//
+// Deriving from the underlying formatter rather than writing parse() is what keeps the whole format spec: a width,
+// a fill, {:#x} on a position and {:d} on a bool all work, and the nested spec a range formatter forwards
+// ({::#x}) reaches them.
+//
+// Not in <xstd/bits.hpp>: the umbrella keeps <format> off every consumer path for the same reason it keeps the
+// ext/ adaptors and Boost off it. A consumer who formats says so by including this header.
+
+// [namespace.std]/2 allows a specialization of a standard library template for a program-defined type.
+template<class Bits, class Traits, class CharT>
+struct std::formatter<xstd::bit_set_reference<Bits, Traits>, CharT>
+:
+        std::formatter<std::size_t, CharT>
+{
+        template<class Context>
+        [[nodiscard]] constexpr auto format(xstd::bit_set_reference<Bits, Traits> ref, Context& ctx) const
+        {
+                return std::formatter<std::size_t, CharT>::format(static_cast<std::size_t>(ref), ctx);
+        }
+};
+
+template<class Bits, class Traits, class CharT>
+struct std::formatter<xstd::bit_sequence_reference<Bits, Traits>, CharT>
+:
+        std::formatter<bool, CharT>
+{
+        template<class Context>
+        [[nodiscard]] constexpr auto format(xstd::bit_sequence_reference<Bits, Traits> ref, Context& ctx) const
+        {
+                return std::formatter<bool, CharT>::format(static_cast<bool>(ref), ctx);
+        }
+};
+
+#endif  // XSTD_BITS_FORMAT_HPP

--- a/include/xstd/bits/set_adaptor.hpp
+++ b/include/xstd/bits/set_adaptor.hpp
@@ -27,6 +27,16 @@
 // The set reading, [set] over any Bits with a bit_traits specialization, owning it or referring to it. [design.md#the-three-adaptors]
 namespace xstd {
 
+namespace detail::set {
+
+// A range of consecutive ascending positions, which is what a block-wise fill needs and what a general input
+// range cannot be asked. std::views::iota is the one that says so in its type. [design.md#the-range-members]
+template<class R> inline constexpr bool is_consecutive = false;
+template<class W, class B> inline constexpr bool is_consecutive<std::ranges::iota_view<W, B>> = true;
+
+}       // namespace detail::set
+
+
 template<class Bits, ownership Own, bit_storage<Bits> Traits = bit_traits<std::remove_const_t<Bits>>>
 class set_adaptor
 {
@@ -218,11 +228,29 @@ public:
                 }
         }
 
+        // Ranged insertion has tiers, as the sequence reading's append_range does. [design.md#the-range-members]
         template<std::ranges::input_range R>
         constexpr void insert_range(this auto&& self, R&& rg)
                 requires std::constructible_from<value_type, std::ranges::range_reference_t<R>> and requires { Traits::insert(self.storage(), 0UZ); }
         {
-                self.insert(std::ranges::begin(rg), std::ranges::end(rg));
+                if constexpr (requires { self |= rg; }) {
+                        // Tier one: another set over the same storage, which is a union and already knows how to do
+                        // one block-wise, mismatched widths included.
+                        self |= rg;
+                } else if constexpr (detail::set::is_consecutive<std::remove_cvref_t<R>> and requires { self.storage().set(0UZ, 0UZ, true); }) {
+                        // Tier two: consecutive positions, so the first and last blocks are masked and everything
+                        // between them is written whole, which is what the ranged set does.
+                        if (not std::ranges::empty(rg)) {
+                                auto const lo  = static_cast<value_type>(*std::ranges::begin(rg));
+                                auto const len = static_cast<std::size_t>(std::ranges::distance(rg));
+                                // The last position first, so a growable storage is already wide enough for the fill
+                                // and a fixed one asserts exactly where an element-wise insert would have.
+                                Traits::insert(self.storage(), lo + len - 1UZ);
+                                self.storage().set(lo, len, true);
+                        }
+                } else {
+                        self.insert(std::ranges::begin(rg), std::ranges::end(rg));
+                }
         }
 
         constexpr void insert(this auto&& self, std::initializer_list<value_type> ilist)

--- a/include/xstd/bits/set_adaptor.hpp
+++ b/include/xstd/bits/set_adaptor.hpp
@@ -11,6 +11,7 @@
 #include <xstd/bits/bit_proxy.hpp>           // bit_set_iterator, bit_set_reference
 #include <xstd/bits/bit_traits.hpp>          // bit_storage, bit_traits, count, find_first, find_next, find_prev, static_bit_extent
 #include <xstd/bits/detail/hash.hpp>         // hash_append_bits, hash_append_positions, std_hash
+#include <xstd/bits/detail/intrin.hpp>       // countl_zero, countr_zero
 #include <xstd/bits/ownership.hpp>           // owned_bits_t, owned_storage, owned_traits_t, owner_of, ownership, owns
 #include <algorithm>                         // any_of, equal, includes, lexicographical_compare_three_way
 #include <cassert>                           // assert
@@ -19,10 +20,11 @@
 #include <cstddef>                           // ptrdiff_t, size_t
 #include <functional>                        // hash, less
 #include <initializer_list>                  // initializer_list
+#include <limits>                            // numeric_limits
 #include <iterator>                          // input_iterator, iter_reference_t, make_reverse_iterator, reverse_iterator, sentinel_for
 #include <ranges>                            // begin, enable_borrowed_range, enable_view, end, input_range, range_reference_t, from_range_t, swap
-#include <type_traits>                       // conditional_t, false_type, is_nothrow_swappable_v, remove_const_t, remove_reference_t
-#include <utility>                           // forward, pair
+#include <type_traits>                       // conditional_t, false_type, is_invocable_r_v, is_nothrow_swappable_v, remove_const_t, remove_cvref_t, remove_reference_t
+#include <utility>                           // forward, move, pair
 
 // The set reading, [set] over any Bits with a bit_traits specialization, owning it or referring to it. [design.md#the-three-adaptors]
 namespace xstd {
@@ -33,6 +35,83 @@ namespace detail::set {
 // range cannot be asked. std::views::iota is the one that says so in its type. [design.md#the-range-members]
 template<class R> inline constexpr bool is_consecutive = false;
 template<class W, class B> inline constexpr bool is_consecutive<std::ranges::iota_view<W, B>> = true;
+
+// Continue unless the functor says otherwise: a void functor always continues, a bool one says.
+// [design.md#the-set-for-each]
+template<class F>
+[[nodiscard]] constexpr auto invoke_continues(F& f, std::size_t pos) -> bool
+{
+        if constexpr (std::is_invocable_r_v<bool, F&, std::size_t>) {
+                return f(pos);
+        } else {
+                f(pos);
+                return true;
+        }
+}
+
+// One tier each, because the tier is the seam and sharing a body puts the whole over
+// readability-function-cognitive-complexity's threshold. [design.md#one-function-per-tier]
+
+// Blocks, lowest position first: load once per block, then tzcnt for the position and blsr to drop it.
+template<class Traits, class Bits, class F>
+constexpr void walk_blocks_ascending(Bits const& c, F& f)
+{
+        using block_type = std::remove_cvref_t<decltype(Traits::block(c, 0UZ))>;
+        constexpr auto digits = static_cast<std::size_t>(std::numeric_limits<block_type>::digits);
+
+        for (auto index = 0UZ, blocks = Traits::num_blocks(c); index < blocks; ++index) {
+                auto block = Traits::block(c, index);
+                while (block != block_type{}) {
+                        auto const offset = static_cast<std::size_t>(detail::bits::countr_zero(block));
+                        if (not invoke_continues(f, (digits * index) + offset)) {
+                                return;
+                        }
+                        block = static_cast<block_type>(block & static_cast<block_type>(block - block_type{1}));
+                }
+        }
+}
+
+// The mirror. w & (w - 1) has no descending twin, so this clears the bit it just reported.
+template<class Traits, class Bits, class F>
+constexpr void walk_blocks_descending(Bits const& c, F& f)
+{
+        using block_type = std::remove_cvref_t<decltype(Traits::block(c, 0UZ))>;
+        constexpr auto digits = static_cast<std::size_t>(std::numeric_limits<block_type>::digits);
+
+        for (auto n = 0UZ, blocks = Traits::num_blocks(c); n < blocks; ++n) {
+                auto const index = blocks - 1UZ - n;
+                auto block = Traits::block(c, index);
+                while (block != block_type{}) {
+                        auto const offset = digits - 1UZ - static_cast<std::size_t>(detail::bits::countl_zero(block));
+                        if (not invoke_continues(f, (digits * index) + offset)) {
+                                return;
+                        }
+                        block = static_cast<block_type>(block ^ static_cast<block_type>(block_type{1} << offset));
+                }
+        }
+}
+
+// The other tier: a storage with no block access -- boost::dynamic_bitset is the one -- walks positions, which
+// is what the iterator does and is still the same answer. [design.md#windows]
+template<class Range, class F>
+constexpr void walk_positions_ascending(Range const& r, F& f)
+{
+        for (auto const pos : r) {
+                if (not invoke_continues(f, pos)) {
+                        return;
+                }
+        }
+}
+
+template<class Range, class F>
+constexpr void walk_positions_descending(Range const& r, F& f)
+{
+        for (auto it = r.rbegin(), last = r.rend(); it != last; ++it) {
+                if (not invoke_continues(f, *it)) {
+                        return;
+                }
+        }
+}
 
 }       // namespace detail::set
 
@@ -172,6 +251,38 @@ public:
         [[nodiscard]] constexpr auto cend()    const noexcept -> const_iterator         { return end();    }
         [[nodiscard]] constexpr auto crbegin() const noexcept -> const_reverse_iterator { return rbegin(); }
         [[nodiscard]] constexpr auto crend()   const noexcept -> const_reverse_iterator { return rend();   }
+
+        // The set reading a block at a time, which is what an iterator cannot be. operator++ is flat: it must
+        // re-derive the word from (pointer, position) on every step, because an iterator stays copyable and
+        // restartable. A loop has somewhere to keep the block between positions, so it loads once per block and
+        // spends two instructions per position -- tzcnt for the position, blsr to drop it. Measured 4.0x to 5.3x
+        // over the range-for on every compiler tried, and the same on a two-word bitboard as at 2^22.
+        // [design.md#the-set-for-each]
+        //
+        // The functor may return void, or bool to mean "keep going", which is what a move generator wants when it
+        // has found its answer. Nothing else is offered: a functor that returns something else is a caller error
+        // rather than a value to discard silently.
+        template<class F>
+        constexpr void for_each(this auto&& self, F f)
+        {
+                if constexpr (requires { Traits::block(self.storage(), 0UZ); Traits::num_blocks(self.storage()); }) {
+                        detail::set::walk_blocks_ascending<Traits>(self.storage(), f);
+                } else {
+                        detail::set::walk_positions_ascending(self, f);
+                }
+        }
+
+        // The mirror, highest position first. w & (w - 1) has no descending twin, so this one clears the top bit
+        // it just reported instead. The set reading iterates both ways, and so does this. [design.md#the-set-for-each]
+        template<class F>
+        constexpr void for_each_reverse(this auto&& self, F f)
+        {
+                if constexpr (requires { Traits::block(self.storage(), 0UZ); Traits::num_blocks(self.storage()); }) {
+                        detail::set::walk_blocks_descending<Traits>(self.storage(), f);
+                } else {
+                        detail::set::walk_positions_descending(self, f);
+                }
+        }
 
         // capacity; a bitset's count() is a set's size(), and max_size() is the positions there are to hold. [design.md#max-size-is-the-bits]
         [[nodiscard]] constexpr auto empty() const noexcept -> bool { return begin() == end(); }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,9 +13,9 @@ find_package(range-v3 CONFIG REQUIRED)
 
 # clang-cl reports CXX_COMPILER_ID Clang but understands only MSVC-style driver flags.
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
-    set(xstd_bits_is_clang_cl ON)
+    set(${project_id}_is_clang_cl ON)
 else()
-    set(xstd_bits_is_clang_cl OFF)
+    set(${project_id}_is_clang_cl OFF)
 endif()
 
 set(cxx_compile_definitions
@@ -33,7 +33,7 @@ set(cxx_compile_options_warnings
         /permissive-
         /bigobj
     >
-    $<$<AND:$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>,$<NOT:$<BOOL:${xstd_bits_is_clang_cl}>>>:
+    $<$<AND:$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>,$<NOT:$<BOOL:${${project_id}_is_clang_cl}>>>:
         -pedantic-errors
     >
     $<$<CXX_COMPILER_ID:Clang>:
@@ -73,8 +73,8 @@ set(cxx_compile_options_warnings
         -Wno-restrict                       # false positive on std::vector's copy inside block_sequence's, inlined into bitset_adaptor's non-member operators (gcc 17-SVN, Release mode)
         -Wno-stringop-overread              # the same copy inlined into set_adaptor's non-member operators, under the name gcc 17-SVN gives it there (Release mode)
     >
-    $<$<AND:$<BOOL:${XSTD_BITS_WARNINGS_AS_ERRORS}>,$<CXX_COMPILER_ID:MSVC>>:/WX>
-    $<$<AND:$<BOOL:${XSTD_BITS_WARNINGS_AS_ERRORS}>,$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>>:-Werror>
+    $<$<AND:$<BOOL:${${project_option_prefix}_WARNINGS_AS_ERRORS}>,$<CXX_COMPILER_ID:MSVC>>:/WX>
+    $<$<AND:$<BOOL:${${project_option_prefix}_WARNINGS_AS_ERRORS}>,$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>>:-Werror>
 )
 
 set(cxx_compile_options_optimization
@@ -122,7 +122,7 @@ foreach(h ${public_headers})
     # Boost::headers because the ext/ self-sufficiency units adapt a header-only Boost library; the target carries only hash2.
     target_link_libraries(
         header.${header_test_id} PRIVATE
-        ${CMAKE_PROJECT_NAME}
+        xstd::bits
         Boost::headers
     )
 
@@ -188,7 +188,7 @@ foreach(t ${targets})
 
     target_link_libraries(
         ${target_id} PRIVATE
-        ${CMAKE_PROJECT_NAME}
+        xstd::bits
         Boost::headers
         Boost::unit_test_framework
         fmt::fmt

--- a/test/include/test/block_types.hpp
+++ b/test/include/test/block_types.hpp
@@ -48,9 +48,9 @@ template<template<std::size_t, class> class C, class Block>
 using straddling_extents = std::tuple
 <       C<    digits_v<Block> - 1, Block>
 ,       C<    digits_v<Block> + 1, Block>
-,       C<2 * digits_v<Block> - 1, Block>
+,       C<(2 * digits_v<Block>) - 1, Block>
 ,       C<2 * digits_v<Block>,     Block>
-,       C<2 * digits_v<Block> + 1, Block>
+,       C<(2 * digits_v<Block>) + 1, Block>
 ,       C<3 * digits_v<Block>,     Block>
 >;
 

--- a/test/include/test/set/ordering.hpp
+++ b/test/include/test/set/ordering.hpp
@@ -17,10 +17,23 @@
 namespace test::set {
 
 // What the set reading must order like, against std::set: set_compare's default trusts the viewed type's <=>, and dynamic_bitset's is wrong.
+//
+// Disagreements are counted rather than asserted per pair, so a universe wide enough to span blocks stays
+// affordable and a failure does not drown the log. [design.md#counted-not-asserted]
+//
+// The width matters as much as the pairs do. A universe inside one block never reaches the word-parallel
+// comparison's cross-block arm, which is where its predecessor was wrong: {0} against {8} compared greater,
+// because a comparator that only looked at the first differing block cannot see that the other side still has
+// elements waiting above it. So the callers pass a block type small enough for the universe to span two and
+// three of them. [design.md#the-ordering-primitive]
 template<class Bits>
 auto ordering_agrees_with_std_set(std::size_t universe = 4) -> void
 {
         auto const bound = 1UZ << universe;
+        auto equality_disagreements = 0UZ;
+        auto less_disagreements     = 0UZ;
+        auto greater_disagreements  = 0UZ;
+
         for (auto i = 0UZ; i < bound; ++i) {
                 for (auto j = 0UZ; j < bound; ++j) {
                         auto x = test::bitset::make_bitset<Bits>(universe);
@@ -40,13 +53,60 @@ auto ordering_agrees_with_std_set(std::size_t universe = 4) -> void
                         auto const xv = xstd::bit_set_view(x);
                         auto const yv = xstd::bit_set_view(y);
 
-                        BOOST_CHECK_EQUAL(xv == yv, kx == ky);
-                        BOOST_CHECK_EQUAL((xv <=> yv) < 0,
-                                          std::lexicographical_compare(kx.begin(), kx.end(), ky.begin(), ky.end()));
-                        BOOST_CHECK_EQUAL((xv <=> yv) > 0,
-                                          std::lexicographical_compare(ky.begin(), ky.end(), kx.begin(), kx.end()));
+                        equality_disagreements += static_cast<std::size_t>((xv == yv) != (kx == ky));
+                        less_disagreements     += static_cast<std::size_t>(
+                                ((xv <=> yv) < 0) != std::lexicographical_compare(kx.begin(), kx.end(), ky.begin(), ky.end()));
+                        greater_disagreements  += static_cast<std::size_t>(
+                                ((xv <=> yv) > 0) != std::lexicographical_compare(ky.begin(), ky.end(), kx.begin(), kx.end()));
                 }
         }
+
+        BOOST_CHECK_EQUAL(equality_disagreements, 0UZ);
+        BOOST_CHECK_EQUAL(less_disagreements,     0UZ);
+        BOOST_CHECK_EQUAL(greater_disagreements,  0UZ);
+}
+
+// Three blocks and up, where an exhaustive sweep is no longer affordable: 2^18 squared is not a test. Random
+// pairs instead, from a fixed seed so a failure is reproducible, which is what the original verification of this
+// algorithm did once it ran out of exhaustive room. [design.md#the-ordering-primitive]
+template<class Bits>
+auto ordering_agrees_with_std_set_sampled(std::size_t universe, std::size_t trials) -> void
+{
+        auto equality_disagreements = 0UZ;
+        auto less_disagreements     = 0UZ;
+        auto greater_disagreements  = 0UZ;
+        auto lcg = 0x9E3779B97F4A7C15ULL;
+        auto const next = [&lcg] { lcg = (lcg * 6364136223846793005ULL) + 1442695040888963407ULL; return lcg >> 11; };
+
+        for (auto t = 0UZ; t < trials; ++t) {
+                auto const i = next();
+                auto const j = next();
+
+                auto x = test::bitset::make_bitset<Bits>(universe);
+                auto y = test::bitset::make_bitset<Bits>(universe);
+                auto kx = std::set<std::size_t>();
+                auto ky = std::set<std::size_t>();
+
+                auto const xw = xstd::bit_set_view(x);
+                auto const yw = xstd::bit_set_view(y);
+                for (auto k = 0UZ; k < universe; ++k) {
+                        if (i >> k & 1UZ) { xw.insert(k); kx.insert(k); }
+                        if (j >> k & 1UZ) { yw.insert(k); ky.insert(k); }
+                }
+
+                auto const xv = xstd::bit_set_view(x);
+                auto const yv = xstd::bit_set_view(y);
+
+                equality_disagreements += static_cast<std::size_t>((xv == yv) != (kx == ky));
+                less_disagreements     += static_cast<std::size_t>(
+                        ((xv <=> yv) < 0) != std::lexicographical_compare(kx.begin(), kx.end(), ky.begin(), ky.end()));
+                greater_disagreements  += static_cast<std::size_t>(
+                        ((xv <=> yv) > 0) != std::lexicographical_compare(ky.begin(), ky.end(), kx.begin(), kx.end()));
+        }
+
+        BOOST_CHECK_EQUAL(equality_disagreements, 0UZ);
+        BOOST_CHECK_EQUAL(less_disagreements,     0UZ);
+        BOOST_CHECK_EQUAL(greater_disagreements,  0UZ);
 }
 
 } // namespace test::set

--- a/test/include/test/set/primitives.hpp
+++ b/test/include/test/set/primitives.hpp
@@ -346,10 +346,14 @@ struct mem_emplace
                 );
 
                 static_assert(std::constructible_from<typename X::value_type, Args...>);                // [associative.reqmts.general]/48
-                auto emplaced = not a.contains(typename X::value_type(std::forward<Args>(args)...));
-                auto r = a.emplace(std::forward<Args>(args)...);                                        // [associative.reqmts.general]/49
+                // Built once and then used three times. Forwarding three times reads args twice after moving
+                // from it: harmless where value_type is a size_t, wrong the moment this harness meets a type
+                // where a move is not a copy, and bugprone-use-after-move is right to say so.
+                auto const value = typename X::value_type(std::forward<Args>(args)...);
+                auto const emplaced = not a.contains(value);
+                auto r = a.emplace(value);                                                              // [associative.reqmts.general]/49
                                                                                 // [associative.reqmts.general]/50
-                BOOST_CHECK(r == std::make_pair(a.find(typename X::value_type(std::forward<Args>(args)...)), emplaced));
+                BOOST_CHECK(r == std::make_pair(a.find(value), emplaced));
         }
 };
 
@@ -364,8 +368,10 @@ struct mem_emplace_hint
                                 typename X::iterator
                         >
                 );
-                auto r = a.emplace_hint(p, std::forward<Args>(args)...);                        // [associative.reqmts.general]/58
-                BOOST_CHECK(r == a.find(typename X::value_type(std::forward<Args>(args)...)));  // [associative.reqmts.general]/59
+                // Built once, for the reason mem_emplace gives.
+                auto const value = typename X::value_type(std::forward<Args>(args)...);
+                auto r = a.emplace_hint(p, value);                                              // [associative.reqmts.general]/58
+                BOOST_CHECK(r == a.find(value));                                                // [associative.reqmts.general]/59
         }
 };
 

--- a/test/src/bits/bit_array.cpp
+++ b/test/src/bits/bit_array.cpp
@@ -11,9 +11,12 @@
 #include <algorithm>                  // equal, none_of
 #include <array>                      // array
 #include <concepts>                   // regular, totally_ordered
+#include <cstddef>                    // size_t
 #include <functional>                 // hash, identity
 #include <iterator>                   // random_access_iterator
 #include <ranges>                     // drop, random_access_range, take
+#include <stdexcept>                  // out_of_range
+#include <vector>                     // vector
 
 BOOST_AUTO_TEST_SUITE(BitArray)
 
@@ -100,6 +103,69 @@ auto model_of(T const& a) -> std::vector<bool>
         return m;
 }
 
+// Every read path at every position, counted rather than asserted one at a time: a failure then names the
+// operation instead of drowning the log in one line per position. [design.md#counted-not-asserted]
+//
+// Taken by non-const reference and aliased to a const one inside, because these take an explicit object
+// parameter and the const and non-const paths are two different functions, both of them under test.
+template<class T>
+auto access_disagreements(T& a, std::vector<bool> const& m) -> std::size_t
+{
+        auto const& ca = a;
+        auto disagreements = 0UZ;
+        for (auto i = 0UZ; i < a.size(); ++i) {
+                disagreements += static_cast<std::size_t>(static_cast<bool>(a[i])     != m[i]);
+                disagreements += static_cast<std::size_t>(static_cast<bool>(ca[i])    != m[i]);
+                disagreements += static_cast<std::size_t>(static_cast<bool>(a.at(i))  != m[i]);
+                disagreements += static_cast<std::size_t>(static_cast<bool>(ca.at(i)) != m[i]);
+        }
+        return disagreements;
+}
+
+// front() and back() are the same four overloads over the two ends, and a zero extent has neither.
+template<class T>
+auto ends_disagreements(T& a, std::vector<bool> const& m) -> std::size_t
+{
+        if (a.empty()) {
+                return 0UZ;
+        }
+        auto const& ca = a;
+        return static_cast<std::size_t>(static_cast<bool>(a.front())  != m.front())
+             + static_cast<std::size_t>(static_cast<bool>(ca.front()) != m.front())
+             + static_cast<std::size_t>(static_cast<bool>(a.back())   != m.back())
+             + static_cast<std::size_t>(static_cast<bool>(ca.back())  != m.back());
+}
+
+// One bit of pattern p at position i. A lookup rather than a conditional chain: six patterns written as a
+// chain nest six deep, and the nesting is not what the test is about.
+auto pattern_bit(std::size_t p, std::size_t i, std::size_t n) -> bool
+{
+        switch (p) {
+        case 0UZ: return false;
+        case 1UZ: return true;
+        case 2UZ: return i == 0UZ;
+        case 3UZ: return i + 1UZ == n;
+        case 4UZ: return (i % 2UZ) == 0UZ;
+        default:  return (i % 3UZ) == 0UZ;
+        }
+}
+
+// Uniform both ways, single-ended both ways, and two strides: enough that every comparison lands on both
+// sides of itself, and cheaper than every pair of values.
+template<class T>
+auto comparison_patterns() -> std::vector<T>
+{
+        auto patterns = std::vector<T>();
+        for (auto p = 0UZ; p < 6UZ; ++p) {
+                auto a = T();
+                for (auto i = 0UZ; i < a.size(); ++i) {
+                        a[i] = pattern_bit(p, i, a.size());
+                }
+                patterns.push_back(a);
+        }
+        return patterns;
+}
+
 }       // namespace
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(ElementAccessAgreesWithTheModel, T, Types)
@@ -115,22 +181,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ElementAccessAgreesWithTheModel, T, Types)
         }
         BOOST_CHECK(std::ranges::equal(a, m));
 
-        // The four value categories, which matter here because these take an explicit object parameter.
-        auto const& ca = a;
-        for (auto i = 0UZ; i < a.size(); ++i) {
-                BOOST_CHECK_EQUAL(static_cast<bool>(a[i]),     m[i]);
-                BOOST_CHECK_EQUAL(static_cast<bool>(ca[i]),    m[i]);
-                BOOST_CHECK_EQUAL(static_cast<bool>(a.at(i)),  m[i]);
-                BOOST_CHECK_EQUAL(static_cast<bool>(ca.at(i)), m[i]);
-        }
-        if (not a.empty()) {
-                BOOST_CHECK_EQUAL(static_cast<bool>(a.front()),  m.front());
-                BOOST_CHECK_EQUAL(static_cast<bool>(ca.front()), m.front());
-                BOOST_CHECK_EQUAL(static_cast<bool>(a.back()),   m.back());
-                BOOST_CHECK_EQUAL(static_cast<bool>(ca.back()),  m.back());
-        }
+        // Both subscripts and both ends, in both qualifications.
+        BOOST_CHECK_EQUAL(access_disagreements(a, m), 0UZ);
+        BOOST_CHECK_EQUAL(ends_disagreements(a, m),   0UZ);
 
         // at() is the checked one, and std::array<bool, N>::at throws in the same place.
+        auto const& ca = a;
         BOOST_CHECK_THROW(static_cast<void>(a.at(a.size())),  std::out_of_range);
         BOOST_CHECK_THROW(static_cast<void>(ca.at(a.size())), std::out_of_range);
 }
@@ -187,35 +243,23 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(FillAndSwapAgreeWithTheModel, T, Types)
 // of patterns, which is cheaper than every pair of values and lands on both sides of each comparison.
 BOOST_AUTO_TEST_CASE_TEMPLATE(TheComparisonsAgreeWithTheModel, T, Types)
 {
-        auto const patterns = [] {
-                auto v = std::vector<T>();
-                for (auto p = 0UZ; p < 6UZ; ++p) {
-                        auto a = T();
-                        for (auto i = 0UZ; i < a.size(); ++i) {
-                                a[i] = (p == 0UZ) ? false
-                                     : (p == 1UZ) ? true
-                                     : (p == 2UZ) ? (i == 0UZ)
-                                     : (p == 3UZ) ? (i + 1UZ == a.size())
-                                     : (p == 4UZ) ? ((i % 2UZ) == 0UZ)
-                                     :              ((i % 3UZ) == 0UZ);
-                        }
-                        v.push_back(a);
-                }
-                return v;
-        }();
+        auto const patterns = comparison_patterns<T>();
+        auto disagreements = 0UZ;
 
         for (auto const& x : patterns) {
                 for (auto const& y : patterns) {
                         auto const mx = model_of(x);
                         auto const my = model_of(y);
-                        BOOST_CHECK_EQUAL(x == y, mx == my);
-                        BOOST_CHECK_EQUAL(x != y, mx != my);
-                        BOOST_CHECK_EQUAL(x <  y, mx <  my);
-                        BOOST_CHECK_EQUAL(x >  y, mx >  my);
-                        BOOST_CHECK_EQUAL(x <= y, mx <= my);
-                        BOOST_CHECK_EQUAL(x >= y, mx >= my);
+                        disagreements += static_cast<std::size_t>((x == y) != (mx == my));
+                        disagreements += static_cast<std::size_t>((x != y) != (mx != my));
+                        disagreements += static_cast<std::size_t>((x <  y) != (mx <  my));
+                        disagreements += static_cast<std::size_t>((x >  y) != (mx >  my));
+                        disagreements += static_cast<std::size_t>((x <= y) != (mx <= my));
+                        disagreements += static_cast<std::size_t>((x >= y) != (mx >= my));
                 }
         }
+
+        BOOST_CHECK_EQUAL(disagreements, 0UZ);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/bits/bit_array.cpp
+++ b/test/src/bits/bit_array.cpp
@@ -84,4 +84,138 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ItIsListInitializedLikeAStdArray, T, Types)
         BOOST_CHECK(T{} == T());
 }
 
+// The behavioural half, which this suite was missing while the bitset and set suites had theirs: every operation
+// run on a bit_array and on the std::array<bool, N> it is held against, and the two compared. A synopsis
+// checklist says the line exists; only this says it answers the same thing. [design.md#the-sequence-contract]
+namespace {
+
+// The model at the same extent, filled the same way, so any disagreement is the packing's.
+template<class T>
+auto model_of(T const& a) -> std::vector<bool>
+{
+        auto m = std::vector<bool>(a.size());
+        for (auto i = 0UZ; i < a.size(); ++i) {
+                m[i] = a[i];
+        }
+        return m;
+}
+
+}       // namespace
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(ElementAccessAgreesWithTheModel, T, Types)
+{
+        auto a = T();
+        auto m = std::vector<bool>(a.size());
+
+        // A deterministic pattern rather than a uniform one, so a block boundary lands mid-pattern.
+        for (auto i = 0UZ; i < a.size(); ++i) {
+                bool const bit = (i % 3UZ) == 1UZ;
+                a[i] = bit;
+                m[i] = bit;
+        }
+        BOOST_CHECK(std::ranges::equal(a, m));
+
+        // The four value categories, which matter here because these take an explicit object parameter.
+        auto const& ca = a;
+        for (auto i = 0UZ; i < a.size(); ++i) {
+                BOOST_CHECK_EQUAL(static_cast<bool>(a[i]),     m[i]);
+                BOOST_CHECK_EQUAL(static_cast<bool>(ca[i]),    m[i]);
+                BOOST_CHECK_EQUAL(static_cast<bool>(a.at(i)),  m[i]);
+                BOOST_CHECK_EQUAL(static_cast<bool>(ca.at(i)), m[i]);
+        }
+        if (not a.empty()) {
+                BOOST_CHECK_EQUAL(static_cast<bool>(a.front()),  m.front());
+                BOOST_CHECK_EQUAL(static_cast<bool>(ca.front()), m.front());
+                BOOST_CHECK_EQUAL(static_cast<bool>(a.back()),   m.back());
+                BOOST_CHECK_EQUAL(static_cast<bool>(ca.back()),  m.back());
+        }
+
+        // at() is the checked one, and std::array<bool, N>::at throws in the same place.
+        BOOST_CHECK_THROW(static_cast<void>(a.at(a.size())),  std::out_of_range);
+        BOOST_CHECK_THROW(static_cast<void>(ca.at(a.size())), std::out_of_range);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(TheIteratorsAgreeWithTheModel, T, Types)
+{
+        auto a = T();
+        for (auto i = 0UZ; i < a.size(); ++i) {
+                a[i] = (i % 4UZ) < 2UZ;
+        }
+        auto const m = model_of(a);
+        auto const& ca = a;
+
+        BOOST_CHECK(std::ranges::equal(a, m));
+        BOOST_CHECK(std::equal(a.begin(),   a.end(),   m.begin(),  m.end()));
+        BOOST_CHECK(std::equal(a.cbegin(),  a.cend(),  m.begin(),  m.end()));
+        BOOST_CHECK(std::equal(ca.begin(),  ca.end(),  m.begin(),  m.end()));
+        BOOST_CHECK(std::equal(a.rbegin(),  a.rend(),  m.rbegin(), m.rend()));
+        BOOST_CHECK(std::equal(a.crbegin(), a.crend(), m.rbegin(), m.rend()));
+        BOOST_CHECK(std::equal(ca.rbegin(), ca.rend(), m.rbegin(), m.rend()));
+
+        BOOST_CHECK_EQUAL(a.empty(), m.empty());
+        BOOST_CHECK_EQUAL(a.size(),  m.size());
+        BOOST_CHECK_EQUAL(a.max_size(), a.size());   // a fixed extent is its own capacity [design.md#width-is-capacity]
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(FillAndSwapAgreeWithTheModel, T, Types)
+{
+        auto a = T();
+        a.fill(true);
+        BOOST_CHECK(std::ranges::equal(a, std::vector<bool>(a.size(), true)));
+        a.fill(false);
+        BOOST_CHECK(std::ranges::equal(a, std::vector<bool>(a.size(), false)));
+
+        auto x = T();
+        auto y = T();
+        for (auto i = 0UZ; i < x.size(); ++i) {
+                x[i] = (i % 2UZ) == 0UZ;
+                y[i] = (i % 5UZ) == 0UZ;
+        }
+        auto const mx = model_of(x);
+        auto const my = model_of(y);
+
+        x.swap(y);
+        BOOST_CHECK(std::ranges::equal(x, my));
+        BOOST_CHECK(std::ranges::equal(y, mx));
+
+        swap(x, y);
+        BOOST_CHECK(std::ranges::equal(x, mx));
+        BOOST_CHECK(std::ranges::equal(y, my));
+}
+
+// std::array<bool, N> orders lexicographically over its elements, and so must this. Every pair of a graded set
+// of patterns, which is cheaper than every pair of values and lands on both sides of each comparison.
+BOOST_AUTO_TEST_CASE_TEMPLATE(TheComparisonsAgreeWithTheModel, T, Types)
+{
+        auto const patterns = [] {
+                auto v = std::vector<T>();
+                for (auto p = 0UZ; p < 6UZ; ++p) {
+                        auto a = T();
+                        for (auto i = 0UZ; i < a.size(); ++i) {
+                                a[i] = (p == 0UZ) ? false
+                                     : (p == 1UZ) ? true
+                                     : (p == 2UZ) ? (i == 0UZ)
+                                     : (p == 3UZ) ? (i + 1UZ == a.size())
+                                     : (p == 4UZ) ? ((i % 2UZ) == 0UZ)
+                                     :              ((i % 3UZ) == 0UZ);
+                        }
+                        v.push_back(a);
+                }
+                return v;
+        }();
+
+        for (auto const& x : patterns) {
+                for (auto const& y : patterns) {
+                        auto const mx = model_of(x);
+                        auto const my = model_of(y);
+                        BOOST_CHECK_EQUAL(x == y, mx == my);
+                        BOOST_CHECK_EQUAL(x != y, mx != my);
+                        BOOST_CHECK_EQUAL(x <  y, mx <  my);
+                        BOOST_CHECK_EQUAL(x >  y, mx >  my);
+                        BOOST_CHECK_EQUAL(x <= y, mx <= my);
+                        BOOST_CHECK_EQUAL(x >= y, mx >= my);
+                }
+        }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/bits/bit_set.cpp
+++ b/test/src/bits/bit_set.cpp
@@ -5,12 +5,13 @@
 
 #include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL
 #include <test/set/concepts.hpp>        // bit_set
-#include <xstd/bits/set_adaptor.hpp>  // set_adaptor
+#include <xstd/bits/set_adaptor.hpp>    // set_adaptor
 #include <xstd/bits/bit_set.hpp>        // bit_set
 #include <xstd/bits/block_sequence.hpp> // block_vector
 #include <xstd/bits/ownership.hpp>      // ownership
-#include <xstd/bits/bit_set_view.hpp> // bit_set_view
+#include <xstd/bits/bit_set_view.hpp>   // bit_set_view
 #include <algorithm>                    // equal
+#include <compare>                      // is_eq
 #include <concepts>                     // same_as
 #include <cstddef>                      // size_t
 #include <cstdint>                      // uint8_t
@@ -79,7 +80,7 @@ BOOST_AUTO_TEST_CASE(TheWidthIsCapacityNotValue)
         wide.erase(100);
         auto const digest = std::hash<T>();
         BOOST_CHECK(narrow == wide);
-        BOOST_CHECK((narrow <=> wide) == 0);
+        BOOST_CHECK(std::is_eq(narrow <=> wide));
         BOOST_CHECK_EQUAL(digest(narrow), digest(wide));
         BOOST_CHECK(digest(narrow) != digest(T({ 1 })));
         BOOST_CHECK(narrow.is_subset_of(wide) and wide.is_subset_of(narrow));

--- a/test/src/bits/bit_set_view.cpp
+++ b/test/src/bits/bit_set_view.cpp
@@ -6,17 +6,18 @@
 #include <boost/test/unit_test.hpp>               // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
 #include <range/v3/view/set_algorithm.hpp>        // set_union
 #include <test/set/ordering.hpp>                  // ordering_agrees_with_std_set
-#include <xstd/bits/set_adaptor.hpp>            // set_adaptor
+#include <xstd/bits/set_adaptor.hpp>              // set_adaptor
 #include <xstd/bits/bit_static_set.hpp>           // bit_static_set
 #include <xstd/bits/bitset.hpp>                   // bitset
 #include <xstd/bits/block_sequence.hpp>           // block_array
 #include <xstd/bits/ext/boost/dynamic_bitset.hpp> // bit_traits over boost::dynamic_bitset
 #include <xstd/bits/ext/std/bitset.hpp>           // bit_traits over std::bitset
 #include <xstd/bits/ownership.hpp>                // ownership
-#include <xstd/bits/bit_set_view.hpp>          // bit_set_view
+#include <xstd/bits/bit_set_view.hpp>             // bit_set_view
 #include <bitset>                                 // bitset
 #include <concepts>                               // derived_from, same_as
 #include <cstddef>                                // size_t
+#include <cstdint>                                // uint8_t
 #include <functional>                             // hash
 #include <ranges>                                 // bidirectional_range, borrowed_range, range, view
 #include <set>                                    // set

--- a/test/src/bits/bit_set_view.cpp
+++ b/test/src/bits/bit_set_view.cpp
@@ -153,6 +153,20 @@ BOOST_AUTO_TEST_CASE(EveryViewedTypeOrdersLikeAStdSet)
         test::set::ordering_agrees_with_std_set<boost::dynamic_bitset<>>();
 }
 
+// One block cannot reach the arm the word-parallel comparison exists for. An eight-bit block makes position 8
+// the second block's first, so a universe of nine spans two blocks and one of eighteen spans three, and the
+// pair {0} against {8} -- the one an earlier comparator got backwards -- is inside the first sweep.
+// [design.md#the-ordering-primitive]
+BOOST_AUTO_TEST_CASE(TheOrderingSpansBlocksAndNotJustPositions)
+{
+        test::set::ordering_agrees_with_std_set<xstd::basic_bitset<9, std::uint8_t>>(9);
+
+        // Three blocks, where "anything above" has to look past the next block as well as into it. 2^18 squared
+        // is not a sweep, so this one samples. [design.md#counted-not-asserted]
+        test::set::ordering_agrees_with_std_set_sampled<xstd::basic_bitset<18, std::uint8_t>>(18UZ, 20000UZ);
+        test::set::ordering_agrees_with_std_set_sampled<boost::dynamic_bitset<std::uint8_t>>(18UZ, 20000UZ);
+}
+
 // A view of keys composes with the lazy set algebra the way an owner does; the block-wise operators are the owner's shortcut around it.
 BOOST_AUTO_TEST_CASE_TEMPLATE(TheLazySetAlgebraRunsOverTheView, T, ViewedTypes)
 {

--- a/test/src/bits/bitset_adaptor.cpp
+++ b/test/src/bits/bitset_adaptor.cpp
@@ -17,7 +17,7 @@
 #include <algorithm>                              // equal
 #include <array>                                  // array
 #include <bitset>                                 // bitset
-#include <compare>                                // strong_ordering
+#include <compare>                                // is_lt, strong_ordering
 #include <concepts>                               // regular, same_as, totally_ordered
 #include <cstddef>                                // size_t
 #include <cstdint>                                // uint8_t, uint64_t
@@ -342,7 +342,7 @@ BOOST_AUTO_TEST_CASE(TheViewsReachABitset)
         BOOST_CHECK((keys == std::vector<std::size_t>{ 1, 69 }));
 
         BOOST_CHECK(va != vb);
-        BOOST_CHECK((vb <=> va) < 0);
+        BOOST_CHECK(std::is_lt(vb <=> va));
         BOOST_CHECK(va.is_subset_of(va));
         BOOST_CHECK_EQUAL(qa[69], true);
 

--- a/test/src/bits/dynamic_bitset.cpp
+++ b/test/src/bits/dynamic_bitset.cpp
@@ -10,6 +10,7 @@
 #include <xstd/bits/dynamic_bitset.hpp>           // dynamic_bitset
 #include <algorithm>                              // equal
 #include <array>                                  // array
+#include <compare>                                // is_eq, is_gt, is_lt
 #include <concepts>                               // regular, same_as, totally_ordered
 #include <cstddef>                                // size_t
 #include <cstdint>                                // uint8_t, uint64_t
@@ -102,9 +103,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(TheOrderingIsBoosts, T, Dynamic)
         for (auto const& [ x, bx ] : values) {
                 for (auto const& [ y, by ] : values) {
                         auto const cmp = x <=> y;
-                        disagreements += static_cast<int>((cmp < 0) != (bx < by));
-                        disagreements += static_cast<int>((cmp > 0) != (by < bx));
-                        disagreements += static_cast<int>((cmp == 0) != (bx == by));
+                        disagreements += static_cast<int>(std::is_lt(cmp) != (bx <  by));
+                        disagreements += static_cast<int>(std::is_gt(cmp) != (by <  bx));
+                        disagreements += static_cast<int>(std::is_eq(cmp) != (bx == by));
                         disagreements += static_cast<int>(cmp != (x.to_string() <=> y.to_string()));
                 }
         }
@@ -128,9 +129,9 @@ auto disagreements_against_boost(std::size_t w, std::size_t u, unsigned long lon
         if (u > 64) { y.set(65); by.set(65); }
 
         auto const cmp = x <=> y;
-        return static_cast<int>((cmp <  0) != (bx <  by))
-             + static_cast<int>((cmp >  0) != (by <  bx))
-             + static_cast<int>((cmp == 0) != (bx == by));
+        return static_cast<int>(std::is_lt(cmp) != (bx <  by))
+             + static_cast<int>(std::is_gt(cmp) != (by <  bx))
+             + static_cast<int>(std::is_eq(cmp) != (bx == by));
 }
 
 }       // namespace

--- a/test/src/bits/ext/boost/dynamic_bitset.cpp
+++ b/test/src/bits/ext/boost/dynamic_bitset.cpp
@@ -10,7 +10,7 @@
 #include <xstd/bits/bit_span.hpp>     // bit_span
 #include <xstd/bits/bit_set_view.hpp>          // bit_set_view
 #include <algorithm>                              // lexicographical_compare
-#include <compare>                                // strong_ordering
+#include <compare>                                // is_lt, strong_ordering
 #include <concepts>                               // regular, totally_ordered
 #include <cstddef>                                // size_t
 #include <ranges>                                 // bidirectional_range, random_access_range
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(TheViewReplacesItsOrderingRatherThanTrustingIt)
                         // What the keys themselves say, which is what the set reading means.
                         auto const expected = std::ranges::lexicographical_compare(kx, ky);
 
-                        BOOST_CHECK_EQUAL((xstd::bit_set_view(x) <=> xstd::bit_set_view(y)) < 0, expected);
+                        BOOST_CHECK_EQUAL(std::is_lt(xstd::bit_set_view(x) <=> xstd::bit_set_view(y)), expected);
                         disagreements += static_cast<int>((x < y) != expected);
                 }
         }

--- a/test/src/bits/format.cpp
+++ b/test/src/bits/format.cpp
@@ -1,0 +1,91 @@
+//          Copyright Rein Halbersma 2014-2026.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/test/unit_test.hpp>      // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
+#include <xstd/bits/bit_array.hpp>       // bit_array
+#include <xstd/bits/bit_set.hpp>         // bit_set
+#include <xstd/bits/bit_set_view.hpp>    // bit_set_view
+#include <xstd/bits/bit_span.hpp>        // bit_span
+#include <xstd/bits/bit_static_set.hpp>  // bit_static_set
+#include <xstd/bits/bit_vector.hpp>      // bit_vector
+#include <xstd/bits/format.hpp>          // IWYU pragma: keep; the formatter over the two proxies, which is what every case below reaches
+#include <format>                        // format
+
+BOOST_AUTO_TEST_SUITE(Format)
+
+// Nothing here says anything about a container: the two proxies carry a formatter and [format.range.formatter]
+// does the rest. So the point of each case below is which container reaches it, not that it was taught to.
+// [design.md#formatting-the-proxies]
+
+// [format.range.fmtkind] chooses range_format::set for a range with a key_type, so the set reading arrives at
+// braces without being told, the way fmt's format_as does. [design.md#two-readings-disagree]
+BOOST_AUTO_TEST_CASE(TheSetReadingFormatsInBraces)
+{
+        auto d = xstd::bit_set();
+        d.insert(1UZ); d.insert(3UZ); d.insert(5UZ);
+        BOOST_CHECK_EQUAL(std::format("{}", d), "{1, 3, 5}");
+
+        auto s = xstd::bit_static_set<8>();
+        s.insert(2UZ); s.insert(7UZ);
+        BOOST_CHECK_EQUAL(std::format("{}", s), "{2, 7}");
+
+        BOOST_CHECK_EQUAL(std::format("{}", xstd::bit_set()), "{}");
+}
+
+// And range_format::sequence otherwise, so the sequence reading arrives at brackets and prints every position,
+// clear ones included, which is the whole difference between the two readings.
+BOOST_AUTO_TEST_CASE(TheSequenceReadingFormatsInBrackets)
+{
+        auto v = xstd::bit_vector(4UZ);
+        v[1] = true;
+        BOOST_CHECK_EQUAL(std::format("{}", v), "[false, true, false, false]");
+
+        auto a = xstd::bit_array<4>();
+        a[2] = true;
+        BOOST_CHECK_EQUAL(std::format("{}", a), "[false, false, true, false]");
+
+        BOOST_CHECK_EQUAL(std::format("{}", xstd::bit_vector()), "[]");
+}
+
+// A view is a range over the same proxies, so it formats as its reading does and never as the owner's.
+BOOST_AUTO_TEST_CASE(TheViewsFormatAsTheirReading)
+{
+        auto v = xstd::bit_vector(4UZ);
+        v[1] = true;
+        v[3] = true;
+
+        BOOST_CHECK_EQUAL(std::format("{}", xstd::bit_set_view(v)), "{1, 3}");
+        BOOST_CHECK_EQUAL(std::format("{}", xstd::bit_span(v)),     "[false, true, false, true]");
+}
+
+// Deriving from formatter<size_t> and formatter<bool> rather than writing parse() is what keeps the spec, so the
+// nested spec a range formatter forwards reaches the underlying one intact.
+BOOST_AUTO_TEST_CASE(TheNestedSpecReachesTheUnderlyingFormatter)
+{
+        auto d = xstd::bit_set();
+        d.insert(1UZ); d.insert(3UZ); d.insert(5UZ);
+        BOOST_CHECK_EQUAL(std::format("{::#x}", d), "{0x1, 0x3, 0x5}");
+
+        auto v = xstd::bit_vector(4UZ);
+        v[1] = true;
+        BOOST_CHECK_EQUAL(std::format("{::d}", v), "[0, 1, 0, 0]");
+}
+
+// A proxy formats on its own too, which is what the container's formatter is built out of.
+BOOST_AUTO_TEST_CASE(AProxyFormatsAsItsValue)
+{
+        auto d = xstd::bit_set();
+        d.insert(42UZ);
+        BOOST_CHECK_EQUAL(std::format("{}",    *d.begin()), "42");
+        BOOST_CHECK_EQUAL(std::format("{:>4}", *d.begin()), "  42");
+
+        auto v = xstd::bit_vector(2UZ);
+        v[1] = true;
+        BOOST_CHECK_EQUAL(std::format("{}",    v[1]), "true");
+        BOOST_CHECK_EQUAL(std::format("{:>7}", v[0]), "  false");
+        BOOST_CHECK_EQUAL(std::format("{:d}",  v[1]), "1");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/bits/set_adaptor.cpp
+++ b/test/src/bits/set_adaptor.cpp
@@ -6,6 +6,7 @@
 #include <boost/test/unit_test.hpp>               // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL
 #include <test/minimal_traits.hpp>                // minimal_traits
 #include <xstd/bits/set_adaptor.hpp>            // set_adaptor
+#include <xstd/bits/bit_set.hpp>                  // bit_set
 #include <xstd/bits/bit_static_set.hpp>           // bit_static_set
 #include <xstd/bits/block_sequence.hpp>           // block_array, block_vector
 #include <xstd/bits/ext/boost/dynamic_bitset.hpp> // bit_traits over boost::dynamic_bitset
@@ -20,7 +21,7 @@
 #include <cstdint>                                // uint8_t, uint64_t
 #include <initializer_list>                       // initializer_list
 #include <limits>                                 // numeric_limits
-#include <ranges>                                 // bidirectional_range
+#include <ranges>                                 // bidirectional_range, iota
 #include <set>                                    // set
 #include <vector>                                 // vector
 
@@ -283,6 +284,71 @@ BOOST_AUTO_TEST_CASE(TheNonMemberFormsAreTheOwners)
         BOOST_CHECK(keys(z) == std::set<std::size_t>({ 6 }));
         swap(z, z);
         BOOST_CHECK(keys(z) == std::set<std::size_t>({ 6 }));
+}
+
+// insert_range takes a tier above the element-wise loop where it can, and the point of every case here is that
+// the answer is the element-wise one. A block-wise fill has to mask its first and last block, so the boundaries
+// are where it would go wrong: a range inside one block, a range spanning several, and one of each degenerate
+// shape. [design.md#the-range-members]
+BOOST_AUTO_TEST_CASE(RangedInsertionAgreesWithTheElementwiseLoop)
+{
+        constexpr auto N = 100UZ;
+
+        // The consecutive tier, over every [lo, hi) the width admits.
+        for (auto lo = 0UZ; lo <= N; ++lo) {
+                for (auto hi = lo; hi <= N; ++hi) {
+                        auto ranged = xstd::bit_static_set<N>();
+                        ranged.insert_range(std::views::iota(lo, hi));
+
+                        auto elementwise = xstd::bit_static_set<N>();
+                        for (auto i = lo; i < hi; ++i) {
+                                elementwise.insert(i);
+                        }
+                        BOOST_CHECK(ranged == elementwise);
+                }
+        }
+
+        // It has to leave what lies outside the range alone, which a whole-block write would not.
+        auto seeded = xstd::bit_static_set<N>();
+        seeded.insert(0UZ); seeded.insert(70UZ); seeded.insert(99UZ);
+        auto expected = seeded;
+        seeded.insert_range(std::views::iota(10UZ, 65UZ));
+        for (auto i = 10UZ; i < 65UZ; ++i) {
+                expected.insert(i);
+        }
+        BOOST_CHECK(seeded == expected);
+
+        // The set tier: a union, and equally the element-wise answer.
+        auto lhs = xstd::bit_static_set<N>();
+        lhs.insert(1UZ); lhs.insert(64UZ);
+        auto const rhs = [] { auto s = xstd::bit_static_set<N>(); s.insert(64UZ); s.insert(99UZ); return s; }();
+        auto united = lhs;
+        united.insert_range(rhs);
+        for (auto const x : rhs) {
+                lhs.insert(x);
+        }
+        BOOST_CHECK(united == lhs);
+}
+
+// The dynamic width grows to hold what is inserted, and the ranged tier must grow the same way the loop does.
+BOOST_AUTO_TEST_CASE(RangedInsertionGrowsADynamicWidth)
+{
+        auto ranged = xstd::bit_set();
+        ranged.insert_range(std::views::iota(5UZ, 130UZ));
+
+        auto elementwise = xstd::bit_set();
+        for (auto i = 5UZ; i < 130UZ; ++i) {
+                elementwise.insert(i);
+        }
+        BOOST_CHECK(ranged == elementwise);
+        BOOST_CHECK_EQUAL(ranged.size(), 125UZ);
+
+        // Appending a second, disjoint stretch grows it again and keeps the first.
+        ranged.insert_range(std::views::iota(200UZ, 260UZ));
+        for (auto i = 200UZ; i < 260UZ; ++i) {
+                elementwise.insert(i);
+        }
+        BOOST_CHECK(ranged == elementwise);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/bits/set_adaptor.cpp
+++ b/test/src/bits/set_adaptor.cpp
@@ -7,6 +7,7 @@
 #include <test/minimal_traits.hpp>                // minimal_traits
 #include <xstd/bits/set_adaptor.hpp>            // set_adaptor
 #include <xstd/bits/bit_set.hpp>                  // bit_set
+#include <xstd/bits/bit_set_view.hpp>             // bit_set_view
 #include <xstd/bits/bit_static_set.hpp>           // bit_static_set
 #include <xstd/bits/block_sequence.hpp>           // block_array, block_vector
 #include <xstd/bits/ext/boost/dynamic_bitset.hpp> // bit_traits over boost::dynamic_bitset
@@ -321,7 +322,9 @@ BOOST_AUTO_TEST_CASE(RangedInsertionAgreesWithTheElementwiseLoop)
         // The set tier: a union, and equally the element-wise answer.
         auto lhs = xstd::bit_static_set<N>();
         lhs.insert(1UZ); lhs.insert(64UZ);
-        auto const rhs = [] { auto s = xstd::bit_static_set<N>(); s.insert(64UZ); s.insert(99UZ); return s; }();
+        auto rhs = xstd::bit_static_set<N>();
+        rhs.insert(64UZ);
+        rhs.insert(99UZ);
         auto united = lhs;
         united.insert_range(rhs);
         for (auto const x : rhs) {
@@ -349,6 +352,84 @@ BOOST_AUTO_TEST_CASE(RangedInsertionGrowsADynamicWidth)
                 elementwise.insert(i);
         }
         BOOST_CHECK(ranged == elementwise);
+}
+
+// for_each is the block-at-a-time walk an iterator cannot be, so what has to be shown is that it answers exactly
+// what iteration answers -- over a storage with block access and over one without, which takes the other arm.
+// [design.md#the-set-for-each]
+BOOST_AUTO_TEST_CASE(ForEachVisitsWhatIterationVisits)
+{
+        auto const positions = { 0UZ, 1UZ, 63UZ, 64UZ, 65UZ, 99UZ };
+
+        auto owner = Owner();
+        for (auto const p : positions) { owner.insert(p); }
+
+        auto foreign = std::bitset<100>();                      // block access through the trait
+        auto boosted = boost::dynamic_bitset<>(100);            // no block access: the position-at-a-time arm
+        for (auto const p : positions) { foreign.set(p); boosted.set(p); }
+        auto const fv = xstd::bit_set_view(foreign);
+        auto const bv = xstd::bit_set_view(boosted);
+
+        auto const collect         = [](auto const& s) -> std::vector<std::size_t> { auto v = std::vector<std::size_t>(); s.for_each        ([&](std::size_t p) -> void { v.push_back(p); }); return v; };
+        auto const collect_reverse = [](auto const& s) -> std::vector<std::size_t> { auto v = std::vector<std::size_t>(); s.for_each_reverse([&](std::size_t p) -> void { v.push_back(p); }); return v; };
+        auto const iterated        = [](auto const& s) -> std::vector<std::size_t> { return { s.begin(), s.end() }; };
+        auto const reversed        = [](auto const& s) -> std::vector<std::size_t> { return { s.rbegin(), s.rend() }; };
+
+        BOOST_CHECK(collect(owner) == iterated(owner));
+        BOOST_CHECK(collect(fv)    == iterated(fv));
+        BOOST_CHECK(collect(bv)    == iterated(bv));
+
+        BOOST_CHECK(collect_reverse(owner) == reversed(owner));
+        BOOST_CHECK(collect_reverse(fv)    == reversed(fv));
+        BOOST_CHECK(collect_reverse(bv)    == reversed(bv));
+
+        // An empty set calls nothing, in either direction, on either arm.
+        auto const empty  = Owner();
+        auto const bnone  = boost::dynamic_bitset<>(100);
+        auto const bnonev = xstd::bit_set_view(bnone);
+        auto calls = 0UZ;
+        empty .for_each        ([&](std::size_t) -> void { ++calls; });
+        empty .for_each_reverse([&](std::size_t) -> void { ++calls; });
+        bnonev.for_each        ([&](std::size_t) -> void { ++calls; });
+        bnonev.for_each_reverse([&](std::size_t) -> void { ++calls; });
+        BOOST_CHECK_EQUAL(calls, 0UZ);
+}
+
+// A functor returning bool means "keep going", which is what a move generator wants once it has its answer. A
+// void one always continues. Both arms honour it.
+BOOST_AUTO_TEST_CASE(ForEachStopsWhenTheFunctorSaysSo)
+{
+        auto const positions = { 0UZ, 1UZ, 63UZ, 64UZ, 65UZ, 99UZ };
+
+        auto owner = Owner();
+        for (auto const p : positions) { owner.insert(p); }
+        auto boosted = boost::dynamic_bitset<>(100);
+        for (auto const p : positions) { boosted.set(p); }
+        auto const bv = xstd::bit_set_view(boosted);
+
+        // Stop after the first position at or above 64, so the cut lands on a block boundary.
+        auto const upto = [](auto const& s) -> std::vector<std::size_t> {
+                auto v = std::vector<std::size_t>();
+                s.for_each([&](std::size_t p) -> bool { v.push_back(p); return p < 64UZ; });
+                return v;
+        };
+        auto const expected = std::vector<std::size_t>{ 0UZ, 1UZ, 63UZ, 64UZ };
+        BOOST_CHECK(upto(owner) == expected);
+        BOOST_CHECK(upto(bv)    == expected);
+
+        auto const downto = [](auto const& s) -> std::vector<std::size_t> {
+                auto v = std::vector<std::size_t>();
+                s.for_each_reverse([&](std::size_t p) -> bool { v.push_back(p); return p > 64UZ; });
+                return v;
+        };
+        auto const expected_reverse = std::vector<std::size_t>{ 99UZ, 65UZ, 64UZ };
+        BOOST_CHECK(downto(owner) == expected_reverse);
+        BOOST_CHECK(downto(bv)    == expected_reverse);
+
+        // Stopping at the very first position visits exactly one.
+        auto first_only = 0UZ;
+        owner.for_each([&](std::size_t) -> bool { ++first_only; return false; });
+        BOOST_CHECK_EQUAL(first_only, 1UZ);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Oldest-first pass over the open issues. Nine resolved in code, two deferred to you, three new issues filed from what the work turned up.

Closes #20
Closes #22
Closes #24
Closes #27
Closes #37
Closes #61
Closes #78
Closes #89
Closes #123

## The README named templates that do not exist

Not from an issue — spotted in review, and the most user-visible thing here. Every cell of the landscape table gave the **short** name the parameter list belonging to the **`basic_`** one, and the dynamic column was worse than a wrong parameter count: `bit_set`, `bit_vector` and `dynamic_bitset` are **not templates at all**, so `bit_set<Block, Allocator>` named nothing.

Verified by compiling the table rather than reading it: all nine short names and all nine `basic_` names exactly as written, plus note 6's claim that `aligned::bitset<120>` is `bitset<128>`. Clean at C++26; at C++23 exactly six errors, all naming the three inplace cells, which is what the README already documents.

## #123 — `for_each` on the set reading

Walks blocks where the iterator walks positions. The difference is not word-parallelism — the functor still sees every set position one at a time — it is where the loop's state may live. `operator++` is flat and must re-derive the word from `(pointer, position)` every step, because an iterator stays copyable and restartable; a loop can hold a partly consumed block.

**4.52× and 4.56× on GCC 15, 5.05× and 4.08× on clang 22**, over a 128-bit board with twenty pieces and over 2²² at 40% density. Stable because `find_next` is serial and no vectorizer engages.

The issue's two open questions, settled: a functor may return `bool` to mean "keep going" (a `void` one always continues); the descending walk clears the bit it just reported, `w & (w - 1)` having no descending twin. A storage without block access takes the iterator — the third tier `fill` already uses.

Recorded as measured rather than assumed: the fat iterator carrying a residual word is **slower** than the member (2.56–3.80× vs 4.00–5.27×) *and* the only one of the two that changes a contract.

## #20 — `std::format` over the containers

P3070R0 was never the blocker. Every owner and view is already a range; `[format.range.formatter]` just requires `formattable<range_reference_t<R>>` and our reference is a proxy. So `xstd/bits/format.hpp` specializes `std::formatter` for the two proxies and stops — every container follows unnamed, and the readings separate themselves via `[format.range.fmtkind]`. Same shape the proxies already had for fmt, in the standard's spelling.

## #22 — `is_proper_subset_of` is a subset that differs

One line, replacing a raw loop and three unrolled arms. Unrolling survives by delegation: at 128 bits GCC now *vectorizes* the inequality into `vpxorq`/`vptest`, which the hand-written version did not.

## #24 — ranged insertion gets its tiers

Two tiers above the element-wise loop, mirroring `append_range`: another set (a union, block-wise via `operator|=`), and consecutive positions via `std::views::iota`. `generate_candidates` is a `views::iota` through `ranges::to`, so the library's own sieve is the first caller. Tested by construction — every `[lo, hi)` the width admits, all 5151.

## #27, #37, #61, #78, #89

- **#27** — two thirds already done; the third is load-bearing and now says so (a `bitset_adaptor` must not become a range).
- **#37** — the algorithm was already resurfaced; the *verification* was single-block, and the bug it exists for is cross-block. Now exhaustive over two blocks and sampled over three. **Mutation-tested: pinning `any_above` to false fails it.**
- **#61** — the behavioural half of the `bit_array` suite, held against `std::array<bool, N>`.
- **#78 / #89** — `${CMAKE_PROJECT_NAME}` was naming the *top-level* project at three link sites; now `xstd::bits`. Identifiers derived once. `CMAKE_CXX_EXTENSIONS` was unset by omission and is now `ON` with the reason.

## Two genuine defects found while measuring #77

Both in `test/include/`, which CI's clang-tidy cannot see:

- **`bugprone-use-after-move` ×3** — `mem_emplace`/`mem_emplace_hint` forwarded `args` three times, so the second and third reads were of a moved-from object. Harmless at `value_type = size_t`, wrong for any type where a move is not a copy.
- **`readability-math-missing-parentheses` ×2** in `block_types.hpp`.

## Deferred to you, and not touched

- **#70** (`.clang-format`) — deferred at your request. Measured: 85 of 96 files either way; it flattens the hand-aligned tables and clang-format cannot preserve them.
- **#82** (`bit_valarray`) — a *fourth reading*, which changes the three-readings thesis the README and design.md are built on, and the issue leaves the cost unweighed. Assessment on the issue, including `cshift`/`rotl`/`rotr` as the separable piece it already endorses.
- **#77** — its headline ask was already done before this branch; the residual gap is measured in #126.
- **#121** — should be closed, not fixed; its premise is measured false.

## Filed from this work

- **#124** — `adjacent_blocks`: `word_at` and both shifts are one funnel shift written three times
- **#126** — 112 clang-tidy findings in `test/include/`, which `HeaderFilterRegex` hides
- **#127** — the sequence reading's `count`/`all`/`any`/`none`/`mismatch`, successor to #121

## Verification

73/73 tests passing; coverage 100% line and 100% branch under CI's own gcovr invocation and thresholds; clang-tidy **22 and 24** clean on every changed unit; the format header verified on GCC 15, GCC 16 and clang 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLhTckKKQENsJPrZMXJJzo