### PR TITLE
straddled_block: the funnel shift, spelled once

### DIFF
--- a/design.md
+++ b/design.md
@@ -177,7 +177,7 @@ whole words and a partial one at the end.
 ### the-funnel-shift
 
 Under `word_at` and both shift operators is one operation: two adjacent blocks spliced into a double-width
-word and shifted down. `block_sequence::straddled_block(index, R_shift, L_shift)` is that splice, and the three
+word and shifted down. `block_sequence::straddled_block(index, L_shift, R_shift)` is that splice, and the three
 sites now read as three uses of it rather than three spellings.
 
 It takes the shift **and** its complement, named as both operators already name them, because both already hold

--- a/design.md
+++ b/design.md
@@ -177,8 +177,16 @@ whole words and a partial one at the end.
 ### the-funnel-shift
 
 Under `word_at` and both shift operators is one operation: two adjacent blocks spliced into a double-width
-word and shifted down. `block_sequence::adjacent_blocks(index, offset)` is that splice, and the three sites
-now read as three uses of it rather than three spellings.
+word and shifted down. `block_sequence::straddled_block(index, R_shift, L_shift)` is that splice, and the three
+sites now read as three uses of it rather than three spellings.
+
+It takes the shift **and** its complement, named as both operators already name them, because both already hold
+the pair as loop invariants: passing only one would have the other derived back inside from what it was derived
+from outside. That round trip is one hoisted instruction, but it is also the thing that made the codegen differ
+at all -- with the pair passed, GCC emits the same instruction mix as the hand-written original (954 lines, 60
+subtractions, six `$64` immediates against 1016, 67 and twelve), differing only in register assignment. The two
+adding to the block width is the whole contract, and the assert says so. There is no one-shift overload:
+`word_at` holds only the offset and spells the complement at its single call site.
 
 They did not look alike, which is why it went unnoticed. `word_at(n)` takes `(index, offset)` from `n`.
 `operator>>=` reads `(i + n_blocks, R_shift)` — literally `word_at(i * digits + n)`, reached without

--- a/design.md
+++ b/design.md
@@ -174,6 +174,26 @@ the tail kept clear. Every masked write goes through it: boost's ranged `set`, `
 `fill`, and a window's bulk operators, each walking the words a range spans with the mask of what each holds,
 whole words and a partial one at the end.
 
+### the-funnel-shift
+
+Under `word_at` and both shift operators is one operation: two adjacent blocks spliced into a double-width
+word and shifted down. `block_sequence::adjacent_blocks(index, offset)` is that splice, and the three sites
+now read as three uses of it rather than three spellings.
+
+They did not look alike, which is why it went unnoticed. `word_at(n)` takes `(index, offset)` from `n`.
+`operator>>=` reads `(i + n_blocks, R_shift)` — literally `word_at(i * digits + n)`, reached without
+recomputing the division. `operator<<=` reads *one block below* its destination, `(i - n_blocks - 1,
+R_shift)`, because it walks down while writing up; its loop names `L_shift` and the complement is the
+offset, which is what hid the third one.
+
+**It asserts rather than guards, and that is the design content.** Every caller already handles its own edge,
+and they are different edges: `word_at`'s is a full-width shift or a missing block above, each operator's is
+the destination block with nothing beyond it, and — the one that matters — both operators branch on the
+*aligned* case **outside** their loop, into `std::shift_left` or `std::shift_right`. A guarded primitive
+called once per block would drag that test into the loop and cost the `memmove` fast path, which is the one
+thing those operators get for free. Keeping the check where it is preserves it, and the splice still exists
+once instead of three times.
+
 ## Contracts
 
 ### total-versus-precondition

--- a/include/xstd/bits/block_sequence.hpp
+++ b/include/xstd/bits/block_sequence.hpp
@@ -218,11 +218,10 @@ public:
         {
                 auto const [ index, offset ] = index_offset(n);
                 assert(index < num_blocks());
-                auto const low = static_cast<block_type>(m_blocks[index] >> offset);
                 if (offset == 0UZ or index == last_block()) {
-                        return low;
+                        return static_cast<block_type>(m_blocks[index] >> offset);
                 }
-                return static_cast<block_type>(low | static_cast<block_type>(m_blocks[index + 1UZ] << (bits_per_block - offset)));
+                return adjacent_blocks(index, offset);
         }
 
         // The write side of word_at, masked: the bits of value under mask land at [n, n + bits_per_block), split over two blocks where n is not aligned, and the tail stays clear. [design.md#the-blit]
