### PR TITLE
The sequence reading answers count, all, any, none, mismatch and for_each (#127)

### DIFF
--- a/design.md
+++ b/design.md
@@ -1135,6 +1135,91 @@ contract: an iterator that caches a block stops observing an erase that lands ah
 caching the same block is unobservable. The member is the faster half and the safer half at once, which is
 rare enough to record.
 
+### the-sequence-aggregates
+
+The sequence reading answers `count`, `all`, `any`, `none` and `mismatch` in its own vocabulary, each taking
+the `bool` that [alg.count] and [alg.all.of] give them where the bitset reading's four take none. That is the
+shape this row already has: `fill` takes a `bool` where the bitset reading splits `set()` and `reset()`.
+
+They are not redundant with `bit_set_view(v).size()`, which already answers a word-parallel count over the
+same storage. That view asks a *different question* -- reinterpret these bools as a set of positions and give
+me its cardinality -- which happens to return the same integer for `value == true`, and has no spelling at all
+for `count(false)`, `all(false)` and `none(false)`. Three readings over one storage is the whole design, and
+[two-readings-disagree](#two-readings-disagree) exists to say they are not interchangeable; making a caller
+change reading to count their bools is the fault the README levels at the two containers this library replaces.
+
+**The `false` arms are identities, not second implementations**, and they hold on a window too:
+
+```
+count(false) == size() - count(true)      all(false)  == none(true)
+any(false)   == not all(true)             none(false) == all(true)
+```
+
+Short-circuiting survives them: `all(false)` really does stop at the first set bit, because it *is*
+`none(true)`. So there are four private helpers -- `count_true`, `any_true`, `all_true`, `none_true` -- and the
+public members are spelled over those, each helper choosing its tier once: the trait's door over the whole, a
+masked word at a time over a window of ours, one position at a time over a window of anything else, which is
+the same three tiers `fill` uses ([windows](#windows)). `none_true` is a helper of its own rather than `not
+any_true`, so a storage that spells `none()` itself is asked in its own words; all three adapted here do.
+
+`bit_traits` grows `all`, `any` and `none` doors beside `count`, taken from an entry where the storage has one
+-- `block_sequence`, `std::bitset` and `boost::dynamic_bitset` all spell all three themselves -- and
+synthesized where it does not. Neither synthesis walks a bit at a time that it could avoid: `any` is
+`find_first` compared against the width, and `all` is `count` compared against it, which is the block tier
+through `count`'s own door.
+
+`mismatch` is `block_sequence::first_difference` plus one `countr_zero`. That helper existed already, private
+and used only by `sequence_three_way`; it is now public, and **keeps its name**: it scans low block to high,
+which is the *ascending* orderings' answer, where `bitset_three_way` deliberately walks the other way and does
+not use it. Calling it `mismatch` on the storage would repeat the mistake `lexicographical_three_way` made
+([two-readings-disagree](#two-readings-disagree)). The counterpart name goes on the public member, which is
+the owner's alone: a window's blocks are not its own.
+
+Measured on GCC 15.2, `-O3 -march=native`, 20% density, best of fifteen:
+
+| | 2^16 | 2^20 | 2^24 |
+|---|---|---|---|
+| `bit_vector::count()` | 0.1 µs | 2.0 µs | 49.5 µs |
+| `std::count` over `bit_vector` | 54.6 µs | 889 µs | 15072 µs |
+| `std::count` over `std::vector<bool>` | 45.1 µs | 702 µs | 11590 µs |
+
+234x to 541x, and the two `std::count` columns are within 1.3x of each other, which settles what #121 asserted
+and this measurement contradicts: **libstdc++ does not specialize `std::count` for `_Bit_iterator`**. A
+specialization would show as two orders of magnitude, not as twenty percent. Under clang 22 the ordering
+inverts -- `std::count` over `bit_vector` runs 2074 µs at 2^24 against `std::vector<bool>`'s 15419 -- because
+our iterator's dereference is a pure function of its index and clang vectorizes it, where `_Bit_iterator`'s
+loop-carried state blocks vectorization everywhere. `count()` is still 47x ahead of the faster of the two.
+
+### the-sequence-for-each
+
+`for_each(f)` on the sequence reading is the set reading's member ([the-set-for-each](#the-set-for-each))
+transposed: an outer loop over words, an inner loop over the bits of one word, so the reload that
+`operator++` must perform on every step becomes the inner loop's exit test. The functor takes what this
+reading's iterator dereferences to, a `bool`, where the set reading's takes a position, and may return `void`,
+or `bool` to mean "keep going", by the same one `if constexpr`.
+
+The reason it has to be a member is the same and the payoff is **not**. Measured across GCC 15, GCC 16, clang
+20 and clang 22, no iterator layout beats the current `(container pointer, index)` on this reading: a block
+pointer plus offset ties, and a cached residual word is *worse*, because `operator++` is flat and the reload
+test becomes a per-bit branch. So whatever `for_each` wins is loop structure, and loop structure is exactly
+what a vectorizer needs:
+
+| GCC 15.2, 2^24 bits | `for_each` | range-for | ratio |
+|---|---|---|---|
+| `n += b` | 1685 µs | 13842 µs | 8.2x |
+| `h = h * 1000003 ^ b` | 18743 µs | 19154 µs | 1.02x |
+
+**The win is the vectorizer's, not the loop's.** Where the body carries a loop-carried dependence there is
+nothing to hoist and the two are parity; where it does not, the outer-loop-over-words shape lets GCC
+vectorize what the flat `operator++` hides. And under clang 22 the range-for already vectorizes -- 2021 µs
+against `for_each`'s 1900, 1.06x -- so on that compiler the member buys almost nothing on this reading.
+
+That is a narrower claim than the one #127 was filed with, and it is the measured one. `for_each` is still
+worth having: it is never slower, it is 8x ahead on the compiler and body shape where the range-for leaves
+the most on the table, and it is the spelling that lets the library choose the loop rather than the caller.
+There is no `for_each_reverse` here, because unlike the set reading's, nothing about this walk is asymmetric:
+a reverse sequence walk is `std::ranges::reverse_view` over a random-access range, and it costs the same.
+
 ### read-only-set-proxy
 
 The set reading's proxy is read-only whatever the qualification of `Bits`, because a key is nothing to write
@@ -1328,11 +1413,12 @@ What the three have found so far, on GCC 15.2, `-O3 -march=native`, x86-64:
   5.8 ns at 32 MiB for both, and construction is parity too. Representation does not matter to a lookup; only
   footprint does. For a database that is the useful negative result: what buys a lookup is fewer bits per
   position, not a better container.
-- **`std::count` over `bit_vector` is about 1.6× slower than over `std::vector<bool>`** -- 120 MiB/s against
-  186 -- and consistently so at every rung. libstdc++ specializes `std::count` for `std::vector<bool>::iterator`
-  and counts a word at a time; our proxy iterator gets the generic element-by-element path. A sequence reading
-  that owns its blocks should not lose a sweep to the one the Standard is embarrassed by, so this is a gap in the
-  library rather than in the bench.
+- **`std::count` is slow over both, and the explanation this once carried was wrong.** It reads about 1.2× to
+  1.3× slower over `bit_vector` than over `std::vector<bool>` on GCC, and this file used to say libstdc++
+  specializes `std::count` for `std::vector<bool>::iterator` and counts a word at a time. It does not: a word-at-
+  a-time count is two orders of magnitude ahead, not twenty percent, which is what `bit_vector::count()` now
+  measures at ([the-sequence-aggregates](#the-sequence-aggregates)). The gap was the generic path over two
+  different proxy iterators, and under clang it runs the other way, ours being the vectorizable one.
 The sequence ladder's fixtures are the expensive part of a `ctest` smoke run: a 32 MiB fixture is filled a bit
 at a time, and the whole file costs about eleven seconds where the other three cost five between them. That is
 proportionate, and it is checked rather than assumed ([the-sieve](#the-sieve) records what happens when it is

--- a/include/xstd/bits/bit_traits.hpp
+++ b/include/xstd/bits/bit_traits.hpp
@@ -280,6 +280,49 @@ template<class Traits, class Bits>
         }
 }
 
+// The three the sequence reading asks in its own vocabulary, each behind an entry where the storage has one and
+// synthesized where it does not. Neither synthesis walks a bit at a time that it could avoid: any is a scan that
+// stops at the first set position, and all counts, which is the block tier through count's own door.
+// [design.md#the-sequence-aggregates]
+template<class Traits, class Bits>
+[[nodiscard]] constexpr auto any(Bits const& c [[maybe_unused]]) noexcept
+        -> bool
+{
+        if constexpr (zero_width<Traits>) {
+                return false;
+        } else if constexpr (requires { { Traits::any(c) } -> std::convertible_to<bool>; }) {
+                return Traits::any(c);
+        } else {
+                return find_first<Traits>(c) != Traits::size(c);
+        }
+}
+
+template<class Traits, class Bits>
+[[nodiscard]] constexpr auto none(Bits const& c [[maybe_unused]]) noexcept
+        -> bool
+{
+        if constexpr (zero_width<Traits>) {
+                return true;
+        } else if constexpr (requires { { Traits::none(c) } -> std::convertible_to<bool>; }) {
+                return Traits::none(c);
+        } else {
+                return not any<Traits>(c);
+        }
+}
+
+template<class Traits, class Bits>
+[[nodiscard]] constexpr auto all(Bits const& c [[maybe_unused]]) noexcept
+        -> bool
+{
+        if constexpr (zero_width<Traits>) {
+                return true;
+        } else if constexpr (requires { { Traits::all(c) } -> std::convertible_to<bool>; }) {
+                return Traits::all(c);
+        } else {
+                return count<Traits>(c) == Traits::size(c);
+        }
+}
+
 template<class Traits, class Bits>
 [[nodiscard]] constexpr auto find_next(Bits const& c [[maybe_unused]], std::size_t n [[maybe_unused]]) noexcept
         -> std::size_t

--- a/include/xstd/bits/block_sequence.hpp
+++ b/include/xstd/bits/block_sequence.hpp
@@ -885,8 +885,11 @@ public:
                 }
         }
 
-private:
         // The first block at which two values differ, with that block's xor; equal values answer the last block and a zero xor, every arm alike. [design.md#the-ordering-primitive]
+        //
+        // Public, because the sequence reading's mismatch is one countr_zero from it. The name stays: it scans
+        // low block to high, which is the ascending orderings' answer and not bitset_three_way's, so calling it
+        // mismatch here would repeat the mistake lexicographical_three_way made. [design.md#two-readings-disagree]
         [[nodiscard]] constexpr auto first_difference(block_sequence const& other) const noexcept
                 -> std::pair<std::size_t, block_type>
         {
@@ -908,6 +911,7 @@ private:
                 }
         }
 
+private:
         // Whether any position strictly above the given one is set; the bit there is clear, so one shift down leaves exactly what is above it. [design.md#the-ordering-primitive]
         [[nodiscard]] constexpr auto any_above(std::size_t index, std::size_t offset) const noexcept
                 -> bool
@@ -1067,6 +1071,14 @@ struct bit_traits<block_sequence<Blocks, N>>
         }
 
         [[nodiscard]] static constexpr auto count(bits_type const& c) noexcept -> std::size_t { return c.count(); }
+
+        // The three the sequence reading asks and the bitset reading already had: entries, so neither is synthesized here. [design.md#the-sequence-aggregates]
+        [[nodiscard]] static constexpr auto all (bits_type const& c) noexcept -> bool { return c.all();  }
+        [[nodiscard]] static constexpr auto any (bits_type const& c) noexcept -> bool { return c.any();  }
+        [[nodiscard]] static constexpr auto none(bits_type const& c) noexcept -> bool { return c.none(); }
+
+        // What mismatch is made of: the first differing block and its xor. [design.md#the-sequence-aggregates]
+        [[nodiscard]] static constexpr auto first_difference(bits_type const& x, bits_type const& y) noexcept { return x.first_difference(y); }
 
         // The two entries the readings cannot synthesize: insert is the one operation that can grow, and fill is bulk. [design.md#what-the-trait-reconciles]
         // A run-time width grows to hold the position, as boost's does; n + 1 must be addressable, the ruled-out position being the one whose successor wraps.

--- a/include/xstd/bits/ext/boost/dynamic_bitset.hpp
+++ b/include/xstd/bits/ext/boost/dynamic_bitset.hpp
@@ -30,6 +30,11 @@ struct bit_traits<boost::dynamic_bitset<Block, Allocator>>
         [[nodiscard]] static constexpr auto at   (bits_type const& c, std::size_t n) noexcept -> bool        { return c[n];      }
         [[nodiscard]] static constexpr auto count(bits_type const& c)                noexcept -> std::size_t { return c.count(); }
 
+        // The three the sequence reading asks, which dynamic_bitset spells itself: entries, so none is synthesized. [design.md#the-sequence-aggregates]
+        [[nodiscard]] static constexpr auto all  (bits_type const& c)                noexcept -> bool        { return c.all();   }
+        [[nodiscard]] static constexpr auto any  (bits_type const& c)                noexcept -> bool        { return c.any();   }
+        [[nodiscard]] static constexpr auto none (bits_type const& c)                noexcept -> bool        { return c.none();  }
+
         static constexpr void unchecked_assign(bits_type& c, std::size_t n, bool value) noexcept { c[n] = value; }
 
         // The one entry a dynamic width answers by growing; n + 1 must be addressable, the ruled-out position being the one whose successor wraps. [design.md#what-the-trait-reconciles]

--- a/include/xstd/bits/ext/std/bitset.hpp
+++ b/include/xstd/bits/ext/std/bitset.hpp
@@ -31,6 +31,11 @@ struct bit_traits<std::bitset<N>>
         [[nodiscard]] static constexpr auto at   (bits_type const& c, std::size_t n) noexcept -> bool        { return c[n];      }
         [[nodiscard]] static constexpr auto count(bits_type const& c)                noexcept -> std::size_t { return c.count(); }
 
+        // The three the sequence reading asks, which std::bitset spells itself: entries, so none is synthesized. [design.md#the-sequence-aggregates]
+        [[nodiscard]] static constexpr auto all  (bits_type const& c)                noexcept -> bool        { return c.all();   }
+        [[nodiscard]] static constexpr auto any  (bits_type const& c)                noexcept -> bool        { return c.any();   }
+        [[nodiscard]] static constexpr auto none (bits_type const& c)                noexcept -> bool        { return c.none();  }
+
         static constexpr void unchecked_assign(bits_type& c, std::size_t n, bool value) noexcept { c[n] = value; }
 
         // A static width cannot grow, so inserting is assigning with the position as a precondition. [design.md#what-the-trait-reconciles]

--- a/include/xstd/bits/sequence_adaptor.hpp
+++ b/include/xstd/bits/sequence_adaptor.hpp
@@ -9,9 +9,10 @@
 #include <boost/container_hash/is_range.hpp>      // is_range
 #include <boost/hash2/hash_append.hpp>            // hash_append_tag
 #include <xstd/bits/bit_proxy.hpp>                // bit_sequence_iterator, bit_sequence_reference
-#include <xstd/bits/bit_traits.hpp>               // bit_storage, bit_traits, static_bit_extent, word_at
+#include <xstd/bits/bit_traits.hpp>               // all, any, bit_storage, bit_traits, count, none, static_bit_extent, word_at
 #include <xstd/bits/detail/allocator_typedef.hpp> // allocator_typedef, no_typedef
 #include <xstd/bits/detail/hash.hpp>              // hash_append_bits, std_hash
+#include <xstd/bits/detail/intrin.hpp>            // countr_zero, popcount
 #include <xstd/bits/ownership.hpp>                // owned_bits_t, owned_storage, owned_traits_t, owner_of, ownership, owns
 #include <cassert>                                // assert
 #include <compare>                                // strong_ordering
@@ -21,16 +22,154 @@
 #include <functional>                             // hash
 #include <initializer_list>                       // initializer_list
 #include <iterator>                               // input_iterator, make_reverse_iterator, reverse_iterator, sentinel_for
+#include <limits>                                 // numeric_limits
 #include <algorithm>                              // copy, min, remove_if
 #include <ranges>                                 // begin, enable_borrowed_range, enable_view, end, from_range_t, input_range, range_reference_t, size, sized_range, subrange
 #include <source_location>                        // source_location
 #include <span>                                   // dynamic_extent
 #include <stdexcept>                              // out_of_range
-#include <type_traits>                            // conditional_t, false_type, is_nothrow_swappable_v, remove_const_t, remove_cvref_t, remove_reference_t
-#include <utility>                                // as_const, declval, forward, move
+#include <type_traits>                            // conditional_t, false_type, is_invocable_r_v, is_nothrow_swappable_v, remove_const_t, remove_cvref_t, remove_reference_t
+#include <utility>                                // as_const, declval, forward, move, pair
 
 // The sequence reading, [array] over any Bits with a bit_traits specialization, owning it or referring to it. [design.md#the-three-adaptors]
 namespace xstd {
+
+namespace detail::sequence {
+
+// The bits a window's word holds: every one but for the last word, which holds what is left over. The one
+// spelling of it, so the bulk operators and the aggregates below cannot disagree about the tail. [design.md#windows]
+template<class Block>
+[[nodiscard]] constexpr auto word_mask(std::size_t count) noexcept
+        -> Block
+{
+        constexpr auto digits = static_cast<std::size_t>(std::numeric_limits<Block>::digits);
+        // No shift by digits, which is undefined: a full word is every bit, spelled without one.
+        return count == digits ? static_cast<Block>(~Block{}) : static_cast<Block>(static_cast<Block>(Block{1} << count) - Block{1});
+}
+
+// Continue unless the functor says otherwise: a void functor always continues, a bool one says. What the set
+// reading's for_each does, over what this reading's iterator dereferences to. [design.md#the-sequence-for-each]
+template<class F>
+[[nodiscard]] constexpr auto invoke_continues(F& f, bool value) -> bool
+{
+        if constexpr (std::is_invocable_r_v<bool, F&, bool>) {
+                return f(value);
+        } else {
+                f(value);
+                return true;
+        }
+}
+
+// One tier each, because the tier is the seam and sharing a body puts the whole over
+// readability-function-cognitive-complexity's threshold. [design.md#one-function-per-tier]
+
+// Every position, lowest first, a word at a time: the outer loop loads once per word and the reload becomes the
+// inner loop's exit test, which a flat operator++ can never express. That structure is the whole speedup, the
+// iterator's layout already being the fastest there is. [design.md#the-sequence-for-each]
+template<class Traits, class Bits, class F>
+constexpr void walk_words(Bits const& c, std::size_t offset, std::size_t size, F& f)
+{
+        using block_type = std::remove_cvref_t<decltype(Traits::block(c, 0UZ))>;
+        constexpr auto digits = static_cast<std::size_t>(std::numeric_limits<block_type>::digits);
+
+        for (auto k = 0UZ; k < size; k += digits) {
+                auto const count = std::ranges::min(digits, size - k);
+                auto const word = detail::bits::word_at<Traits>(c, offset + k);
+                for (auto n = 0UZ; n < count; ++n) {
+                        if (not invoke_continues(f, (static_cast<block_type>(word >> n) & block_type{1}) != block_type{})) {
+                                return;
+                        }
+                }
+        }
+}
+
+// The other tier: a storage with no block access -- libc++'s std::bitset and boost's are the ones -- walks
+// positions, which is what the iterator does and is still the same answer. [design.md#windows]
+template<class Traits, class Bits, class F>
+constexpr void walk_positions(Bits const& c, std::size_t offset, std::size_t size, F& f)
+{
+        for (auto n = 0UZ; n < size; ++n) {
+                if (not invoke_continues(f, Traits::at(c, offset + n))) {
+                        return;
+                }
+        }
+}
+
+// The three aggregates over a window, each masked to what the window holds: a word at a time, so a window pays
+// what the whole pays and not a test per bit. A window of ours only -- the tail is clear where the mask does not
+// reach, and above the last word there is nothing. [design.md#windows]
+template<class Traits, class Bits>
+[[nodiscard]] constexpr auto count_words(Bits const& c, std::size_t offset, std::size_t size) noexcept
+        -> std::size_t
+{
+        using block_type = std::remove_cvref_t<decltype(Traits::block(c, 0UZ))>;
+        constexpr auto digits = static_cast<std::size_t>(std::numeric_limits<block_type>::digits);
+
+        auto n = 0UZ;
+        for (auto k = 0UZ; k < size; k += digits) {
+                auto const mask = word_mask<block_type>(std::ranges::min(digits, size - k));
+                n += detail::bits::popcount(static_cast<block_type>(detail::bits::word_at<Traits>(c, offset + k) & mask));
+        }
+        return n;
+}
+
+template<class Traits, class Bits>
+[[nodiscard]] constexpr auto any_words(Bits const& c, std::size_t offset, std::size_t size) noexcept
+        -> bool
+{
+        using block_type = std::remove_cvref_t<decltype(Traits::block(c, 0UZ))>;
+        constexpr auto digits = static_cast<std::size_t>(std::numeric_limits<block_type>::digits);
+
+        for (auto k = 0UZ; k < size; k += digits) {
+                auto const mask = word_mask<block_type>(std::ranges::min(digits, size - k));
+                if (static_cast<block_type>(detail::bits::word_at<Traits>(c, offset + k) & mask) != block_type{}) {
+                        return true;
+                }
+        }
+        return false;
+}
+
+template<class Traits, class Bits>
+[[nodiscard]] constexpr auto all_words(Bits const& c, std::size_t offset, std::size_t size) noexcept
+        -> bool
+{
+        using block_type = std::remove_cvref_t<decltype(Traits::block(c, 0UZ))>;
+        constexpr auto digits = static_cast<std::size_t>(std::numeric_limits<block_type>::digits);
+
+        for (auto k = 0UZ; k < size; k += digits) {
+                auto const mask = word_mask<block_type>(std::ranges::min(digits, size - k));
+                if (static_cast<block_type>(detail::bits::word_at<Traits>(c, offset + k) & mask) != mask) {
+                        return false;
+                }
+        }
+        return true;
+}
+
+// The same three over a window of anything else, one position at a time, which is what that storage offers.
+template<class Traits, class Bits>
+[[nodiscard]] constexpr auto count_positions(Bits const& c, std::size_t offset, std::size_t size) noexcept
+        -> std::size_t
+{
+        auto n = 0UZ;
+        for (auto k = 0UZ; k < size; ++k) {
+                n += Traits::at(c, offset + k) ? 1UZ : 0UZ;
+        }
+        return n;
+}
+
+template<class Traits, class Bits>
+[[nodiscard]] constexpr auto any_positions(Bits const& c, std::size_t offset, std::size_t size, bool value) noexcept
+        -> bool
+{
+        for (auto k = 0UZ; k < size; ++k) {
+                if (Traits::at(c, offset + k) == value) {
+                        return true;
+                }
+        }
+        return false;
+}
+
+}       // namespace detail::sequence
 
 // A sequence adaptor of any shape, told by its public typedefs, whose trait reads blocks of the given type: what a blit reads. [design.md#the-blit]
 template<class S, class Block>
@@ -445,6 +584,31 @@ public:
         [[nodiscard]] constexpr auto crbegin() const noexcept -> const_reverse_iterator { return std::make_reverse_iterator(cend());   }
         [[nodiscard]] constexpr auto crend()   const noexcept -> const_reverse_iterator { return std::make_reverse_iterator(cbegin()); }
 
+        // The sequence reading a word at a time, which the range-for cannot be. operator++ is flat: it must re-derive
+        // the word from (pointer, position) on every step, because an iterator stays copyable and restartable. A loop
+        // has somewhere to keep the word between positions, so the reload becomes an inner loop's exit test.
+        //
+        // What that buys is the vectorizer's and not the loop's, and it is narrower than it first looked: on GCC 15 at
+        // 2^24 bits a counting body runs 8.2x ahead of the range-for and a body with a loop-carried dependence runs at
+        // parity, and under clang 22 the range-for already vectorizes, leaving 1.06x. Never slower, 8x where the
+        // range-for leaves the most on the table. It is loop structure and not layout: the iterator's (container
+        // pointer, index) is the fastest of the four shapes tried and the only one clang vectorizes, precisely because
+        // the dereference is a pure function of the index -- which is also why this has to be a member, no iterator
+        // being able to express the outer loop. [design.md#the-sequence-for-each]
+        //
+        // The functor takes what this reading's iterator dereferences to, a bool, where the set reading's takes a
+        // position; it may return void, or bool to mean "keep going". Nothing else is offered: a functor that returns
+        // something else is a caller error rather than a value to discard silently. [design.md#the-set-for-each]
+        template<class F>
+        constexpr void for_each(this auto&& self, F f)
+        {
+                if constexpr (block_readable<Traits, bits_type>) {
+                        detail::sequence::walk_words<Traits>(self.storage(), self.offset(), self.size(), f);
+                } else {
+                        detail::sequence::walk_positions<Traits>(self.storage(), self.offset(), self.size(), f);
+                }
+        }
+
         // capacity; max_size() is the positions there are to hold: a growing one what its storage can address, and a
         // static width, a view or a window their own, none of them able to grow. [design.md#max-size-is-the-bits]
         [[nodiscard]] constexpr auto empty() const noexcept -> bool { return size() == 0UZ; }
@@ -467,6 +631,53 @@ public:
                 } else {
                         return size();
                 }
+        }
+
+        // The sequence reading's aggregates, in its own vocabulary and with the bool that [alg.count] and [alg.all.of]
+        // give them, where the bitset reading's four take none. That is the shape this row already has: fill takes a
+        // bool where the bitset reading splits set() and reset().
+        //
+        // Not redundant with bit_set_view(*this).size(). That asks a different question -- reinterpret these bools as a
+        // set of positions and give me its cardinality -- which happens to answer the same integer for value == true,
+        // and has no spelling at all for count(false), all(false) and none(false). Making a caller change reading to
+        // count their bools is the exact fault this library levels at the two it replaces.
+        // [design.md#two-readings-disagree]
+        //
+        // The false arms are identities rather than second implementations, and they hold on a window too. Short
+        // circuiting survives them: all(false) really does stop at the first set bit, because it is none(true).
+        // [design.md#the-sequence-aggregates]
+        [[nodiscard]] constexpr auto count(value_type value = true) const noexcept
+                -> size_type
+        {
+                auto const n = count_true();
+                return value ? n : size() - n;
+        }
+
+        [[nodiscard]] constexpr auto all (value_type value = true) const noexcept -> bool { return value ? all_true()  : none_true(); }
+        [[nodiscard]] constexpr auto any (value_type value = true) const noexcept -> bool { return value ? any_true()  : not all_true(); }
+        [[nodiscard]] constexpr auto none(value_type value = true) const noexcept -> bool { return value ? none_true() : all_true(); }
+
+        // std::mismatch's answer over the machinery the orderings are already made of: the first differing block and
+        // its xor, one countr_zero from the position, and size() where the two agree, as [alg.mismatch] answers last.
+        // 208x over std::mismatch on the same bit_vector at 2^22, GCC 15.
+        // An owner's alone, and only over storage that has the entry: a window's blocks are not its own.
+        // [design.md#the-sequence-aggregates]
+        [[nodiscard]] constexpr auto mismatch(sequence_adaptor const& other) const noexcept
+                -> size_type
+                requires (not is_window) and requires { Traits::first_difference(std::declval<bits_type const&>(), std::declval<bits_type const&>()); }
+        {
+                assert(size() == other.size());
+                // A zero width has no blocks to ask about, and answers its own width, which is nought.
+                if (empty()) {
+                        return 0UZ;
+                }
+                auto const [ index, diff ] = Traits::first_difference(storage(), other.storage());
+                using block_type = std::remove_cvref_t<decltype(diff)>;
+                constexpr auto digits = static_cast<size_type>(std::numeric_limits<block_type>::digits);
+                if (diff == block_type{}) {
+                        return size();
+                }
+                return (index * digits) + detail::bits::countr_zero(diff);
         }
 
         // Growth, [vector]'s members over storage that spells them alike, so detected on the storage rather than reconciled by the trait. [design.md#growth]
@@ -555,17 +766,69 @@ public:
         static constexpr void swap(reference x, reference y) noexcept { bool const t = x; x = y; y = t; }
 
 private:
+        // One tier each for the three aggregates above, chosen once: the trait's door over the whole, a masked word at
+        // a time over a window of ours, one position at a time over a window of anything else. [design.md#windows]
+        [[nodiscard]] constexpr auto count_true() const noexcept
+                -> size_type
+        {
+                if constexpr (not is_window) {
+                        return detail::bits::count<Traits>(storage());
+                } else if constexpr (block_readable<Traits, bits_type>) {
+                        return detail::sequence::count_words<Traits>(storage(), offset(), size());
+                } else {
+                        return detail::sequence::count_positions<Traits>(storage(), offset(), size());
+                }
+        }
+
+        [[nodiscard]] constexpr auto any_true() const noexcept
+                -> bool
+        {
+                if constexpr (not is_window) {
+                        return detail::bits::any<Traits>(storage());
+                } else if constexpr (block_readable<Traits, bits_type>) {
+                        return detail::sequence::any_words<Traits>(storage(), offset(), size());
+                } else {
+                        return detail::sequence::any_positions<Traits>(storage(), offset(), size(), true);
+                }
+        }
+
+        // Its own helper rather than not any_true(), so a storage that spells none() itself is asked in its own
+        // words; every storage adapted here does.
+        [[nodiscard]] constexpr auto none_true() const noexcept
+                -> bool
+        {
+                if constexpr (not is_window) {
+                        return detail::bits::none<Traits>(storage());
+                } else if constexpr (block_readable<Traits, bits_type>) {
+                        return not detail::sequence::any_words<Traits>(storage(), offset(), size());
+                } else {
+                        return not detail::sequence::any_positions<Traits>(storage(), offset(), size(), true);
+                }
+        }
+
+        // Not count() == size(): a clear position ends it, which is what the position tier looks for and what a word
+        // that is not all ones is.
+        [[nodiscard]] constexpr auto all_true() const noexcept
+                -> bool
+        {
+                if constexpr (not is_window) {
+                        return detail::bits::all<Traits>(storage());
+                } else if constexpr (block_readable<Traits, bits_type>) {
+                        return detail::sequence::all_words<Traits>(storage(), offset(), size());
+                } else {
+                        return not detail::sequence::any_positions<Traits>(storage(), offset(), size(), false);
+                }
+        }
+
         // The words of this window against the words of another at its own alignment, each masked to what the window holds.
         template<class Other, class F>
         constexpr void combine(this auto&& self, Other const& other, F f) noexcept
         {
                 using block_type = bits_type::block_type;
                 constexpr auto digits = bits_type::bits_per_block;
-                constexpr auto unit = block_type{1};
                 assert(self.size() == other.size());
                 for (auto k = 0UZ; k < self.size(); k += digits) {
-                        auto const count = std::ranges::min(digits, self.size() - k);
-                        auto const mask = count == digits ? static_cast<block_type>(~block_type{}) : static_cast<block_type>(static_cast<block_type>(unit << count) - unit);
+                        auto const mask = detail::sequence::word_mask<block_type>(std::ranges::min(digits, self.size() - k));
                         auto const mine   = detail::bits::word_at<Traits>(self.storage(), self.offset() + k);
                         auto const theirs = detail::bits::word_at<typename Other::traits_type>(other.storage(), other.offset() + k);
                         self.storage().set_word(self.offset() + k, f(mine, theirs), mask);

--- a/test/src/bits/bit_traits.cpp
+++ b/test/src/bits/bit_traits.cpp
@@ -5,7 +5,7 @@
 
 #include <boost/test/unit_test.hpp>      // BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL
 #include <test/block_types.hpp>          // graded_extents
-#include <xstd/bits/bit_traits.hpp>      // bit_storage, bit_traits, block_readable, scan_*, static_bit_extent, word_at
+#include <xstd/bits/bit_traits.hpp>      // all, any, bit_storage, bit_traits, block_readable, count, none, scan_*, static_bit_extent, word_at
 #include <xstd/bits/block_sequence.hpp>  // block_array
 #include <cstddef>                       // size_t
 #include <cstdint>                       // uint8_t
@@ -79,6 +79,21 @@ template<class T>
         return c;
 }
 
+// The four the sequence reading asks, synthesized here: neither adapter declares an entry, so this is the
+// fallback arm on both tiers, and at N == 0 the arm before either. Its own function, four BOOST_CHECK_EQUALs
+// being enough to put check_scans over the cognitive-complexity threshold. [design.md#one-function-per-tier]
+template<class T>
+auto check_aggregates(std::set<std::size_t> const& model) -> void
+{
+        auto const c = make<T>(model);
+        constexpr auto N = extent_of<T>;
+
+        BOOST_CHECK_EQUAL(bits::count<traits_of<T>>(c), model.size());
+        BOOST_CHECK_EQUAL(bits::any  <traits_of<T>>(c), not model.empty());
+        BOOST_CHECK_EQUAL(bits::none <traits_of<T>>(c), model.empty());
+        BOOST_CHECK_EQUAL(bits::all  <traits_of<T>>(c), model.size() == N);
+}
+
 // Every scan, at every argument its domain admits, against std::set answering the same question.
 template<class T>
 auto check_scans(std::set<std::size_t> const& model) -> void
@@ -110,17 +125,21 @@ auto check_every_pattern() -> void
         constexpr auto N = extent_of<T>;
 
         check_scans<T>({});
+        check_aggregates<T>({});
 
         auto full = std::set<std::size_t>();
         for (auto i = 0UZ; i < N; ++i) {
                 full.insert(i);
         }
         check_scans<T>(full);
+        check_aggregates<T>(full);
 
         for (auto i = 0UZ; i < N; ++i) {
                 check_scans<T>({ i });
+                check_aggregates<T>({ i });
                 if (i + 1UZ < N) {
                         check_scans<T>({ i, i + 1UZ });
+                        check_aggregates<T>({ i, i + 1UZ });
                 }
         }
 }

--- a/test/src/bits/sequence_adaptor.cpp
+++ b/test/src/bits/sequence_adaptor.cpp
@@ -4,12 +4,15 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/test/unit_test.hpp>          // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL, BOOST_CHECK_THROW
+#include <test/block_types.hpp>              // graded_extents
 #include <xstd/bits/sequence_adaptor.hpp>  // sequence_adaptor
 #include <xstd/bits/bit_array.hpp>           // bit_array
+#include <xstd/bits/bit_traits.hpp>          // bit_traits, block_readable
+#include <xstd/bits/bit_span.hpp>            // bit_span
 #include <xstd/bits/block_sequence.hpp>      // block_array, block_vector
 #include <xstd/bits/ext/std/bitset.hpp>      // bit_traits over std::bitset
 #include <xstd/bits/ownership.hpp>           // ownership
-#include <algorithm>                         // lexicographical_compare_three_way, ranges::equal
+#include <algorithm>                         // all_of, any_of, count, equal, lexicographical_compare_three_way, mismatch, none_of
 #include <bitset>                            // bitset
 #include <compare>                           // strong_ordering
 #include <concepts>                          // copyable, equality_comparable, regular, same_as, totally_ordered
@@ -212,6 +215,195 @@ BOOST_AUTO_TEST_CASE(AZeroWidthSequenceIsEmpty)
         auto c = xstd::block_array<std::uint8_t, 0>();
         auto const v = xstd::sequence_adaptor<xstd::block_array<std::uint8_t, 0>, xstd::ownership::refers, false>(c);
         BOOST_CHECK(v.empty() and v.begin() == v.end());
+}
+
+// The sequence reading's own aggregates, against the reading they belong to rather than the set reading that
+// happens to answer the same integer for one of the eight. Every operation on the packing and on the
+// std::vector<bool> it is held against, at every graded extent and block type so a block boundary lands
+// mid-pattern, and at both values of the bool. [design.md#the-sequence-aggregates]
+namespace {
+
+using Graded = test::graded_extents<xstd::basic_bit_array>;
+
+// One bit of pattern p at position i, as bit_array's model cases have it. Empty and full are the two degenerate
+// widths the aggregates disagree about most: they are the fixed points of all and none.
+auto pattern_bit(std::size_t p, std::size_t i, std::size_t n) -> bool
+{
+        switch (p) {
+        case 0UZ: return false;
+        case 1UZ: return true;
+        case 2UZ: return i == 0UZ;
+        case 3UZ: return i + 1UZ == n;
+        case 4UZ: return (i % 2UZ) == 0UZ;
+        default:  return (i % 3UZ) == 0UZ;
+        }
+}
+
+// The model at the same extent, written through the sequence under test so the two are filled by one loop.
+template<class Seq>
+auto write_pattern(Seq& s, std::size_t p) -> std::vector<bool>
+{
+        auto m = std::vector<bool>(s.size());
+        for (auto i = 0UZ; i < s.size(); ++i) {
+                bool const bit = pattern_bit(p, i, s.size());
+                s[i] = bit;
+                m[i] = bit;
+        }
+        return m;
+}
+
+// Counted rather than asserted per position, so a failure names the operation instead of drowning the log.
+// [design.md#counted-not-asserted]
+template<class Seq>
+auto aggregate_disagreements(Seq const& s, std::vector<bool> const& m) -> std::size_t
+{
+        auto disagreements = 0UZ;
+        for (auto const value : { true, false }) {
+                auto const is = [value](bool b) -> bool { return b == value; };
+                disagreements += static_cast<std::size_t>(s.count(value) != static_cast<std::size_t>(std::ranges::count(m, value)));
+                disagreements += static_cast<std::size_t>(s.all (value) != std::ranges::all_of (m, is));
+                disagreements += static_cast<std::size_t>(s.any (value) != std::ranges::any_of (m, is));
+                disagreements += static_cast<std::size_t>(s.none(value) != std::ranges::none_of(m, is));
+        }
+        // The argument defaults to the true arm, which is where the bitset reading's four already are.
+        disagreements += static_cast<std::size_t>(s.count() != s.count(true));
+        disagreements += static_cast<std::size_t>(s.all()   != s.all(true));
+        disagreements += static_cast<std::size_t>(s.any()   != s.any(true));
+        disagreements += static_cast<std::size_t>(s.none()  != s.none(true));
+        // The four identities the false arms are, spelled here because they are the implementation.
+        disagreements += static_cast<std::size_t>(s.count(false) != s.size() - s.count(true));
+        disagreements += static_cast<std::size_t>(s.all(false)   != s.none(true));
+        disagreements += static_cast<std::size_t>(s.any(false)   != not s.all(true));
+        disagreements += static_cast<std::size_t>(s.none(false)  != s.all(true));
+        return disagreements;
+}
+
+// What for_each hands its functor, in the order it hands it: the range-for's own answer, which is the contract.
+template<class Seq>
+auto for_each_bools(Seq const& s) -> std::vector<bool>
+{
+        auto v = std::vector<bool>();
+        s.for_each([&v](bool b) -> void { v.push_back(b); });
+        return v;
+}
+
+}       // namespace
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(TheAggregatesAgreeWithTheModel, T, Graded)
+{
+        auto disagreements = 0UZ;
+        for (auto p = 0UZ; p < 6UZ; ++p) {
+                auto a = T();
+                auto const m = write_pattern(a, p);
+                disagreements += aggregate_disagreements(a, m);
+        }
+        BOOST_CHECK_EQUAL(disagreements, 0UZ);
+}
+
+// The same over a window, whose blocks are not its own: a masked word at a time, at every offset and every
+// length, so the mask is exercised at both ends of a word rather than only at the top. [design.md#windows]
+BOOST_AUTO_TEST_CASE(TheAggregatesAgreeWithTheModelOnAWindowOfOurs)
+{
+        using Storage24 = xstd::block_array<std::uint8_t, 24>;
+        auto disagreements = 0UZ;
+        for (auto p = 0UZ; p < 6UZ; ++p) {
+                auto c = Storage24();
+                auto v = xstd::bit_span(c);
+                auto const m = write_pattern(v, p);
+                for (auto off = 0UZ; off <= v.size(); ++off) {
+                        for (auto count = 0UZ; off + count <= v.size(); ++count) {
+                                auto const w = v.subspan(off, count);
+                                auto const mw = std::vector<bool>(m.begin() + static_cast<std::ptrdiff_t>(off), m.begin() + static_cast<std::ptrdiff_t>(off + count));
+                                disagreements += aggregate_disagreements(w, mw);
+                                disagreements += static_cast<std::size_t>(not std::ranges::equal(for_each_bools(w), mw));
+                        }
+                }
+        }
+        BOOST_CHECK_EQUAL(disagreements, 0UZ);
+}
+
+// And over a window of a storage that keeps its blocks to itself, which is the one position-at-a-time tier: a
+// std::bitset too wide for the portable to_ullong() read has no block entry at all. [design.md#detection-by-absence]
+BOOST_AUTO_TEST_CASE(TheAggregatesAgreeWithTheModelOnAWindowOfAnythingElse)
+{
+        using Wide = std::bitset<100>;
+        static_assert(not xstd::block_readable<xstd::bit_traits<Wide>, Wide>);
+
+        auto disagreements = 0UZ;
+        for (auto p = 0UZ; p < 6UZ; ++p) {
+                auto c = Wide();
+                auto v = xstd::bit_span(c);
+                auto const m = write_pattern(v, p);
+                for (auto const off : { 0UZ, 1UZ, 7UZ, 63UZ, 100UZ }) {
+                        for (auto const count : { 0UZ, 1UZ, 9UZ, 37UZ }) {
+                                if (off + count > v.size()) {
+                                        continue;
+                                }
+                                auto const w = v.subspan(off, count);
+                                auto const mw = std::vector<bool>(m.begin() + static_cast<std::ptrdiff_t>(off), m.begin() + static_cast<std::ptrdiff_t>(off + count));
+                                disagreements += aggregate_disagreements(w, mw);
+                                disagreements += static_cast<std::size_t>(not std::ranges::equal(for_each_bools(w), mw));
+
+                                // The position tier's own early exit, which the block tier's case below covers for it.
+                                auto seen = 0UZ;
+                                w.for_each([&seen](bool) -> bool { return ++seen < 3UZ; });
+                                disagreements += static_cast<std::size_t>(seen != std::ranges::min(w.size(), 3UZ));
+                        }
+                }
+        }
+        BOOST_CHECK_EQUAL(disagreements, 0UZ);
+}
+
+// std::mismatch's answer, over the machinery operator== is already made of: the position, or size() where the two
+// agree. Every pair of patterns, so the answer lands inside a block, on a boundary and past the end.
+BOOST_AUTO_TEST_CASE_TEMPLATE(MismatchAgreesWithTheModel, T, Graded)
+{
+        auto disagreements = 0UZ;
+        for (auto p = 0UZ; p < 6UZ; ++p) {
+                for (auto q = 0UZ; q < 6UZ; ++q) {
+                        auto x = T();
+                        auto y = T();
+                        auto const mx = write_pattern(x, p);
+                        auto const my = write_pattern(y, q);
+                        auto const [i, j] = std::ranges::mismatch(mx, my);
+                        auto const expected = static_cast<std::size_t>(i - mx.begin());
+                        disagreements += static_cast<std::size_t>(x.mismatch(y) != expected);
+                        // Symmetric, and equal values answer the width rather than any position in it.
+                        disagreements += static_cast<std::size_t>(y.mismatch(x) != expected);
+                        disagreements += static_cast<std::size_t>(x.mismatch(x) != x.size());
+                }
+        }
+        BOOST_CHECK_EQUAL(disagreements, 0UZ);
+}
+
+// Dependent, so a constrained-away member is a false rather than a hard error.
+template<class S> constexpr bool can_mismatch = requires (S const& a) { a.mismatch(a); };
+
+// A window's blocks are not its own, so it has no mismatch; nor has an owner over storage without the entry.
+BOOST_AUTO_TEST_CASE(MismatchIsTheOwnersOverStorageThatHasTheEntry)
+{
+        static_assert(can_mismatch<Owner>);
+        static_assert(can_mismatch<View>);
+        static_assert(not can_mismatch<View::subspan_type>);
+        static_assert(not can_mismatch<xstd::sequence_adaptor<std::bitset<9>, xstd::ownership::owns, false>>);
+}
+
+// for_each hands the functor what the iterator dereferences to, in the same order, and stops where a bool functor
+// says to: the range-for's answer by a loop structure no iterator can express. [design.md#the-sequence-for-each]
+BOOST_AUTO_TEST_CASE_TEMPLATE(ForEachAgreesWithTheRangeFor, T, Graded)
+{
+        auto disagreements = 0UZ;
+        for (auto p = 0UZ; p < 6UZ; ++p) {
+                auto a = T();
+                auto const m = write_pattern(a, p);
+                disagreements += static_cast<std::size_t>(not std::ranges::equal(for_each_bools(a), m));
+
+                // A void functor always continues; a bool one says, and three is inside every extent but the two smallest.
+                auto seen = 0UZ;
+                a.for_each([&seen](bool) -> bool { return ++seen < 3UZ; });
+                disagreements += static_cast<std::size_t>(seen != std::ranges::min(a.size(), 3UZ));
+        }
+        BOOST_CHECK_EQUAL(disagreements, 0UZ);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/bits/sequence_adaptor.cpp
+++ b/test/src/bits/sequence_adaptor.cpp
@@ -43,7 +43,41 @@ template<class Seq>
         return { s.begin(), s.end() };
 }
 
+// A storage that keeps its blocks to itself on every standard library, which a std::bitset is not: libc++ has no
+// block entry at all, libstdc++ none above the portable to_ullong() read, and MSVC one at every width through
+// _Getword. So the position tier gets a fixture of its own, the required entries and a write and nothing more,
+// as test/src/bits/bit_traits.cpp's element_bits is. [design.md#detection-by-absence]
+template<std::size_t N>
+struct element_bits
+{
+        xstd::block_array<std::uint8_t, N> bits{};
+};
+
 }       // namespace
+
+namespace xstd {
+
+template<std::size_t N>
+struct bit_traits<element_bits<N>>
+{
+        using bits_type = element_bits<N>;
+
+        static constexpr std::size_t extent = N;
+
+        [[nodiscard]] static constexpr auto size(bits_type const&)                  noexcept -> std::size_t { return N; }
+        [[nodiscard]] static constexpr auto at  (bits_type const& c, std::size_t n) noexcept -> bool        { return c.bits.test(n); }
+
+        static constexpr void unchecked_assign(bits_type& c, std::size_t n, bool value) noexcept
+        {
+                if (value) {
+                        c.bits.set(n);
+                } else {
+                        c.bits.reset(n);
+                }
+        }
+};
+
+}       // namespace xstd
 
 BOOST_AUTO_TEST_SUITE(SequenceAdaptor)
 
@@ -322,11 +356,11 @@ BOOST_AUTO_TEST_CASE(TheAggregatesAgreeWithTheModelOnAWindowOfOurs)
         BOOST_CHECK_EQUAL(disagreements, 0UZ);
 }
 
-// And over a window of a storage that keeps its blocks to itself, which is the one position-at-a-time tier: a
-// std::bitset too wide for the portable to_ullong() read has no block entry at all. [design.md#detection-by-absence]
+// And over a window of a storage that keeps its blocks to itself, which is the one position-at-a-time tier.
+// [design.md#detection-by-absence]
 BOOST_AUTO_TEST_CASE(TheAggregatesAgreeWithTheModelOnAWindowOfAnythingElse)
 {
-        using Wide = std::bitset<100>;
+        using Wide = element_bits<100>;
         static_assert(not xstd::block_readable<xstd::bit_traits<Wide>, Wide>);
 
         auto disagreements = 0UZ;


### PR DESCRIPTION
Closes #127.

## What lands

`sequence_adaptor` grows the five the issue asks for, plus `for_each`:

```cpp
[[nodiscard]] constexpr auto count(value_type value = true) const noexcept -> size_type;
[[nodiscard]] constexpr auto all  (value_type value = true) const noexcept -> bool;
[[nodiscard]] constexpr auto any  (value_type value = true) const noexcept -> bool;
[[nodiscard]] constexpr auto none (value_type value = true) const noexcept -> bool;
[[nodiscard]] constexpr auto mismatch(sequence_adaptor const& other) const noexcept -> size_type;
template<class F> constexpr void for_each(this auto&& self, F f);
```

The `false` arms are identities, not second implementations, and short-circuiting survives them: `all(false)` really does stop at the first set bit, because it *is* `none(true)`. Four private helpers — `count_true`, `any_true`, `all_true`, `none_true` — each choose their tier once: the trait's door over the whole, a masked word at a time over a window of ours, one position at a time over a window of anything else, which is the same three tiers `fill` uses. `none_true` is a helper of its own rather than `not any_true`, so a storage that spells `none()` itself is asked in its own words.

`bit_traits` gains `all`, `any` and `none` doors beside `count`, and all three adapted storages (`block_sequence`, `std::bitset`, `boost::dynamic_bitset`) get entries. `block_sequence::first_difference` moves from private to public and **keeps its name**: it scans low block to high, which is the ascending orderings' answer and not `bitset_three_way`'s, so calling it `mismatch` there would repeat the `lexicographical_three_way` mistake. The counterpart name goes on the public member.

The window mask now has one spelling, `detail::sequence::word_mask`, which `combine` takes too.

## Measured — and narrower than the issue claimed

GCC 15.2, `-O3 -march=native`, 20% density, best of fifteen:

| | 2^16 | 2^20 | 2^24 |
|---|---|---|---|
| `bit_vector::count()` | 0.1 µs | 2.0 µs | 49.5 µs |
| `std::count` over `bit_vector` | 54.6 µs | 889 µs | 15072 µs |
| `std::count` over `std::vector<bool>` | 45.1 µs | 702 µs | 11590 µs |

234× to 541×, and the two `std::count` columns are within 1.3× of each other — which settles the premise #121 was filed on: **libstdc++ does not specialize `std::count` for `_Bit_iterator`.** A word-at-a-time count shows as two orders of magnitude, not as twenty percent. Under clang 22 the ordering inverts (2074 µs against `std::vector<bool>`'s 15419 at 2^24) because our iterator's dereference is a pure function of its index and clang vectorizes it. `count()` is still 47× ahead of the faster of the two.

`for_each` is the part the issue overstated. At 2^24 on GCC 15:

| body | `for_each` | range-for | ratio |
|---|---|---|---|
| `n += b` | 1685 µs | 13842 µs | 8.2× |
| `h = h * 1000003 ^ b` | 18743 µs | 19154 µs | 1.02× |

**The win is the vectorizer's, not the loop's.** Where the body carries a loop-carried dependence the two are parity; where it does not, the outer-loop-over-words shape lets GCC vectorize what a flat `operator++` hides. Under clang 22 the range-for already vectorizes, leaving 1.06×. So not the flat 2.12× the issue quotes — but never slower, 8× where the range-for leaves the most on the table, and the spelling that lets the library choose the loop rather than the caller.

`mismatch` runs 208× over `std::mismatch` on the same `bit_vector` at 2^22.

`design.md` records all of this, and the `the-sequence-ladder` bullet whose explanation this measurement refutes is corrected rather than left standing.

## No `for_each_reverse`

The issue lists `for_each` singular, and unlike the set reading's, nothing about this walk is asymmetric: a reverse sequence walk is `std::ranges::reverse_view` over a random-access range and costs the same. Say the word if you want it anyway.

## Tests

Against `std::vector<bool>`, as #61's `bit_array` cases do: every operation at every graded extent and block type so a block boundary lands mid-pattern, at both values of the `bool`, over the whole and over a window at every offset and every length, on a storage with block access (`block_array<uint8_t, 24>`) and on one without, and the empty and full degenerate widths. `mismatch` against `std::ranges::mismatch` over every pair of six patterns. The synthesized trait arms are covered in `test/src/bits/bit_traits.cpp`, where neither adapter declares an entry.

The no-block-access fixture was first written as `std::bitset<100>`, and the Windows half of the matrix caught that as a platform assumption: MSVC's STL satisfies `block_readable` at every width through `_Getword`, where libc++ has no block entry at all and libstdc++ none above the portable `to_ullong()` read. The `static_assert` was the bug rather than the code under test — the aggregates agree on either tier — but without it the case would have exercised the word tier on Windows and the position tier elsewhere, which is not a fixture. So the tier gets a storage of its own, a local `element_bits<N>` carrying the required entries plus a write and nothing more, as `test/src/bits/bit_traits.cpp`'s namesake already is. `block_readable` is false for it by construction on every standard library.

Six mutations of the new code — `count` ignoring the false arm, `word_mask` never trimming the tail, `all_words` comparing against zero, `mismatch` dropping the block index, `walk_words` ignoring the tail count, the position tier's `all` answering `any` — were tried and all six failed the suite.

## Verification

All 86 checks green on `0a52772`, `coverage / gcovr` (100% line and branch, enforced) and the three clang-tidy rungs among them, and the PR is mergeable against `main` with no conflict.

Locally before each push: GCC 15 Debug 73/73 ctest, clang 22 `-Werror` clean on the touched binaries, clang-tidy 22 and 24-SVN with no findings on the changed TUs or the header self-sufficiency TUs. (Two findings those runs also show — `clang-diagnostic-nrvo` in `bit_subspan.cpp` and a `clang-analyzer` hit inside `/usr/include/boost/dynamic_bitset` — were confirmed present on `main` without this diff and are left alone.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLhTckKKQENsJPrZMXJJzo