### PR TITLE
The test headers pass clang-tidy, and the filter is widened so they keep doing it

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,9 +4,15 @@
 #          http://www.boost.org/LICENSE_1_0.txt)
 
 ---
-# Static analysis for the public headers, run by the Clang-Tidy workflow
-# over the generated header self-sufficiency translation units (the
-# Boost.Test sources are excluded: test macros drown the signal in noise).
+# Static analysis for the public headers and for the test tree, run by the
+# Clang-Tidy workflow over two passes: the generated header self-sufficiency
+# translation units, and the test sources named by its sources_regex.
+#
+# The filter below carries test/include as well as include/xstd, because a
+# diagnostic raised inside a header is reported only if the header matches it.
+# Without that half the test headers were analyzed and then filtered out, and
+# the two genuine defects #126 found -- a use-after-move and a pair of missing
+# parentheses -- had been sitting there unreported.
 # bugprone-easily-swappable-parameters is off because both sites it reports
 # are fixed by the interface rather than chosen: to_string(charT zero, charT
 # one) is the signature std::bitset::to_string carries, and
@@ -31,7 +37,7 @@ Checks: >
   -readability-simplify-boolean-expr,
   -bugprone-easily-swappable-parameters
 WarningsAsErrors: '*'
-HeaderFilterRegex: 'include/xstd/.*'
+HeaderFilterRegex: '(include/xstd|test/include)/.*'
 FormatStyle: none
 CheckOptions:
   # Prefer alternative tokens for logical operators.