@@ -548,7 +547,8 @@ public:
                         } else {
                                 auto const R_shift = bits_per_block - L_shift;
                                 for (auto i = last_block(); i > n_blocks; --i) {
-                                        m_blocks[i] = static_cast<block_type>(static_cast<block_type>(m_blocks[i - n_blocks] << L_shift) | static_cast<block_type>(m_blocks[i - n_blocks - 1] >> R_shift));
+                                        // Read one block lower than the destination: the splice of [i - n_blocks - 1, i - n_blocks]. [design.md#the-funnel-shift]
+                                        m_blocks[i] = adjacent_blocks(i - n_blocks - 1UZ, R_shift);
                                 }
                                 m_blocks[n_blocks] = static_cast<block_type>(m_blocks[0] << L_shift);
                         }
@@ -571,9 +571,9 @@ public:
                         if (R_shift == 0) {
                                 std::shift_left(std::ranges::begin(m_blocks), std::ranges::end(m_blocks), static_cast<std::ptrdiff_t>(n_blocks));
                         } else {
-                                auto const L_shift = bits_per_block - R_shift;
                                 for (auto i = 0UZ; i + n_blocks < last_block(); ++i) {
-                                        m_blocks[i] = static_cast<block_type>(static_cast<block_type>(m_blocks[i + n_blocks] >> R_shift) | static_cast<block_type>(m_blocks[i + n_blocks + 1] << L_shift));
+                                        // Which is word_at(i * bits_per_block + n), reached without recomputing the division. [design.md#the-funnel-shift]
+                                        m_blocks[i] = adjacent_blocks(i + n_blocks, R_shift);
                                 }
                                 m_blocks[last_block() - n_blocks] = static_cast<block_type>(m_blocks[last_block()] >> R_shift);
                         }
@@ -927,6 +927,19 @@ private:
                         }
                         return false;
                 }
+        }
+
+        // The blocks at index and index + 1 as one double-width word shifted down by offset: the funnel shift that
+        // word_at and both shift operators are each made of, spelled once. [design.md#the-funnel-shift]
+        [[nodiscard]] constexpr auto adjacent_blocks(std::size_t index, std::size_t offset) const noexcept
+                -> block_type
+        {
+                assert(0UZ < offset and offset < bits_per_block);
+                assert(index + 1UZ < num_blocks());
+                return static_cast<block_type>(
+                        static_cast<block_type>(m_blocks[index] >> offset) |
+                        static_cast<block_type>(m_blocks[index + 1UZ] << (bits_per_block - offset))
+                );
         }
 
         [[nodiscard]] constexpr auto last_block() const noexcept

--- a/include/xstd/bits/block_sequence.hpp
+++ b/include/xstd/bits/block_sequence.hpp
@@ -221,7 +221,7 @@ public:
                 if (offset == 0UZ or index == last_block()) {
                         return static_cast<block_type>(m_blocks[index] >> offset);
                 }
-                return straddled_block(index, offset, bits_per_block - offset);
+                return straddled_block(index, bits_per_block - offset, offset);
         }
 
         // The write side of word_at, masked: the bits of value under mask land at [n, n + bits_per_block), split over two blocks where n is not aligned, and the tail stays clear. [design.md#the-blit]
@@ -548,7 +548,7 @@ public:
                                 auto const R_shift = bits_per_block - L_shift;
                                 for (auto i = last_block(); i > n_blocks; --i) {
                                         // Read one block lower than the destination: the splice of [i - n_blocks - 1, i - n_blocks]. [design.md#the-funnel-shift]
-                                        m_blocks[i] = straddled_block(i - n_blocks - 1UZ, R_shift, L_shift);
+                                        m_blocks[i] = straddled_block(i - n_blocks - 1UZ, L_shift, R_shift);
                                 }
                                 m_blocks[n_blocks] = static_cast<block_type>(m_blocks[0] << L_shift);
                         }
@@ -574,7 +574,7 @@ public:
                                 auto const L_shift = bits_per_block - R_shift;
                                 for (auto i = 0UZ; i + n_blocks < last_block(); ++i) {
                                         // Which is word_at(i * bits_per_block + n), reached without recomputing the division. [design.md#the-funnel-shift]
-                                        m_blocks[i] = straddled_block(i + n_blocks, R_shift, L_shift);
+                                        m_blocks[i] = straddled_block(i + n_blocks, L_shift, R_shift);
                                 }
                                 m_blocks[last_block() - n_blocks] = static_cast<block_type>(m_blocks[last_block()] >> R_shift);
                         }
@@ -930,22 +930,23 @@ private:
                 }
         }
 
-        // The block straddling index and index + 1: the two spliced into one double-width word and shifted down by
-        // R_shift, which is the funnel shift word_at and both shift operators are each made of. [design.md#the-funnel-shift]
+        // The block straddling index and index + 1: the high one shifted up by L_shift and the low one down by
+        // R_shift, spliced into one. The funnel shift word_at and both shift operators are each made of.
+        // [design.md#the-funnel-shift]
         //
         // Named as both shift operators name them, and taken as a pair: they already hold both halves as loop
         // invariants, so neither has one derived back from what the other was derived from. word_at, holding only
         // the one, spells the complement at its single call site. That the two add to the block width is the whole
         // contract, and the assert says so.
-        [[nodiscard]] constexpr auto straddled_block(std::size_t index, std::size_t R_shift, std::size_t L_shift) const noexcept
+        [[nodiscard]] constexpr auto straddled_block(std::size_t index, std::size_t L_shift, std::size_t R_shift) const noexcept
                 -> block_type
         {
-                assert(R_shift + L_shift == bits_per_block);
+                assert(L_shift + R_shift == bits_per_block);
                 assert(0UZ < R_shift and R_shift < bits_per_block);
                 assert(index + 1UZ < num_blocks());
                 return static_cast<block_type>(
-                        static_cast<block_type>(m_blocks[index] >> R_shift) |
-                        static_cast<block_type>(m_blocks[index + 1UZ] << L_shift)
+                        static_cast<block_type>(m_blocks[index + 1UZ] << L_shift) |
+                        static_cast<block_type>(m_blocks[index] >> R_shift)
                 );
         }
 

--- a/include/xstd/bits/block_sequence.hpp
+++ b/include/xstd/bits/block_sequence.hpp
@@ -221,7 +221,7 @@ public:
                 if (offset == 0UZ or index == last_block()) {
                         return static_cast<block_type>(m_blocks[index] >> offset);
                 }
-                return adjacent_blocks(index, offset);
+                return straddled_block(index, offset, bits_per_block - offset);
         }
 
         // The write side of word_at, masked: the bits of value under mask land at [n, n + bits_per_block), split over two blocks where n is not aligned, and the tail stays clear. [design.md#the-blit]
@@ -548,7 +548,7 @@ public:
                                 auto const R_shift = bits_per_block - L_shift;
                                 for (auto i = last_block(); i > n_blocks; --i) {
                                         // Read one block lower than the destination: the splice of [i - n_blocks - 1, i - n_blocks]. [design.md#the-funnel-shift]
-                                        m_blocks[i] = adjacent_blocks(i - n_blocks - 1UZ, R_shift);
+                                        m_blocks[i] = straddled_block(i - n_blocks - 1UZ, R_shift, L_shift);
                                 }
                                 m_blocks[n_blocks] = static_cast<block_type>(m_blocks[0] << L_shift);
                         }
@@ -571,9 +571,10 @@ public:
                         if (R_shift == 0) {
                                 std::shift_left(std::ranges::begin(m_blocks), std::ranges::end(m_blocks), static_cast<std::ptrdiff_t>(n_blocks));
                         } else {
+                                auto const L_shift = bits_per_block - R_shift;
                                 for (auto i = 0UZ; i + n_blocks < last_block(); ++i) {
                                         // Which is word_at(i * bits_per_block + n), reached without recomputing the division. [design.md#the-funnel-shift]
-                                        m_blocks[i] = adjacent_blocks(i + n_blocks, R_shift);
+                                        m_blocks[i] = straddled_block(i + n_blocks, R_shift, L_shift);
                                 }
                                 m_blocks[last_block() - n_blocks] = static_cast<block_type>(m_blocks[last_block()] >> R_shift);
                         }