--- a/test/include/test/bitset/exhaustive.hpp
+++ b/test/include/test/bitset/exhaustive.hpp
@@ -22,11 +22,11 @@ namespace test::bitset {
 template<class X, auto Limit>
 inline constexpr auto limit_v = dynamic<X> ? Limit : X().size();
 
-inline constexpr auto L0 = 128uz;
-inline constexpr auto L1 =  64uz;
-inline constexpr auto L2 =  32uz;
-inline constexpr auto L3 =  16uz;
-inline constexpr auto L4 =   8uz;
+inline constexpr auto L0 = 128UZ;
+inline constexpr auto L1 =  64UZ;
+inline constexpr auto L2 =  32UZ;
+inline constexpr auto L3 =  16UZ;
+inline constexpr auto L4 =   8UZ;
 
 namespace on0 {
 
@@ -59,7 +59,7 @@ namespace on1 {
 template<class X, auto N = limit_v<X, L1>>
 auto all_valid(auto fun)
 {
-        for (auto i : std::views::iota(0uz, N)) {
+        for (auto i : std::views::iota(0UZ, N)) {
                 fun(i);
         }
 }
@@ -67,7 +67,7 @@ auto all_valid(auto fun)
 template<class X, auto N = limit_v<X, L1>>
 auto any_value(auto fun)
 {
-        for (auto i : std::views::iota(0uz, N + 1)) {
+        for (auto i : std::views::iota(0UZ, N + 1)) {
                 fun(i);
         }
 }
@@ -75,9 +75,9 @@ auto any_value(auto fun)
 template<class X, auto N = limit_v<X, L1>>
 auto all_cardinality_sets(auto fun)
 {
-        for (auto i : std::views::iota(0uz, N + 1)) {
+        for (auto i : std::views::iota(0UZ, N + 1)) {
                 auto a = make_bitset<X>(N);
-                for (auto j : std::views::iota(0uz, i)) {
+                for (auto j : std::views::iota(0UZ, i)) {
                         a.set(j);
                 }
                 assert(a.count() == i);
@@ -88,7 +88,7 @@ auto all_cardinality_sets(auto fun)
 template<class X, auto N = limit_v<X, L1>>
 auto all_singleton_sets(auto fun)
 {
-        for (auto i : std::views::iota(0uz, N)) {
+        for (auto i : std::views::iota(0UZ, N)) {
                 auto a = make_bitset<X>(N); a.set(i); assert(a.count() == 1);
                 fun(a);
         }
@@ -101,8 +101,8 @@ namespace on2 {
 template<class X, auto N = limit_v<X, L2>>
 auto all_singleton_set_pairs(auto fun)
 {
-        for (auto i : std::views::iota(0uz, N)) {
-                for (auto j : std::views::iota(0uz, N)) {
+        for (auto i : std::views::iota(0UZ, N)) {
+                for (auto j : std::views::iota(0UZ, N)) {
                         auto a = make_bitset<X>(N); a.set(i); assert(a.count() == 1);
                         auto b = make_bitset<X>(N); b.set(j); assert(b.count() == 1);
                         fun(a, b);
@@ -113,8 +113,8 @@ auto all_singleton_set_pairs(auto fun)
 template<class X, auto N = limit_v<X, L2>>
 auto all_doubleton_sets(auto fun)
 {
-        for (auto j : std::views::iota(1uz, std::ranges::max(N, 1uz))) {
-                for (auto i : std::views::iota(0uz, j)) {
+        for (auto j : std::views::iota(1UZ, std::ranges::max(N, 1UZ))) {
+                for (auto i : std::views::iota(0UZ, j)) {
                         auto a = make_bitset<X>(N); a.set(i); a.set(j); assert(a.count() == 2);
                         fun(a);
                 }
@@ -128,9 +128,9 @@ namespace on3 {
 template<class X, auto N = limit_v<X, L3>>
 auto all_singleton_set_triples(auto fun)
 {
-        for (auto i : std::views::iota(0uz, N)) {
-                for (auto j : std::views::iota(0uz, N)) {
-                        for (auto k : std::views::iota(0uz, N)) {
+        for (auto i : std::views::iota(0UZ, N)) {
+                for (auto j : std::views::iota(0UZ, N)) {
+                        for (auto k : std::views::iota(0UZ, N)) {
                                 auto a = make_bitset<X>(N); a.set(i); assert(a.count() == 1);
                                 auto b = make_bitset<X>(N); b.set(j); assert(b.count() == 1);
                                 auto c = make_bitset<X>(N); c.set(k); assert(c.count() == 1);
@@ -143,9 +143,9 @@ auto all_singleton_set_triples(auto fun)
 template<class X, auto N = limit_v<X, L3>>
 auto all_triplet_sets(auto fun)
 {
-        for (auto k : std::views::iota(2uz, std::ranges::max(N, 2uz))) {
-                for (auto j : std::views::iota(1uz, k)) {
-                        for (auto i : std::views::iota(0uz, j)) {
+        for (auto k : std::views::iota(2UZ, std::ranges::max(N, 2UZ))) {
+                for (auto j : std::views::iota(1UZ, k)) {
+                        for (auto i : std::views::iota(0UZ, j)) {
                                 auto a = make_bitset<X>(N); a.set(i); a.set(j); a.set(k); assert(a.count() == 3);
                                 fun(a);
                         }
@@ -160,10 +160,10 @@ namespace on4 {
 template<class X, auto N = limit_v<X, L4>>
 auto all_doubleton_set_pairs(auto fun)
 {
-        for (auto j : std::views::iota(1uz, std::ranges::max(N, 1uz))) {
-                for (auto n : std::views::iota(1uz, std::ranges::max(N, 1uz))) {
-                        for (auto i : std::views::iota(0uz, j)) {
-                                for (auto m : std::views::iota(0uz, n)) {
+        for (auto j : std::views::iota(1UZ, std::ranges::max(N, 1UZ))) {
+                for (auto n : std::views::iota(1UZ, std::ranges::max(N, 1UZ))) {
+                        for (auto i : std::views::iota(0UZ, j)) {
+                                for (auto m : std::views::iota(0UZ, n)) {
                                         auto a = make_bitset<X>(N); a.set(i); a.set(j); assert(a.count() == 2);
                                         auto b = make_bitset<X>(N); b.set(m); b.set(n); assert(b.count() == 2);
                                         fun(a, b);

--- a/test/include/test/bitset/exhaustive.hpp
+++ b/test/include/test/bitset/exhaustive.hpp
@@ -18,10 +18,6 @@
 #endif
 
 namespace test::bitset {
-// NOLINTBEGIN(misc-const-correctness): every object built below is handed to fun, and fun is the whole point --
-// some of the functors this harness is called with take their argument by non-const reference and write through
-// it, which is exactly what the set/reset/flip cases exist to check. clang-tidy sees one instantiation at a time
-// and proposes a const that would stop the mutating ones compiling. [design.md#clang-tidy-false-positives]
 
 template<class X, auto Limit>
 inline constexpr auto limit_v = dynamic<X> ? Limit : X().size();
@@ -37,22 +33,22 @@ namespace on0 {
 template<class X, auto N = limit_v<X, L0>>
 auto empty_set(auto fun)
 {
-        auto a = make_bitset<X>(N); assert(a.none());
+        auto a = make_bitset<X>(N); assert(a.none());  // NOLINT(misc-const-correctness): handed to fun, which some functors take by non-const reference
         fun(a);
 }
 
 template<class X, auto N = limit_v<X, L0>>
 auto full_set(auto fun)
 {
-        auto a = make_bitset<X>(N, true); assert(a.all());
+        auto a = make_bitset<X>(N, true); assert(a.all());  // NOLINT(misc-const-correctness): handed to fun, which some functors take by non-const reference
         fun(a);
 }
 
 template<class X, auto N = limit_v<X, L0>>
 auto empty_set_pair(auto fun)
 {
-        auto a = make_bitset<X>(N); assert(a.none());
-        auto b = make_bitset<X>(N); assert(b.none());
+        auto a = make_bitset<X>(N); assert(a.none());  // NOLINT(misc-const-correctness): handed to fun, which some functors take by non-const reference
+        auto b = make_bitset<X>(N); assert(b.none());  // NOLINT(misc-const-correctness): handed to fun, which some functors take by non-const reference
         fun(a, b);
 }
 
@@ -178,8 +174,6 @@ auto all_doubleton_set_pairs(auto fun)
 }
 
 }       // namespace on4
-
-// NOLINTEND(misc-const-correctness)
 
 } // namespace test::bitset
 

--- a/test/include/test/bitset/exhaustive.hpp
+++ b/test/include/test/bitset/exhaustive.hpp
@@ -18,6 +18,10 @@
 #endif
 
 namespace test::bitset {
+// NOLINTBEGIN(misc-const-correctness): every object built below is handed to fun, and fun is the whole point --
+// some of the functors this harness is called with take their argument by non-const reference and write through
+// it, which is exactly what the set/reset/flip cases exist to check. clang-tidy sees one instantiation at a time
+// and proposes a const that would stop the mutating ones compiling. [design.md#clang-tidy-false-positives]
 
 template<class X, auto Limit>
 inline constexpr auto limit_v = dynamic<X> ? Limit : X().size();
@@ -59,7 +63,7 @@ namespace on1 {
 template<class X, auto N = limit_v<X, L1>>
 auto all_valid(auto fun)
 {
-        for (auto i : std::views::iota(0UZ, N)) {
+        for (auto const i : std::views::iota(0UZ, N)) {
                 fun(i);
         }
 }
@@ -67,7 +71,7 @@ auto all_valid(auto fun)
 template<class X, auto N = limit_v<X, L1>>
 auto any_value(auto fun)
 {
-        for (auto i : std::views::iota(0UZ, N + 1)) {
+        for (auto const i : std::views::iota(0UZ, N + 1)) {
                 fun(i);
         }
 }
@@ -75,9 +79,9 @@ auto any_value(auto fun)
 template<class X, auto N = limit_v<X, L1>>
 auto all_cardinality_sets(auto fun)
 {
-        for (auto i : std::views::iota(0UZ, N + 1)) {
+        for (auto const i : std::views::iota(0UZ, N + 1)) {
                 auto a = make_bitset<X>(N);
-                for (auto j : std::views::iota(0UZ, i)) {
+                for (auto const j : std::views::iota(0UZ, i)) {
                         a.set(j);
                 }
                 assert(a.count() == i);
@@ -88,7 +92,7 @@ auto all_cardinality_sets(auto fun)
 template<class X, auto N = limit_v<X, L1>>
 auto all_singleton_sets(auto fun)
 {
-        for (auto i : std::views::iota(0UZ, N)) {
+        for (auto const i : std::views::iota(0UZ, N)) {
                 auto a = make_bitset<X>(N); a.set(i); assert(a.count() == 1);
                 fun(a);
         }
@@ -101,8 +105,8 @@ namespace on2 {
 template<class X, auto N = limit_v<X, L2>>
 auto all_singleton_set_pairs(auto fun)
 {
-        for (auto i : std::views::iota(0UZ, N)) {
-                for (auto j : std::views::iota(0UZ, N)) {
+        for (auto const i : std::views::iota(0UZ, N)) {
+                for (auto const j : std::views::iota(0UZ, N)) {
                         auto a = make_bitset<X>(N); a.set(i); assert(a.count() == 1);
                         auto b = make_bitset<X>(N); b.set(j); assert(b.count() == 1);
                         fun(a, b);
@@ -113,8 +117,8 @@ auto all_singleton_set_pairs(auto fun)
 template<class X, auto N = limit_v<X, L2>>
 auto all_doubleton_sets(auto fun)
 {
-        for (auto j : std::views::iota(1UZ, std::ranges::max(N, 1UZ))) {
-                for (auto i : std::views::iota(0UZ, j)) {
+        for (auto const j : std::views::iota(1UZ, std::ranges::max(N, 1UZ))) {
+                for (auto const i : std::views::iota(0UZ, j)) {
                         auto a = make_bitset<X>(N); a.set(i); a.set(j); assert(a.count() == 2);
                         fun(a);
                 }
@@ -143,9 +147,9 @@ auto all_singleton_set_triples(auto fun)
 template<class X, auto N = limit_v<X, L3>>
 auto all_triplet_sets(auto fun)
 {
-        for (auto k : std::views::iota(2UZ, std::ranges::max(N, 2UZ))) {
-                for (auto j : std::views::iota(1UZ, k)) {
-                        for (auto i : std::views::iota(0UZ, j)) {
+        for (auto const k : std::views::iota(2UZ, std::ranges::max(N, 2UZ))) {
+                for (auto const j : std::views::iota(1UZ, k)) {
+                        for (auto const i : std::views::iota(0UZ, j)) {
                                 auto a = make_bitset<X>(N); a.set(i); a.set(j); a.set(k); assert(a.count() == 3);
                                 fun(a);
                         }
@@ -160,10 +164,10 @@ namespace on4 {
 template<class X, auto N = limit_v<X, L4>>
 auto all_doubleton_set_pairs(auto fun)
 {
-        for (auto j : std::views::iota(1UZ, std::ranges::max(N, 1UZ))) {
-                for (auto n : std::views::iota(1UZ, std::ranges::max(N, 1UZ))) {
-                        for (auto i : std::views::iota(0UZ, j)) {
-                                for (auto m : std::views::iota(0UZ, n)) {
+        for (auto const j : std::views::iota(1UZ, std::ranges::max(N, 1UZ))) {
+                for (auto const n : std::views::iota(1UZ, std::ranges::max(N, 1UZ))) {
+                        for (auto const i : std::views::iota(0UZ, j)) {
+                                for (auto const m : std::views::iota(0UZ, n)) {
                                         auto a = make_bitset<X>(N); a.set(i); a.set(j); assert(a.count() == 2);
                                         auto b = make_bitset<X>(N); b.set(m); b.set(n); assert(b.count() == 2);
                                         fun(a, b);
@@ -174,6 +178,8 @@ auto all_doubleton_set_pairs(auto fun)
 }
 
 }       // namespace on4
+
+// NOLINTEND(misc-const-correctness)
 
 } // namespace test::bitset
 

--- a/test/include/test/bitset/primitives.hpp
+++ b/test/include/test/bitset/primitives.hpp
@@ -472,8 +472,8 @@ struct mem_is_proper_subset_of_edges
                 }
                 auto const lo = 0UZ;
                 auto const hi = N - 1;
-                auto const one = [&](std::size_t i)                 { auto x = a; x.set(i);           return x; };
-                auto const two = [&](std::size_t i, std::size_t j)  { auto x = a; x.set(i); x.set(j); return x; };
+                auto const one = [&](std::size_t i)                -> X { auto x = a; x.set(i);           return x; };
+                auto const two = [&](std::size_t i, std::size_t j) -> X { auto x = a; x.set(i); x.set(j); return x; };
 
                 auto const check = mem_is_proper_subset_of();
                 check(one(lo), one(lo));                // equal: every block compares the same

--- a/test/include/test/bitset/primitives.hpp
+++ b/test/include/test/bitset/primitives.hpp
@@ -49,7 +49,7 @@ struct constructor
                         );
 
                         if constexpr (N > 0) {
-                                auto ones = std::string(N, '1');
+                                auto const ones = std::string(N, '1');
                                 BOOST_CHECK(X(std::string_view(ones)).all());   // [bitset.cons]/4
 
                                 auto invalid = zeros;
@@ -75,7 +75,7 @@ struct mem_bit_and_assign
         {
                 auto const src = self;
                 auto const& dst = self &= rhs;
-                for (auto const N = self.size(); auto i : std::views::iota(0UZ, N)) {
+                for (auto const N = self.size(); auto const i : std::views::iota(0UZ, N)) {
                         BOOST_CHECK_EQUAL(dst[i], not rhs[i] ? false : src[i]); // [bitset.members]/1
                 }
                 BOOST_CHECK_EQUAL(std::addressof(dst), std::addressof(self));   // [bitset.members]/2
@@ -89,7 +89,7 @@ struct mem_bit_or_assign
         {
                 auto const src = self;
                 auto const& dst = self |= rhs;
-                for (auto const N = self.size(); auto i : std::views::iota(0UZ, N)) {
+                for (auto const N = self.size(); auto const i : std::views::iota(0UZ, N)) {
                         BOOST_CHECK_EQUAL(dst[i], rhs[i] ? true : src[i]);      // [bitset.members]/3
                 }
                 BOOST_CHECK_EQUAL(std::addressof(dst), std::addressof(self));   // [bitset.members]/4
@@ -103,7 +103,7 @@ struct mem_bit_xor_assign
         {
                 auto const src = self;
                 auto const& dst = self ^= rhs;
-                for (auto const N = self.size(); auto i : std::views::iota(0UZ, N)) {
+                for (auto const N = self.size(); auto const i : std::views::iota(0UZ, N)) {
                         BOOST_CHECK_EQUAL(dst[i], rhs[i] ? not src[i] : src[i]);// [bitset.members]/5
                 }
                 BOOST_CHECK_EQUAL(std::addressof(dst), std::addressof(self));   // [bitset.members]/6
@@ -119,7 +119,7 @@ struct mem_bit_minus_assign
                 if constexpr (requires { self -= rhs; }) {
                         auto const src = self;
                         auto const& dst = self -= rhs;
-                        for (auto const N = self.size(); auto i : std::views::iota(0UZ, N)) {
+                        for (auto const N = self.size(); auto const i : std::views::iota(0UZ, N)) {
                                 BOOST_CHECK_EQUAL(dst[i], rhs[i] ? false : src[i]);
                         }
                         BOOST_CHECK_EQUAL(std::addressof(dst), std::addressof(self));
@@ -133,7 +133,7 @@ struct mem_shift_left_assign
         {
                 auto const src = self;
                 auto const& dst = self <<= pos;
-                for (auto const N = self.size(); auto I : std::views::iota(0UZ, N)) {
+                for (auto const N = self.size(); auto const I : std::views::iota(0UZ, N)) {
                         if (I < pos) {
                                 BOOST_CHECK(not dst[I]);                        // [bitset.members]/7.1
                         } else {
@@ -150,7 +150,7 @@ struct mem_shift_right_assign
         {
                 auto const src = self;
                 auto const& dst = self >>= pos;
-                for (auto const N = self.size(); auto I : std::views::iota(0UZ, N)) {
+                for (auto const N = self.size(); auto const I : std::views::iota(0UZ, N)) {
                         if (pos >= N - I) {
                                 BOOST_CHECK(not dst[I]);                        // [bitset.members]/9.1
                         } else {
@@ -193,7 +193,7 @@ struct mem_set
                 if (auto const N = self.size(); pos < N) {
                         auto const src = self;
                         auto const& dst = self.set(pos, val);
-                        for (auto i : std::views::iota(0UZ, N)) {
+                        for (auto const i : std::views::iota(0UZ, N)) {
                                 BOOST_CHECK_EQUAL(dst[i], i == pos ? val : src[i]);     // [bitset.members]/15
                         }
                         BOOST_CHECK_EQUAL(std::addressof(dst), std::addressof(self));   // [bitset.members]/16
@@ -217,7 +217,7 @@ struct mem_reset
                 if (auto const N = self.size(); pos < N) {
                         auto const src = self;
                         auto const& dst = self.reset(pos);
-                        for (auto i : std::views::iota(0UZ, N)) {
+                        for (auto const i : std::views::iota(0UZ, N)) {
                                 BOOST_CHECK_EQUAL(dst[i], i == pos ? false : src[i]);   // [bitset.members]/20
                         }
                         BOOST_CHECK_EQUAL(std::addressof(dst), std::addressof(self));   // [bitset.members]/21
@@ -243,7 +243,7 @@ struct mem_flip
         {
                 auto const src = self;
                 auto const& dst = self.flip();
-                for (auto const N = self.size(); auto i : std::views::iota(0UZ, N)) {
+                for (auto const N = self.size(); auto const i : std::views::iota(0UZ, N)) {
                         BOOST_CHECK_NE(dst[i], src[i]);                                 // [bitset.members]/25
                 }
                 BOOST_CHECK_EQUAL(std::addressof(dst), std::addressof(self));           // [bitset.members]/26
@@ -254,7 +254,7 @@ struct mem_flip
                 if (auto const N = self.size(); pos < N) {
                         auto const src = self;
                         auto const& dst = self.flip(pos);
-                        for (auto i : std::views::iota(0UZ, N)) {
+                        for (auto const i : std::views::iota(0UZ, N)) {
                                 BOOST_CHECK_EQUAL(dst[i], i == pos ? not src[i] : src[i]);      // [bitset.members]/27
                         }
                         BOOST_CHECK_EQUAL(std::addressof(dst), std::addressof(self));           // [bitset.members]/28

--- a/test/include/test/bitset/primitives.hpp
+++ b/test/include/test/bitset/primitives.hpp
@@ -60,7 +60,7 @@ struct constructor
                         }
                 } else if constexpr (dynamic_string_view_constructible<X>) {
                         // A run-time width is boost's contract: the text read is the width, and the two throws are as at a static width.
-                        BOOST_CHECK_EQUAL(X(std::string_view("0101")).size(), 4uz);
+                        BOOST_CHECK_EQUAL(X(std::string_view("0101")).size(), 4UZ);
                         BOOST_CHECK(X(std::string_view("11")).all());
                         BOOST_CHECK_THROW((static_cast<void>(X(std::string_view("01"), 3))),  std::out_of_range);
                         BOOST_CHECK_THROW((static_cast<void>(X(std::string_view("012")))),   std::invalid_argument);
@@ -75,7 +75,7 @@ struct mem_bit_and_assign
         {
                 auto const src = self;
                 auto const& dst = self &= rhs;
-                for (auto const N = self.size(); auto i : std::views::iota(0uz, N)) {
+                for (auto const N = self.size(); auto i : std::views::iota(0UZ, N)) {
                         BOOST_CHECK_EQUAL(dst[i], not rhs[i] ? false : src[i]); // [bitset.members]/1
                 }
                 BOOST_CHECK_EQUAL(std::addressof(dst), std::addressof(self));   // [bitset.members]/2
@@ -89,7 +89,7 @@ struct mem_bit_or_assign
         {
                 auto const src = self;
                 auto const& dst = self |= rhs;
-                for (auto const N = self.size(); auto i : std::views::iota(0uz, N)) {
+                for (auto const N = self.size(); auto i : std::views::iota(0UZ, N)) {
                         BOOST_CHECK_EQUAL(dst[i], rhs[i] ? true : src[i]);      // [bitset.members]/3
                 }
                 BOOST_CHECK_EQUAL(std::addressof(dst), std::addressof(self));   // [bitset.members]/4
@@ -103,7 +103,7 @@ struct mem_bit_xor_assign
         {
                 auto const src = self;
                 auto const& dst = self ^= rhs;
-                for (auto const N = self.size(); auto i : std::views::iota(0uz, N)) {
+                for (auto const N = self.size(); auto i : std::views::iota(0UZ, N)) {
                         BOOST_CHECK_EQUAL(dst[i], rhs[i] ? not src[i] : src[i]);// [bitset.members]/5
                 }
                 BOOST_CHECK_EQUAL(std::addressof(dst), std::addressof(self));   // [bitset.members]/6
@@ -119,7 +119,7 @@ struct mem_bit_minus_assign
                 if constexpr (requires { self -= rhs; }) {
                         auto const src = self;
                         auto const& dst = self -= rhs;
-                        for (auto const N = self.size(); auto i : std::views::iota(0uz, N)) {
+                        for (auto const N = self.size(); auto i : std::views::iota(0UZ, N)) {
                                 BOOST_CHECK_EQUAL(dst[i], rhs[i] ? false : src[i]);
                         }
                         BOOST_CHECK_EQUAL(std::addressof(dst), std::addressof(self));
@@ -133,7 +133,7 @@ struct mem_shift_left_assign
         {
                 auto const src = self;
                 auto const& dst = self <<= pos;
-                for (auto const N = self.size(); auto I : std::views::iota(0uz, N)) {
+                for (auto const N = self.size(); auto I : std::views::iota(0UZ, N)) {
                         if (I < pos) {
                                 BOOST_CHECK(not dst[I]);                        // [bitset.members]/7.1
                         } else {
@@ -150,7 +150,7 @@ struct mem_shift_right_assign
         {
                 auto const src = self;
                 auto const& dst = self >>= pos;
-                for (auto const N = self.size(); auto I : std::views::iota(0uz, N)) {
+                for (auto const N = self.size(); auto I : std::views::iota(0UZ, N)) {
                         if (pos >= N - I) {
                                 BOOST_CHECK(not dst[I]);                        // [bitset.members]/9.1
                         } else {
@@ -193,7 +193,7 @@ struct mem_set
                 if (auto const N = self.size(); pos < N) {
                         auto const src = self;
                         auto const& dst = self.set(pos, val);
-                        for (auto i : std::views::iota(0uz, N)) {
+                        for (auto i : std::views::iota(0UZ, N)) {
                                 BOOST_CHECK_EQUAL(dst[i], i == pos ? val : src[i]);     // [bitset.members]/15
                         }
                         BOOST_CHECK_EQUAL(std::addressof(dst), std::addressof(self));   // [bitset.members]/16
@@ -217,7 +217,7 @@ struct mem_reset
                 if (auto const N = self.size(); pos < N) {
                         auto const src = self;
                         auto const& dst = self.reset(pos);
-                        for (auto i : std::views::iota(0uz, N)) {
+                        for (auto i : std::views::iota(0UZ, N)) {
                                 BOOST_CHECK_EQUAL(dst[i], i == pos ? false : src[i]);   // [bitset.members]/20
                         }
                         BOOST_CHECK_EQUAL(std::addressof(dst), std::addressof(self));   // [bitset.members]/21
@@ -243,7 +243,7 @@ struct mem_flip
         {
                 auto const src = self;
                 auto const& dst = self.flip();
-                for (auto const N = self.size(); auto i : std::views::iota(0uz, N)) {
+                for (auto const N = self.size(); auto i : std::views::iota(0UZ, N)) {
                         BOOST_CHECK_NE(dst[i], src[i]);                                 // [bitset.members]/25
                 }
                 BOOST_CHECK_EQUAL(std::addressof(dst), std::addressof(self));           // [bitset.members]/26
@@ -254,7 +254,7 @@ struct mem_flip
                 if (auto const N = self.size(); pos < N) {
                         auto const src = self;
                         auto const& dst = self.flip(pos);
-                        for (auto i : std::views::iota(0uz, N)) {
+                        for (auto i : std::views::iota(0UZ, N)) {
                                 BOOST_CHECK_EQUAL(dst[i], i == pos ? not src[i] : src[i]);      // [bitset.members]/27
                         }
                         BOOST_CHECK_EQUAL(std::addressof(dst), std::addressof(self));           // [bitset.members]/28
@@ -302,9 +302,9 @@ struct mem_count
                 BOOST_CHECK_EQUAL(
                         self.count(),
                         std::ranges::fold_left(
-                                std::views::iota(0uz, N) | std::views::transform([&](auto i) {
+                                std::views::iota(0UZ, N) | std::views::transform([&](auto i) {
                                         return self[i];
-                                }), 0uz, std::plus<>()
+                                }), 0UZ, std::plus<>()
                         )
                 );                                                              // [bitset.members]/43
         }
@@ -329,7 +329,7 @@ struct mem_equal_to
                 auto const N = self.size();
                 BOOST_CHECK_EQUAL(
                         self == rhs,
-                        std::ranges::all_of(std::views::iota(0uz, N), [&](auto i) {
+                        std::ranges::all_of(std::views::iota(0UZ, N), [&](auto i) {
                                 return self[i] == rhs[i];
                         })
                 );                                                              // [bitset.members]/45
@@ -470,7 +470,7 @@ struct mem_is_proper_subset_of_edges
                 if (N == 0) {
                         return;
                 }
-                auto const lo = 0uz;
+                auto const lo = 0UZ;
                 auto const hi = N - 1;
                 auto const one = [&](std::size_t i)                 { auto x = a; x.set(i);           return x; };
                 auto const two = [&](std::size_t i, std::size_t j)  { auto x = a; x.set(i); x.set(j); return x; };
@@ -589,7 +589,7 @@ struct op_istream_failure
                                 auto x = X();
                                 is >> x;
                                 BOOST_CHECK(not is.fail());
-                                BOOST_CHECK_EQUAL(x.count(), 1uz);
+                                BOOST_CHECK_EQUAL(x.count(), 1UZ);
                                 BOOST_CHECK(x.test(0));                         // [bitset.operators]/6
                         }
                 }

--- a/test/include/test/bitset/primitives.hpp
+++ b/test/include/test/bitset/primitives.hpp
@@ -31,6 +31,46 @@ concept fixed_string_view_constructible = requires { X(std::string_view()); } an
 template<class X>
 concept dynamic_string_view_constructible = requires { X(std::string_view()); typename xstd::owned_storage<X>::bits_type; } and dynamic<X>;
 
+// One function per tier, because the tiers are what this checks and a BOOST_CHECK_THROW is three branches to
+// the complexity check: inline, the three of them nested under two if constexprs came to 64 against a threshold
+// of 25, and none of that 64 was the logic. [design.md#one-function-per-tier]
+
+// A width the text must fit: too long throws, whatever the text says.
+template<class X>
+auto check_string_view_at_a_static_width() -> void  // NOLINT(bugprone-exception-escape)
+{
+        constexpr auto N = X().size();
+        auto const zeros = std::string(N, '0');
+        BOOST_CHECK_THROW(                                                      // [bitset.cons]/3
+                (static_cast<void>(X(std::string_view(zeros), N + 1))), std::out_of_range
+        );
+}
+
+// The two a zero width has no room to state: every position set, and a character that is neither 0 nor 1.
+template<class X>
+auto check_string_view_at_a_nonzero_width() -> void  // NOLINT(bugprone-exception-escape)
+{
+        constexpr auto N = X().size();
+        auto const ones = std::string(N, '1');
+        BOOST_CHECK(X(std::string_view(ones)).all());                           // [bitset.cons]/4
+
+        auto invalid = std::string(N, '0');
+        invalid[N - 1] = '2';
+        BOOST_CHECK_THROW(                                                      // [bitset.cons]/5
+                (static_cast<void>(X(std::string_view(invalid)))), std::invalid_argument
+        );
+}
+
+// A run-time width is boost's contract: the text read is the width, and the two throws are as at a static width.
+template<class X>
+auto check_string_view_at_a_run_time_width() -> void  // NOLINT(bugprone-exception-escape)
+{
+        BOOST_CHECK_EQUAL(X(std::string_view("0101")).size(), 4UZ);
+        BOOST_CHECK(X(std::string_view("11")).all());
+        BOOST_CHECK_THROW((static_cast<void>(X(std::string_view("01"), 3))),  std::out_of_range);
+        BOOST_CHECK_THROW((static_cast<void>(X(std::string_view("012")))),   std::invalid_argument);
+}
+
 template<class X>
 struct constructor
 {
@@ -41,29 +81,12 @@ struct constructor
 
                 // [bitset.cons]/2 describes the constructor taking unsigned long long
                 if constexpr (fixed_string_view_constructible<X>) {
-                        constexpr auto N = X().size();
-                        auto const zeros = std::string(N, '0');
-
-                        BOOST_CHECK_THROW(                                      // [bitset.cons]/3
-                                (static_cast<void>(X(std::string_view(zeros), N + 1))), std::out_of_range
-                        );
-
-                        if constexpr (N > 0) {
-                                auto const ones = std::string(N, '1');
-                                BOOST_CHECK(X(std::string_view(ones)).all());   // [bitset.cons]/4
-
-                                auto invalid = zeros;
-                                invalid[N - 1] = '2';
-                                BOOST_CHECK_THROW(                              // [bitset.cons]/5
-                                        (static_cast<void>(X(std::string_view(invalid)))), std::invalid_argument
-                                );
+                        check_string_view_at_a_static_width<X>();
+                        if constexpr (X().size() > 0) {
+                                check_string_view_at_a_nonzero_width<X>();
                         }
                 } else if constexpr (dynamic_string_view_constructible<X>) {
-                        // A run-time width is boost's contract: the text read is the width, and the two throws are as at a static width.
-                        BOOST_CHECK_EQUAL(X(std::string_view("0101")).size(), 4UZ);
-                        BOOST_CHECK(X(std::string_view("11")).all());
-                        BOOST_CHECK_THROW((static_cast<void>(X(std::string_view("01"), 3))),  std::out_of_range);
-                        BOOST_CHECK_THROW((static_cast<void>(X(std::string_view("012")))),   std::invalid_argument);
+                        check_string_view_at_a_run_time_width<X>();
                 }
         }
 };

--- a/test/include/test/sequence/concepts.hpp
+++ b/test/include/test/sequence/concepts.hpp
@@ -47,7 +47,7 @@ concept reversible_container_typedefs = container_typedefs<C> and requires {
 
 // [container.reqmts] and [container.rev.reqmts]: what any container answers, on a const one and a mutable one.
 template<class C>
-concept container_members = reversible_container_typedefs<C> and requires (C c, C const cc, typename C::size_type n) {
+concept container_members = reversible_container_typedefs<C> and requires (C c, C const cc, C::size_type n) {
         { c.begin()    } -> std::same_as<typename C::iterator>;
         { c.end()      } -> std::same_as<typename C::iterator>;
         { cc.begin()   } -> std::same_as<typename C::const_iterator>;
@@ -87,7 +87,7 @@ concept array_bool = container_members<C> and requires (C c, bool b) {
 
 // [vector.bool]'s synopsis, likewise, with [vector.erasure] and the allocator: std::vector<bool> is the model and the packing answers every line of it.
 template<class C, class A = C::allocator_type>
-concept vector_bool = container_members<C> and requires (C c, C o, C const cc, typename C::size_type n, bool b, A a, std::initializer_list<bool> il, bool const* first, bool const* last, typename C::const_iterator p) {
+concept vector_bool = container_members<C> and requires (C c, C o, C const cc, C::size_type n, bool b, A a, std::initializer_list<bool> il, bool const* first, bool const* last, C::const_iterator p) {
         typename C::allocator_type;
         C();
         C(a);
@@ -136,7 +136,7 @@ concept vector_bool = container_members<C> and requires (C c, C o, C const cc, t
 // [vector.bool] minus the allocator, which is every line a fixed-capacity sequence can answer. P0843 declined a bool
 // specialization, so this checklist has no inplace model of its own and std::vector<bool> stands in for the lines it shares.
 template<class C>
-concept inplace_vector_bool = container_members<C> and requires (C c, C o, C const cc, typename C::size_type n, bool b, std::initializer_list<bool> il, bool const* first, bool const* last, typename C::const_iterator p) {
+concept inplace_vector_bool = container_members<C> and requires (C c, C o, C const cc, C::size_type n, bool b, std::initializer_list<bool> il, bool const* first, bool const* last, C::const_iterator p) {
         C();
         C(n);
         C(n, b);
@@ -175,7 +175,7 @@ concept inplace_vector_bool = container_members<C> and requires (C c, C o, C con
 
 // [vector.bool]'s C++23 lines, apart so the model can be held to them where its standard library has them (__cpp_lib_containers_ranges).
 template<class C, class A = C::allocator_type>
-concept vector_bool_ranges = requires (C c, A a, std::initializer_list<bool> il, typename C::const_iterator p) {
+concept vector_bool_ranges = requires (C c, A a, std::initializer_list<bool> il, C::const_iterator p) {
         C(std::from_range, il);
         C(std::from_range, il, a);
         c.assign_range(il);
@@ -185,7 +185,7 @@ concept vector_bool_ranges = requires (C c, A a, std::initializer_list<bool> il,
 
 // The same lines without the allocator-extended constructor, for the column that has no allocator to extend them with.
 template<class C>
-concept inplace_vector_bool_ranges = requires (C c, std::initializer_list<bool> il, typename C::const_iterator p) {
+concept inplace_vector_bool_ranges = requires (C c, std::initializer_list<bool> il, C::const_iterator p) {
         C(std::from_range, il);
         c.assign_range(il);
         { c.insert_range(p, il) } -> std::same_as<typename C::iterator>;

--- a/test/include/test/sequence/ordering.hpp
+++ b/test/include/test/sequence/ordering.hpp
@@ -45,8 +45,8 @@ auto ordering_agrees_with_vector_bool(std::size_t universe = 4) -> void
 
                         BOOST_CHECK_EQUAL(std::ranges::equal(xv, yv), vx == vy);
                         auto const order = std::lexicographical_compare_three_way(xv.begin(), xv.end(), yv.begin(), yv.end());
-                        BOOST_CHECK_EQUAL(std::is_lt(order), std::lexicographical_compare(vx.begin(), vx.end(), vy.begin(), vy.end()));
-                        BOOST_CHECK_EQUAL(std::is_gt(order), std::lexicographical_compare(vy.begin(), vy.end(), vx.begin(), vx.end()));
+                        BOOST_CHECK_EQUAL(std::is_lt(order), std::ranges::lexicographical_compare(vx, vy));
+                        BOOST_CHECK_EQUAL(std::is_gt(order), std::ranges::lexicographical_compare(vy, vx));
                 }
         }
 }

--- a/test/include/test/sequence/ordering.hpp
+++ b/test/include/test/sequence/ordering.hpp
@@ -10,7 +10,7 @@
 #include <test/bitset/factory.hpp>            // make_bitset
 #include <xstd/bits/bit_span.hpp> // bit_span
 #include <algorithm>                          // equal, lexicographical_compare, lexicographical_compare_three_way
-#include <compare>                            // strong_ordering
+#include <compare>                            // is_gt, is_lt, strong_ordering
 #include <cstddef>                            // size_t
 #include <vector>                             // vector
 
@@ -45,8 +45,8 @@ auto ordering_agrees_with_vector_bool(std::size_t universe = 4) -> void
 
                         BOOST_CHECK_EQUAL(std::ranges::equal(xv, yv), vx == vy);
                         auto const order = std::lexicographical_compare_three_way(xv.begin(), xv.end(), yv.begin(), yv.end());
-                        BOOST_CHECK_EQUAL(order < 0, std::lexicographical_compare(vx.begin(), vx.end(), vy.begin(), vy.end()));
-                        BOOST_CHECK_EQUAL(order > 0, std::lexicographical_compare(vy.begin(), vy.end(), vx.begin(), vx.end()));
+                        BOOST_CHECK_EQUAL(std::is_lt(order), std::lexicographical_compare(vx.begin(), vx.end(), vy.begin(), vy.end()));
+                        BOOST_CHECK_EQUAL(std::is_gt(order), std::lexicographical_compare(vy.begin(), vy.end(), vx.begin(), vx.end()));
                 }
         }
 }

--- a/test/include/test/set/exhaustive.hpp
+++ b/test/include/test/set/exhaustive.hpp
@@ -21,6 +21,10 @@
 #endif
 
 namespace test::set {
+// NOLINTBEGIN(misc-const-correctness): every object built below is handed to fun, and fun is the whole point --
+// some of the functors this harness is called with take their argument by non-const reference and write through
+// it, which is exactly what the set/reset/flip cases exist to check. clang-tidy sees one instantiation at a time
+// and proposes a const that would stop the mutating ones compiling. [design.md#clang-tidy-false-positives]
 
 inline constexpr auto L1 = 128UZ;
 inline constexpr auto L2 =  64UZ;
@@ -71,7 +75,7 @@ namespace on1 {
 template<class X, std::size_t N = limit_v<X, L1>>
 auto all_valid(auto fun)
 {
-        for (auto i : std::views::iota(0UZ, N)) {
+        for (auto const i : std::views::iota(0UZ, N)) {
                 fun(i);
         }
 }
@@ -79,7 +83,7 @@ auto all_valid(auto fun)
 template<class X, std::size_t N = limit_v<X, L1>>
 auto all_cardinality_sets(auto fun)
 {
-        for (auto i : std::views::iota(0UZ, N + 1)) {
+        for (auto const i : std::views::iota(0UZ, N + 1)) {
                 auto a = std::views::iota(0UZ, i) | std::ranges::to<X>(); assert(a.size() == i);
                 fun(a);
         }
@@ -88,7 +92,7 @@ auto all_cardinality_sets(auto fun)
 template<class X, std::size_t N = limit_v<X, L1>>
 auto all_singleton_arrays(auto fun)
 {
-        for (auto i : std::views::iota(0UZ, N)) {
+        for (auto const i : std::views::iota(0UZ, N)) {
                 auto a = std::array{ i }; assert(a.size() == 1);
                 fun(a);
         }
@@ -97,7 +101,7 @@ auto all_singleton_arrays(auto fun)
 template<class X, std::size_t N = limit_v<X, L1>>
 auto all_singleton_ilists(auto fun)
 {
-        for (auto i : std::views::iota(0UZ, N)) {
+        for (auto const i : std::views::iota(0UZ, N)) {
                 auto a = { i }; assert(a.size() == 1);
                 fun(a);
         }
@@ -106,7 +110,7 @@ auto all_singleton_ilists(auto fun)
 template<class X, std::size_t N = limit_v<X, L1>>
 auto all_singleton_sets(auto fun)
 {
-        for (auto i : std::views::iota(0UZ, N)) {
+        for (auto const i : std::views::iota(0UZ, N)) {
                 auto a = X({ i }); assert(a.size() == 1);
                 fun(a);
         }
@@ -119,8 +123,8 @@ namespace on2 {
 template<class X, std::size_t N = limit_v<X, L2>>
 auto all_doubleton_arrays(auto fun)
 {
-        for (auto j : std::views::iota(1UZ, std::ranges::max(N, 1UZ))) {
-                for (auto i : std::views::iota(0UZ, j)) {
+        for (auto const j : std::views::iota(1UZ, std::ranges::max(N, 1UZ))) {
+                for (auto const i : std::views::iota(0UZ, j)) {
                         auto a = std::array{ i, j }; assert(a.size() == 2);
                         fun(a);
                 }
@@ -130,8 +134,8 @@ auto all_doubleton_arrays(auto fun)
 template<class X, std::size_t N = limit_v<X, L2>>
 auto all_doubleton_ilists(auto fun)
 {
-        for (auto j : std::views::iota(1UZ, std::ranges::max(N, 1UZ))) {
-                for (auto i : std::views::iota(0UZ, j)) {
+        for (auto const j : std::views::iota(1UZ, std::ranges::max(N, 1UZ))) {
+                for (auto const i : std::views::iota(0UZ, j)) {
                         auto a = { i, j }; assert(a.size() == 2);
                         fun(a);
                 }
@@ -141,8 +145,8 @@ auto all_doubleton_ilists(auto fun)
 template<class X, std::size_t N = limit_v<X, L2>>
 auto all_doubleton_sets(auto fun)
 {
-        for (auto j : std::views::iota(1UZ, std::ranges::max(N, 1UZ))) {
-                for (auto i : std::views::iota(0UZ, j)) {
+        for (auto const j : std::views::iota(1UZ, std::ranges::max(N, 1UZ))) {
+                for (auto const i : std::views::iota(0UZ, j)) {
                         auto a = X({ i, j }); assert(a.size() == 2);
                         fun(a);
                 }
@@ -152,8 +156,8 @@ auto all_doubleton_sets(auto fun)
 template<class X, std::size_t N = limit_v<X, L2>>
 auto all_singleton_set_pairs(auto fun)
 {
-        for (auto i : std::views::iota(0UZ, N)) {
-                for (auto j : std::views::iota(0UZ, N)) {
+        for (auto const i : std::views::iota(0UZ, N)) {
+                for (auto const j : std::views::iota(0UZ, N)) {
                         auto a = X({ i }); assert(a.size() == 1);
                         auto b = X({ j }); assert(b.size() == 1);
                         fun(a, b);
@@ -168,9 +172,9 @@ namespace on3 {
 template<class X, std::size_t N = limit_v<X, L3>>
 auto all_singleton_set_triples(auto fun)
 {
-        for (auto i : std::views::iota(0UZ, N)) {
-                for (auto j : std::views::iota(0UZ, N)) {
-                        for (auto k : std::views::iota(0UZ, N)) {
+        for (auto const i : std::views::iota(0UZ, N)) {
+                for (auto const j : std::views::iota(0UZ, N)) {
+                        for (auto const k : std::views::iota(0UZ, N)) {
                                 auto a = X({ i }); assert(a.size() == 1);
                                 auto b = X({ j }); assert(b.size() == 1);
                                 auto c = X({ k }); assert(c.size() == 1);
@@ -187,10 +191,10 @@ namespace on4 {
 template<class X, std::size_t N = limit_v<X, L4>>
 auto all_doubleton_set_pairs(auto fun)
 {
-        for (auto j : std::views::iota(1UZ, std::ranges::max(N, 1UZ))) {
-                for (auto n : std::views::iota(1UZ, std::ranges::max(N, 1UZ))) {
-                        for (auto i : std::views::iota(0UZ, j)) {
-                                for (auto m : std::views::iota(0UZ, n)) {
+        for (auto const j : std::views::iota(1UZ, std::ranges::max(N, 1UZ))) {
+                for (auto const n : std::views::iota(1UZ, std::ranges::max(N, 1UZ))) {
+                        for (auto const i : std::views::iota(0UZ, j)) {
+                                for (auto const m : std::views::iota(0UZ, n)) {
                                         auto a = X({ i, j }); assert(a.size() == 2);
                                         auto b = X({ m, n }); assert(b.size() == 2);
                                         fun(a, b);
@@ -201,6 +205,8 @@ auto all_doubleton_set_pairs(auto fun)
 }
 
 }       // namespace on4
+
+// NOLINTEND(misc-const-correctness)
 
 } // namespace test::set
 

--- a/test/include/test/set/exhaustive.hpp
+++ b/test/include/test/set/exhaustive.hpp
@@ -11,6 +11,7 @@
 #include <algorithm>        // max
 #include <array>            // array
 #include <cassert>          // assert
+#include <cstddef>          // size_t
 #include <initializer_list> // initializer_list
 #include <ranges>           // iota, to
 
@@ -31,7 +32,7 @@ template<class X>
 concept static_width = requires { typename xstd::owned_storage<X>::bits_type; } and xstd::static_bit_extent<typename X::traits_type, typename xstd::owned_storage<X>::bits_type>;
 
 template<class X, std::size_t Limit>
-inline constexpr auto limit_v = []() {
+inline constexpr auto limit_v = [] -> std::size_t {
         if constexpr (static_width<X>) {
                 return X().max_size();
         } else {

--- a/test/include/test/set/exhaustive.hpp
+++ b/test/include/test/set/exhaustive.hpp
@@ -21,10 +21,10 @@
 
 namespace test::set {
 
-inline constexpr auto L1 = 128uz;
-inline constexpr auto L2 =  64uz;
-inline constexpr auto L3 =  32uz;
-inline constexpr auto L4 =  16uz;
+inline constexpr auto L1 = 128UZ;
+inline constexpr auto L2 =  64UZ;
+inline constexpr auto L3 =  32UZ;
+inline constexpr auto L4 =  16UZ;
 
 // A static width is its own limit; a growing one, ours or the standard library's, takes the sweep's.
 template<class X>
@@ -51,7 +51,7 @@ auto empty_set(auto fun)
 template<class X, std::size_t N = limit_v<X, L1>>
 auto full_set(auto fun)
 {
-        auto a = std::views::iota(0uz, N) | std::ranges::to<X>(); assert(a.size() == N);
+        auto a = std::views::iota(0UZ, N) | std::ranges::to<X>(); assert(a.size() == N);
         fun(a);
 }
 
@@ -70,7 +70,7 @@ namespace on1 {
 template<class X, std::size_t N = limit_v<X, L1>>
 auto all_valid(auto fun)
 {
-        for (auto i : std::views::iota(0uz, N)) {
+        for (auto i : std::views::iota(0UZ, N)) {
                 fun(i);
         }
 }
@@ -78,8 +78,8 @@ auto all_valid(auto fun)
 template<class X, std::size_t N = limit_v<X, L1>>
 auto all_cardinality_sets(auto fun)
 {
-        for (auto i : std::views::iota(0uz, N + 1)) {
-                auto a = std::views::iota(0uz, i) | std::ranges::to<X>(); assert(a.size() == i);
+        for (auto i : std::views::iota(0UZ, N + 1)) {
+                auto a = std::views::iota(0UZ, i) | std::ranges::to<X>(); assert(a.size() == i);
                 fun(a);
         }
 }
@@ -87,7 +87,7 @@ auto all_cardinality_sets(auto fun)
 template<class X, std::size_t N = limit_v<X, L1>>
 auto all_singleton_arrays(auto fun)
 {
-        for (auto i : std::views::iota(0uz, N)) {
+        for (auto i : std::views::iota(0UZ, N)) {
                 auto a = std::array{ i }; assert(a.size() == 1);
                 fun(a);
         }
@@ -96,7 +96,7 @@ auto all_singleton_arrays(auto fun)
 template<class X, std::size_t N = limit_v<X, L1>>
 auto all_singleton_ilists(auto fun)
 {
-        for (auto i : std::views::iota(0uz, N)) {
+        for (auto i : std::views::iota(0UZ, N)) {
                 auto a = { i }; assert(a.size() == 1);
                 fun(a);
         }
@@ -105,7 +105,7 @@ auto all_singleton_ilists(auto fun)
 template<class X, std::size_t N = limit_v<X, L1>>
 auto all_singleton_sets(auto fun)
 {
-        for (auto i : std::views::iota(0uz, N)) {
+        for (auto i : std::views::iota(0UZ, N)) {
                 auto a = X({ i }); assert(a.size() == 1);
                 fun(a);
         }
@@ -118,8 +118,8 @@ namespace on2 {
 template<class X, std::size_t N = limit_v<X, L2>>
 auto all_doubleton_arrays(auto fun)
 {
-        for (auto j : std::views::iota(1uz, std::ranges::max(N, 1uz))) {
-                for (auto i : std::views::iota(0uz, j)) {
+        for (auto j : std::views::iota(1UZ, std::ranges::max(N, 1UZ))) {
+                for (auto i : std::views::iota(0UZ, j)) {
                         auto a = std::array{ i, j }; assert(a.size() == 2);
                         fun(a);
                 }
@@ -129,8 +129,8 @@ auto all_doubleton_arrays(auto fun)
 template<class X, std::size_t N = limit_v<X, L2>>
 auto all_doubleton_ilists(auto fun)
 {
-        for (auto j : std::views::iota(1uz, std::ranges::max(N, 1uz))) {
-                for (auto i : std::views::iota(0uz, j)) {
+        for (auto j : std::views::iota(1UZ, std::ranges::max(N, 1UZ))) {
+                for (auto i : std::views::iota(0UZ, j)) {
                         auto a = { i, j }; assert(a.size() == 2);
                         fun(a);
                 }
@@ -140,8 +140,8 @@ auto all_doubleton_ilists(auto fun)
 template<class X, std::size_t N = limit_v<X, L2>>
 auto all_doubleton_sets(auto fun)
 {
-        for (auto j : std::views::iota(1uz, std::ranges::max(N, 1uz))) {
-                for (auto i : std::views::iota(0uz, j)) {
+        for (auto j : std::views::iota(1UZ, std::ranges::max(N, 1UZ))) {
+                for (auto i : std::views::iota(0UZ, j)) {
                         auto a = X({ i, j }); assert(a.size() == 2);
                         fun(a);
                 }
@@ -151,8 +151,8 @@ auto all_doubleton_sets(auto fun)
 template<class X, std::size_t N = limit_v<X, L2>>
 auto all_singleton_set_pairs(auto fun)
 {
-        for (auto i : std::views::iota(0uz, N)) {
-                for (auto j : std::views::iota(0uz, N)) {
+        for (auto i : std::views::iota(0UZ, N)) {
+                for (auto j : std::views::iota(0UZ, N)) {
                         auto a = X({ i }); assert(a.size() == 1);
                         auto b = X({ j }); assert(b.size() == 1);
                         fun(a, b);
@@ -167,9 +167,9 @@ namespace on3 {
 template<class X, std::size_t N = limit_v<X, L3>>
 auto all_singleton_set_triples(auto fun)
 {
-        for (auto i : std::views::iota(0uz, N)) {
-                for (auto j : std::views::iota(0uz, N)) {
-                        for (auto k : std::views::iota(0uz, N)) {
+        for (auto i : std::views::iota(0UZ, N)) {
+                for (auto j : std::views::iota(0UZ, N)) {
+                        for (auto k : std::views::iota(0UZ, N)) {
                                 auto a = X({ i }); assert(a.size() == 1);
                                 auto b = X({ j }); assert(b.size() == 1);
                                 auto c = X({ k }); assert(c.size() == 1);
@@ -186,10 +186,10 @@ namespace on4 {
 template<class X, std::size_t N = limit_v<X, L4>>
 auto all_doubleton_set_pairs(auto fun)
 {
-        for (auto j : std::views::iota(1uz, std::ranges::max(N, 1uz))) {
-                for (auto n : std::views::iota(1uz, std::ranges::max(N, 1uz))) {
-                        for (auto i : std::views::iota(0uz, j)) {
-                                for (auto m : std::views::iota(0uz, n)) {
+        for (auto j : std::views::iota(1UZ, std::ranges::max(N, 1UZ))) {
+                for (auto n : std::views::iota(1UZ, std::ranges::max(N, 1UZ))) {
+                        for (auto i : std::views::iota(0UZ, j)) {
+                                for (auto m : std::views::iota(0UZ, n)) {
                                         auto a = X({ i, j }); assert(a.size() == 2);
                                         auto b = X({ m, n }); assert(b.size() == 2);
                                         fun(a, b);

--- a/test/include/test/set/exhaustive.hpp
+++ b/test/include/test/set/exhaustive.hpp
@@ -21,10 +21,6 @@
 #endif
 
 namespace test::set {
-// NOLINTBEGIN(misc-const-correctness): every object built below is handed to fun, and fun is the whole point --
-// some of the functors this harness is called with take their argument by non-const reference and write through
-// it, which is exactly what the set/reset/flip cases exist to check. clang-tidy sees one instantiation at a time
-// and proposes a const that would stop the mutating ones compiling. [design.md#clang-tidy-false-positives]
 
 inline constexpr auto L1 = 128UZ;
 inline constexpr auto L2 =  64UZ;
@@ -84,7 +80,7 @@ template<class X, std::size_t N = limit_v<X, L1>>
 auto all_cardinality_sets(auto fun)
 {
         for (auto const i : std::views::iota(0UZ, N + 1)) {
-                auto a = std::views::iota(0UZ, i) | std::ranges::to<X>(); assert(a.size() == i);
+                auto a = std::views::iota(0UZ, i) | std::ranges::to<X>(); assert(a.size() == i);  // NOLINT(misc-const-correctness): handed to fun, which some functors take by non-const reference
                 fun(a);
         }
 }
@@ -93,7 +89,7 @@ template<class X, std::size_t N = limit_v<X, L1>>
 auto all_singleton_arrays(auto fun)
 {
         for (auto const i : std::views::iota(0UZ, N)) {
-                auto a = std::array{ i }; assert(a.size() == 1);
+                auto a = std::array{ i }; assert(a.size() == 1);  // NOLINT(misc-const-correctness): handed to fun, which some functors take by non-const reference
                 fun(a);
         }
 }
@@ -102,7 +98,7 @@ template<class X, std::size_t N = limit_v<X, L1>>
 auto all_singleton_ilists(auto fun)
 {
         for (auto const i : std::views::iota(0UZ, N)) {
-                auto a = { i }; assert(a.size() == 1);
+                auto a = { i }; assert(a.size() == 1);  // NOLINT(misc-const-correctness): handed to fun, which some functors take by non-const reference
                 fun(a);
         }
 }
@@ -111,7 +107,7 @@ template<class X, std::size_t N = limit_v<X, L1>>
 auto all_singleton_sets(auto fun)
 {
         for (auto const i : std::views::iota(0UZ, N)) {
-                auto a = X({ i }); assert(a.size() == 1);
+                auto a = X({ i }); assert(a.size() == 1);  // NOLINT(misc-const-correctness): handed to fun, which some functors take by non-const reference
                 fun(a);
         }
 }
@@ -125,7 +121,7 @@ auto all_doubleton_arrays(auto fun)
 {
         for (auto const j : std::views::iota(1UZ, std::ranges::max(N, 1UZ))) {
                 for (auto const i : std::views::iota(0UZ, j)) {
-                        auto a = std::array{ i, j }; assert(a.size() == 2);
+                        auto a = std::array{ i, j }; assert(a.size() == 2);  // NOLINT(misc-const-correctness): handed to fun, which some functors take by non-const reference
                         fun(a);
                 }
         }
@@ -136,7 +132,7 @@ auto all_doubleton_ilists(auto fun)
 {
         for (auto const j : std::views::iota(1UZ, std::ranges::max(N, 1UZ))) {
                 for (auto const i : std::views::iota(0UZ, j)) {
-                        auto a = { i, j }; assert(a.size() == 2);
+                        auto a = { i, j }; assert(a.size() == 2);  // NOLINT(misc-const-correctness): handed to fun, which some functors take by non-const reference
                         fun(a);
                 }
         }
@@ -158,8 +154,8 @@ auto all_singleton_set_pairs(auto fun)
 {
         for (auto const i : std::views::iota(0UZ, N)) {
                 for (auto const j : std::views::iota(0UZ, N)) {
-                        auto a = X({ i }); assert(a.size() == 1);
-                        auto b = X({ j }); assert(b.size() == 1);
+                        auto a = X({ i }); assert(a.size() == 1);  // NOLINT(misc-const-correctness): handed to fun, which some functors take by non-const reference
+                        auto b = X({ j }); assert(b.size() == 1);  // NOLINT(misc-const-correctness): handed to fun, which some functors take by non-const reference
                         fun(a, b);
                 }
         }
@@ -175,9 +171,9 @@ auto all_singleton_set_triples(auto fun)
         for (auto const i : std::views::iota(0UZ, N)) {
                 for (auto const j : std::views::iota(0UZ, N)) {
                         for (auto const k : std::views::iota(0UZ, N)) {
-                                auto a = X({ i }); assert(a.size() == 1);
-                                auto b = X({ j }); assert(b.size() == 1);
-                                auto c = X({ k }); assert(c.size() == 1);
+                                auto a = X({ i }); assert(a.size() == 1);  // NOLINT(misc-const-correctness): handed to fun, which some functors take by non-const reference
+                                auto b = X({ j }); assert(b.size() == 1);  // NOLINT(misc-const-correctness): handed to fun, which some functors take by non-const reference
+                                auto c = X({ k }); assert(c.size() == 1);  // NOLINT(misc-const-correctness): handed to fun, which some functors take by non-const reference
                                 fun(a, b, c);
                         }
                 }
@@ -195,8 +191,8 @@ auto all_doubleton_set_pairs(auto fun)
                 for (auto const n : std::views::iota(1UZ, std::ranges::max(N, 1UZ))) {
                         for (auto const i : std::views::iota(0UZ, j)) {
                                 for (auto const m : std::views::iota(0UZ, n)) {
-                                        auto a = X({ i, j }); assert(a.size() == 2);
-                                        auto b = X({ m, n }); assert(b.size() == 2);
+                                        auto a = X({ i, j }); assert(a.size() == 2);  // NOLINT(misc-const-correctness): handed to fun, which some functors take by non-const reference
+                                        auto b = X({ m, n }); assert(b.size() == 2);  // NOLINT(misc-const-correctness): handed to fun, which some functors take by non-const reference
                                         fun(a, b);
                                 }
                         }
@@ -205,8 +201,6 @@ auto all_doubleton_set_pairs(auto fun)
 }
 
 }       // namespace on4
-
-// NOLINTEND(misc-const-correctness)
 
 } // namespace test::set
 

--- a/test/include/test/set/ordering.hpp
+++ b/test/include/test/set/ordering.hpp
@@ -79,7 +79,7 @@ auto ordering_agrees_with_std_set_sampled(std::size_t universe, std::size_t tria
         // Fixed width, not ULL: the sequence a fixed seed reproduces should not depend on how wide the
         // platform makes unsigned long long.
         auto lcg = std::uint64_t{0x9E3779B97F4A7C15};
-        auto const next = [&lcg] -> std::uint64_t { lcg = (lcg * 6364136223846793005ULL) + 1442695040888963407ULL; return lcg >> 11; };
+        auto const next = [&lcg] -> std::uint64_t { lcg = (lcg * 6364136223846793005ULL) + 1442695040888963407ULL; return lcg >> 11U; };
 
         for (auto t = 0UZ; t < trials; ++t) {
                 auto const i = next();

--- a/test/include/test/set/ordering.hpp
+++ b/test/include/test/set/ordering.hpp
@@ -10,7 +10,7 @@
 #include <test/bitset/factory.hpp>       // make_bitset
 #include <xstd/bits/bit_set_view.hpp> // bit_set_view
 #include <algorithm>                     // lexicographical_compare
-#include <compare>                       // strong_ordering
+#include <compare>                       // is_gt, is_lt, strong_ordering
 #include <cstddef>                       // size_t
 #include <set>                           // set
 
@@ -55,9 +55,9 @@ auto ordering_agrees_with_std_set(std::size_t universe = 4) -> void
 
                         equality_disagreements += static_cast<std::size_t>((xv == yv) != (kx == ky));
                         less_disagreements     += static_cast<std::size_t>(
-                                ((xv <=> yv) < 0) != std::lexicographical_compare(kx.begin(), kx.end(), ky.begin(), ky.end()));
+                                std::is_lt(xv <=> yv) != std::lexicographical_compare(kx.begin(), kx.end(), ky.begin(), ky.end()));
                         greater_disagreements  += static_cast<std::size_t>(
-                                ((xv <=> yv) > 0) != std::lexicographical_compare(ky.begin(), ky.end(), kx.begin(), kx.end()));
+                                std::is_gt(xv <=> yv) != std::lexicographical_compare(ky.begin(), ky.end(), kx.begin(), kx.end()));
                 }
         }
 
@@ -99,9 +99,9 @@ auto ordering_agrees_with_std_set_sampled(std::size_t universe, std::size_t tria
 
                 equality_disagreements += static_cast<std::size_t>((xv == yv) != (kx == ky));
                 less_disagreements     += static_cast<std::size_t>(
-                        ((xv <=> yv) < 0) != std::lexicographical_compare(kx.begin(), kx.end(), ky.begin(), ky.end()));
+                        std::is_lt(xv <=> yv) != std::lexicographical_compare(kx.begin(), kx.end(), ky.begin(), ky.end()));
                 greater_disagreements  += static_cast<std::size_t>(
-                        ((xv <=> yv) > 0) != std::lexicographical_compare(ky.begin(), ky.end(), kx.begin(), kx.end()));
+                        std::is_gt(xv <=> yv) != std::lexicographical_compare(ky.begin(), ky.end(), kx.begin(), kx.end()));
         }
 
         BOOST_CHECK_EQUAL(equality_disagreements, 0UZ);

--- a/test/include/test/set/ordering.hpp
+++ b/test/include/test/set/ordering.hpp
@@ -55,9 +55,9 @@ auto ordering_agrees_with_std_set(std::size_t universe = 4) -> void
 
                         equality_disagreements += static_cast<std::size_t>((xv == yv) != (kx == ky));
                         less_disagreements     += static_cast<std::size_t>(
-                                std::is_lt(xv <=> yv) != std::lexicographical_compare(kx.begin(), kx.end(), ky.begin(), ky.end()));
+                                std::is_lt(xv <=> yv) != std::ranges::lexicographical_compare(kx, ky));
                         greater_disagreements  += static_cast<std::size_t>(
-                                std::is_gt(xv <=> yv) != std::lexicographical_compare(ky.begin(), ky.end(), kx.begin(), kx.end()));
+                                std::is_gt(xv <=> yv) != std::ranges::lexicographical_compare(ky, kx));
                 }
         }
 
@@ -99,9 +99,9 @@ auto ordering_agrees_with_std_set_sampled(std::size_t universe, std::size_t tria
 
                 equality_disagreements += static_cast<std::size_t>((xv == yv) != (kx == ky));
                 less_disagreements     += static_cast<std::size_t>(
-                        std::is_lt(xv <=> yv) != std::lexicographical_compare(kx.begin(), kx.end(), ky.begin(), ky.end()));
+                        std::is_lt(xv <=> yv) != std::ranges::lexicographical_compare(kx, ky));
                 greater_disagreements  += static_cast<std::size_t>(
-                        std::is_gt(xv <=> yv) != std::lexicographical_compare(ky.begin(), ky.end(), kx.begin(), kx.end()));
+                        std::is_gt(xv <=> yv) != std::ranges::lexicographical_compare(ky, kx));
         }
 
         BOOST_CHECK_EQUAL(equality_disagreements, 0UZ);

--- a/test/include/test/set/ordering.hpp
+++ b/test/include/test/set/ordering.hpp
@@ -12,6 +12,7 @@
 #include <algorithm>                     // lexicographical_compare
 #include <compare>                       // is_gt, is_lt, strong_ordering
 #include <cstddef>                       // size_t
+#include <cstdint>                       // uint64_t
 #include <set>                           // set
 
 namespace test::set {
@@ -75,8 +76,10 @@ auto ordering_agrees_with_std_set_sampled(std::size_t universe, std::size_t tria
         auto equality_disagreements = 0UZ;
         auto less_disagreements     = 0UZ;
         auto greater_disagreements  = 0UZ;
-        auto lcg = 0x9E3779B97F4A7C15ULL;
-        auto const next = [&lcg] { lcg = (lcg * 6364136223846793005ULL) + 1442695040888963407ULL; return lcg >> 11; };
+        // Fixed width, not ULL: the sequence a fixed seed reproduces should not depend on how wide the
+        // platform makes unsigned long long.
+        auto lcg = std::uint64_t{0x9E3779B97F4A7C15};
+        auto const next = [&lcg] -> std::uint64_t { lcg = (lcg * 6364136223846793005ULL) + 1442695040888963407ULL; return lcg >> 11; };
 
         for (auto t = 0UZ; t < trials; ++t) {
                 auto const i = next();

--- a/test/include/test/set/primitives.hpp
+++ b/test/include/test/set/primitives.hpp
@@ -10,7 +10,7 @@
 #include <xstd/bits/set_adaptor.hpp> // set_adaptor
 #include <xstd/bits/ownership.hpp>     // ownership
 #include <algorithm>                    // equal_range, lexicographical_compare_three_way
-#include <compare>                      // strong_ordering
+#include <compare>                      // is_gteq, is_gt, is_lteq, is_lt, strong_ordering
 #include <concepts>                     // convertible_to, default_initializable, equality_comparable, integral, same_as, unsigned_integral
 #include <cstddef>                      // ptrdiff_t
 #include <functional>                   // hash
@@ -612,7 +612,7 @@ struct op_less
         auto operator()(auto const& a, auto const& b) const noexcept
         {                                                                       // [tab:container.opt]
                 static_assert(std::convertible_to<decltype(a < b), bool>);
-                BOOST_CHECK_EQUAL(a < b, (a <=> b) < 0);
+                BOOST_CHECK_EQUAL(a < b, std::is_lt(a <=> b));
                 BOOST_CHECK_EQUAL(a < b, std::ranges::lexicographical_compare(a, b));
                 BOOST_CHECK(not (a < b) or not (b < a));                        // asymmetric
         }
@@ -628,7 +628,7 @@ struct op_greater
         auto operator()(auto const& a, auto const& b) const noexcept
         {                                                                       // [tab:container.opt]
                 static_assert(std::convertible_to<decltype(a > b), bool>);
-                BOOST_CHECK_EQUAL(a > b, (a <=> b) > 0);
+                BOOST_CHECK_EQUAL(a > b, std::is_gt(a <=> b));
                 BOOST_CHECK_EQUAL(a > b, b < a);
         }
 };
@@ -638,7 +638,7 @@ struct op_less_equal
         auto operator()(auto const& a, auto const& b) const noexcept
         {                                                                       // [tab:container.opt]
                 static_assert(std::convertible_to<decltype(a <= b), bool>);
-                BOOST_CHECK_EQUAL(a <= b, (a <=> b) <= 0);
+                BOOST_CHECK_EQUAL(a <= b, std::is_lteq(a <=> b));
                 BOOST_CHECK_EQUAL(a <= b, not (b < a));
         }
 };
@@ -648,7 +648,7 @@ struct op_greater_equal
         auto operator()(auto const& a, auto const& b) const noexcept
         {                                                                       // [tab:container.opt]
                 static_assert(std::convertible_to<decltype(a >= b), bool>);
-                BOOST_CHECK_EQUAL(a >= b, (a <=> b) >= 0);
+                BOOST_CHECK_EQUAL(a >= b, std::is_gteq(a <=> b));
                 BOOST_CHECK_EQUAL(a >= b, not (a < b));
         }
 };

--- a/test/include/test/set/primitives.hpp
+++ b/test/include/test/set/primitives.hpp
@@ -40,7 +40,7 @@ struct ref_same_as_pred<xstd::set_adaptor<Bits, Own, Traits>>
 template<class X, class R, class T>
 inline constexpr auto ref_same_as = ref_same_as_pred<X>::template value<R, T>;
 
-template<class X, std::integral T = typename X::key_type>
+template<class X, std::integral T = X::key_type>
 struct nested_types
 {
         static_assert(std::same_as<typename X::value_type, T>);                         // [container.reqmts]/2

--- a/test/include/test/set/primitives.hpp
+++ b/test/include/test/set/primitives.hpp
@@ -263,7 +263,8 @@ struct mem_swap
         auto operator()(auto& a, auto& b) const noexcept
         {
                 static_assert(std::same_as<decltype(a.swap(b)), void>);         // [container.reqmts]/45
-                auto a1 = a, b1 = b;
+                auto a1 = a;
+                auto b1 = b;
                 a1.swap(b1);
                 BOOST_CHECK(a1 == b and b1 == a);                               // [container.reqmts]/46
         }
@@ -273,8 +274,10 @@ struct fn_swap
 {
         auto operator()(auto& a, auto& b) const noexcept
         {
-                auto a1 = a, b1 = b;
-                auto a2 = a, b2 = b;
+                auto a1 = a;
+                auto b1 = b;
+                auto a2 = a;
+                auto b2 = b;
                 swap(a1, b1); a2.swap(b2);
                 BOOST_CHECK(a1 == a2 and b1 == b2);                             // [container.reqmts]/48
         }

--- a/test/include/test/set/primitives.hpp
+++ b/test/include/test/set/primitives.hpp
@@ -40,7 +40,12 @@ struct ref_same_as_pred<xstd::set_adaptor<Bits, Own, Traits>>
 template<class X, class R, class T>
 inline constexpr auto ref_same_as = ref_same_as_pred<X>::template value<R, T>;
 
-template<class X, std::integral T = X::key_type>
+// typename stays here, and only here, of the eight sites P0634R3 made it redundant. MSVC 2022 rejects the
+// default argument of a constrained type-parameter without it -- "error C2061: syntax error: identifier
+// 'integral'" -- while GCC, clang, clang-cl and Apple clang all take it. The seven in sequence/concepts.hpp are
+// requires(...) parameter lists, which MSVC does accept.
+// NOLINTNEXTLINE(readability-redundant-typename)
+template<class X, std::integral T = typename X::key_type>
 struct nested_types
 {
         static_assert(std::same_as<typename X::value_type, T>);                         // [container.reqmts]/2

--- a/test/include/test/set/primitives.hpp
+++ b/test/include/test/set/primitives.hpp
@@ -354,7 +354,7 @@ struct mem_emplace
                 // where a move is not a copy, and bugprone-use-after-move is right to say so.
                 auto const value = typename X::value_type(std::forward<Args>(args)...);
                 auto const emplaced = not a.contains(value);
-                auto r = a.emplace(value);                                                              // [associative.reqmts.general]/49
+                auto const r = a.emplace(value);                                                              // [associative.reqmts.general]/49
                                                                                 // [associative.reqmts.general]/50
                 BOOST_CHECK(r == std::make_pair(a.find(value), emplaced));
         }
@@ -373,7 +373,7 @@ struct mem_emplace_hint
                 );
                 // Built once, for the reason mem_emplace gives.
                 auto const value = typename X::value_type(std::forward<Args>(args)...);
-                auto r = a.emplace_hint(p, value);                                              // [associative.reqmts.general]/58
+                auto const r = a.emplace_hint(p, value);                                              // [associative.reqmts.general]/58
                 BOOST_CHECK(r == a.find(value));                                                // [associative.reqmts.general]/59
         }
 };
@@ -404,7 +404,7 @@ struct mem_insert
         template<class X>
         auto operator()(X& a, X::iterator p, X::value_type const& t) const
         {
-                auto r = a.insert(p, t);
+                auto r = a.insert(p, t);  // NOLINT(misc-const-correctness): the next line asserts decltype(r), so const would break the assertion this exists to make
                 static_assert(std::same_as<decltype(r), typename X::iterator>); // [associative.reqmts.general]/70
                 static_assert(requires { a.insert(p, t); });                    // [associative.reqmts.general]/71
                 BOOST_CHECK(r == a.find(t));                                    // [associative.reqmts.general]/73


### PR DESCRIPTION
Closes #126

One commit per check, then the filter widening last.

| commit | check | count |
| --- | --- | ---: |
| `ea9aeb0` | `readability-uppercase-literal-suffix` | 75 |
| `54428aa` | `modernize-use-nullptr` | 10 |
| `0b7fe18` | `modernize-use-ranges` | 6 |
| `29b799e` | `readability-redundant-typename` | 8 |
| `b049e60` | `modernize-use-trailing-return-type` | 4 |
| `3fcb9f3` | `readability-isolate-declaration` | 3 |
| `660412f` | `bugprone-signed-bitwise` | 1 |
| `7a7a85b` | `misc-const-correctness` | 67 |
| `56f21c7` | `readability-function-cognitive-complexity` | 1 |
| `6bbf45a` | — the filter | — |

## The inventory was incomplete

#126 counts 112 findings, measured on clang-tidy 22. **68 of the 175 in this PR are reported only by clang-tidy 24**, and CI gates all three rungs.

Established on one tree rather than by comparing two — the first 22 sweep ran before any of these commits, which is not a comparison. Same tree, same 42 TUs, same config: **22 finds 1, 24 finds 68.** Almost all of it is `misc-const-correctness`, plus a `bugprone-signed-bitwise` on `lcg >> 11` that had been sitting on main unseen.

## Four things that were not mechanical

**`typename` nearly went badly.** A blanket replace of `typename C::` makes **65** substitutions where the check flags **8**. The other 57 are type-requirements inside `requires` bodies, where `typename` is mandatory syntax — dropping it silently turns a type-requirement into an expression-requirement that can still compile while asserting something else. Reverted and redone against the flagged lines by number.

**Two checks pull opposite ways.** 22's `modernize-use-trailing-return-type` wants a return type on the LCG lambda; 24's `readability-redundant-lambda-parameter-list` then wants the `()` gone, which needs C++23's P1102. Settled by precedent, not preference: `bitset_adaptor.hpp:753` already ships `[&] -> std::size_t` in a public header the whole ladder compiles.

**49 of the 67 const-correctness findings are right; 18 are not.** Applying all of them broke **290 compilations** — the exhaustive harnesses hand every object they build to `fun`, and some functors take it by non-const reference and write through it, which is what the set/reset/flip cases are *for*. clang-tidy sees one instantiation at a time. The eighteenth is sharper: `auto r = a.insert(p, t)` is followed by `static_assert(same_as<decltype(r), X::iterator>)` per [associative.reqmts.general]/70 — `const` changes `decltype(r)` and fails the assertion the line exists to make.

**One lint fix was a real improvement.** The LCG deduced `unsigned long long` from its `ULL` seed. Naming that would write the platform's width into a generator whose point is that a fixed seed reproduces a fixed sequence; the state is now `std::uint64_t`.

## The gate is verified by mutation, not by reading the regex

Clean: **0 findings on clang-tidy 22 and 24** across all 42 TUs with the repo config alone — no `--header-filter` on the command line. Reverting one range-`for` const is reported.

That verification paid for itself. The const-correctness commit first used one `NOLINTBEGIN` per harness file, which stated the rule once but stated it over the whole file — suppressing the 46 range-`for` consts in those same files along with the 17 declarations that needed it. A regression on any of them would have gone unreported by the very gate this PR closes. Narrowed to 17 per-site NOLINTs in `6bbf45a`.

Three earlier mutation attempts reported nothing and were my error, not the gate's: they landed on code the chosen TU never instantiates.

## Verification

- GCC 15 and clang 22: warning-free, **73/73** after every commit
- `typename` removal additionally checked on GCC 16 and clang 24; MSVC, clang-cl, MinGW and Apple clang are CI's to answer, and a NOLINT naming the refuser is the answer if one does

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLhTckKKQENsJPrZMXJJzo

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLhTckKKQENsJPrZMXJJzo)_