@@ -929,16 +930,22 @@ private:
                 }
         }
 
-        // The blocks at index and index + 1 as one double-width word shifted down by offset: the funnel shift that
-        // word_at and both shift operators are each made of, spelled once. [design.md#the-funnel-shift]
-        [[nodiscard]] constexpr auto adjacent_blocks(std::size_t index, std::size_t offset) const noexcept
+        // The block straddling index and index + 1: the two spliced into one double-width word and shifted down by
+        // R_shift, which is the funnel shift word_at and both shift operators are each made of. [design.md#the-funnel-shift]
+        //
+        // Named as both shift operators name them, and taken as a pair: they already hold both halves as loop
+        // invariants, so neither has one derived back from what the other was derived from. word_at, holding only
+        // the one, spells the complement at its single call site. That the two add to the block width is the whole
+        // contract, and the assert says so.
+        [[nodiscard]] constexpr auto straddled_block(std::size_t index, std::size_t R_shift, std::size_t L_shift) const noexcept
                 -> block_type
         {
-                assert(0UZ < offset and offset < bits_per_block);
+                assert(R_shift + L_shift == bits_per_block);
+                assert(0UZ < R_shift and R_shift < bits_per_block);
                 assert(index + 1UZ < num_blocks());
                 return static_cast<block_type>(
-                        static_cast<block_type>(m_blocks[index] >> offset) |
-                        static_cast<block_type>(m_blocks[index + 1UZ] << (bits_per_block - offset))
+                        static_cast<block_type>(m_blocks[index] >> R_shift) |
+                        static_cast<block_type>(m_blocks[index + 1UZ] << L_shift)
                 );
         }
 

--- a/test/src/bits/block_sequence.cpp
+++ b/test/src/bits/block_sequence.cpp
@@ -921,6 +921,21 @@ auto word_sample() -> T
         return b;
 }
 
+// A whole number of blocks, so there is no unused tail. operator<<= masks one off at the end, and the case below is
+// about the splice rather than about that mask.
+template<class T>
+auto aligned_sample() -> T
+{
+        auto b = T();
+        if constexpr (requires { b.resize(24UZ); }) {
+                b.resize(24UZ);
+        }
+        for (auto const i : { 0UZ, 3UZ, 7UZ, 8UZ, 12UZ, 15UZ, 19UZ, 23UZ }) {
+                b.set(i);
+        }
+        return b;
+}
+
 // One start and length through set, flip and reset, each against the model; a function rather than a loop body so the
 // case that sweeps it stays under readability-function-cognitive-complexity's threshold.
 template<class T>
@@ -979,6 +994,36 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(TheRangedFormsGoAWordAtATime, T, WordTypes)
                         if (n + len <= 20UZ) {
                                 check_ranged_forms<T>(n, len);
                         }
+                }
+        }
+}
+
+// Three blocks with no tail, so a shift's destination block is exactly the splice and nothing masks it afterwards.
+using AlignedWordTypes = std::tuple<xstd::block_array<std::uint8_t, 24>, xstd::block_vector<std::uint8_t>>;
+
+// The identity that lets one primitive serve all three sites: a right shift's destination block is word_at at that
+// position of the operand, and a left shift's is the same read one block lower. Each holds only where the block
+// above it exists -- past that there is nothing left to splice, which is the edge both operators hoist out of their
+// loop rather than test per block. [design.md#the-funnel-shift]
+BOOST_AUTO_TEST_CASE_TEMPLATE(BothShiftsAreWordAtOnTheOperand, T, AlignedWordTypes)
+{
+        constexpr auto D = 8UZ;
+        auto const c = aligned_sample<T>();
+        auto const last = c.num_blocks() - 1UZ;
+
+        for (auto n = 0UZ; n < c.size(); ++n) {
+                auto const n_blocks = n / D;
+
+                auto r = c;
+                r >>= n;
+                for (auto i = 0UZ; i + n_blocks <= last; ++i) {
+                        BOOST_CHECK_EQUAL(r.block(i), c.word_at((i * D) + n));
+                }
+
+                auto l = c;
+                l <<= n;
+                for (auto i = n_blocks + 1UZ; i <= last; ++i) {
+                        BOOST_CHECK_EQUAL(l.block(i), c.word_at((i * D) - n));
                 }
         }
 }


### PR DESCRIPTION
Closes #124

`word_at`, `operator<<=` and `operator>>=` each splice two adjacent blocks into one double-width word and shift it down. Three spellings of one operation, and none of them said so.

## The primitive

```cpp
// The block straddling index and index + 1: the high one shifted up by L_shift and the low one down by
// R_shift, spliced into one.
[[nodiscard]] constexpr auto straddled_block(std::size_t index, std::size_t L_shift, std::size_t R_shift) const noexcept -> block_type;
```

Private, one expression, and the three sites are now three uses of it:

| site | passes | why it did not look like the others |
| --- | --- | --- |
| `word_at(n)` | `(index, bits_per_block - offset, offset)` | keeps its `offset == 0 or index == last_block()` guard, then calls; holding only the offset, it spells the complement here |
| `operator>>=` | `(i + n_blocks, L_shift, R_shift)` | literally `word_at(i * bits_per_block + n)`, reached without recomputing the division |
| `operator<<=` | `(i - n_blocks - 1, L_shift, R_shift)` | reads **one block below** its destination: it walks down while writing up, and the offset is its `L_shift`'s complement |

That last row is what hid the third one.

**It takes the shift and its complement as a pair**, named as both operators already name them, with `assert(L_shift + R_shift == bits_per_block)` as the contract. Both operators already hold both halves as loop invariants; deriving one back inside from what the other was derived from outside is exactly the redundancy this removes. There is no two-parameter overload — a default argument could not spell one anyway, since [dcl.fct.default]/9 forbids naming another parameter.

**It asserts rather than guards**, per the issue's argument. Every caller handles a different edge, and — the one that matters — both operators branch on the *aligned* case **outside** their loop, into `std::shift_left`/`std::shift_right`. A guarded primitive called once per block would drag that test inside and cost the `memmove` fast path.

The compiler confirmed the redundancy was real: `operator>>=`'s `L_shift` briefly became an unused variable, and is now used again as the argument it always was.

## Measured, not assumed

The issue asked for this, and #117's ladder already benchmarks `bm_shift_left` from 1 to 512 words. The answer came out stronger than timing could have given on its own.

**Codegen.** GCC 15 at `-O3 -march=native`, over `bitset<256>`, `bitset<1024>` and `dynamic_bitset`:

| | non-directive lines | subtractions | `$64` immediates |
| --- | ---: | ---: | ---: |
| pre-refactor | 954 | 60 | 6 |
| one-shift form (superseded) | 1016 | 67 | 12 |
| **`(L_shift, R_shift)` pair** | **953** | **60** | **6** |

Passing the pair restores the original instruction mix exactly; what remains differs only in register assignment and operand order. The derived-back subtraction was the *only* reason the generated code differed at all.

**Timing**, run against the superseded one-shift form before that was known: both binaries built, then 9 alternating runs of the whole ladder, because this machine drifts several-fold across builds and only interleaved comparison is trustworthy. Ratios scattered 0.83×–1.04× with no consistent direction, and dispersion on identical code exceeded every difference — no measurable change even then. Worth recording that a shorter earlier run showed 8 of 11 rungs slower, which read as a small regression until more samples dissolved it.

## The test

`BothShiftsAreWordAtOnTheOperand` pins the identity the shared primitive rests on: a right shift's destination block **is** `word_at` at that position of the operand, and a left shift's is the same read one block lower.

Over a 24-bit sample — three blocks, **no unused tail, deliberately**, because `operator<<=` masks a tail off at the end and that would mask the very thing under test. Both halves stop where the block above runs out, which is exactly the edge each operator hoists out of its loop.

Mutation-tested, all three caught: the `<<=` off-by-one on the index, the splice reading the same block twice, and the low block shifted the wrong way.

## Verification

- GCC 15 and clang 22: warning-free, **73/73**
- clang-tidy 22 and 24: clean on the changed header and its test unit
- [design.md#gcc-array-bounds](../blob/main/design.md#gcc-array-bounds) checked specifically, since moving `m_blocks[index + 1]` behind a call could have cost GCC the flow information: at `-O2 -g` with asserts live the warning counts are identical before and after, and none names this header
- `design.md` gains `### the-funnel-shift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLhTckKKQENsJPrZMXJJzo