### PR TITLE
Spell decay-copy as auto(x), which the dropped rung makes possible

### DIFF
--- a/design.md
+++ b/design.md
@@ -1463,10 +1463,16 @@ class subscripts and `std::ranges::contiguous_range` does not promise that.
 
 ### the-functor-takes-a-value
 
-Both `for_each`es hand their functor a **prvalue** -- through a three-line `decay_copy`, not `auto(x)`: MSVC
-2022 does not implement P0849R8, and `T{x}` reads to clang-tidy as a cast to the type it already has -- and
-both members say so with `requires std::invocable<F&, bool>` and `requires std::invocable<F&, size_t>`. That is one fix for one defect, spelled in two places because
-it is worth catching at the interface and worth being right in the body.
+Both `for_each`es hand their functor a **prvalue** -- as `auto(x)`, C++23's decay-copy in the language
+([P0849R8](https://wg21.link/P0849R8)) -- and both members say so with `requires std::invocable<F&, bool>` and
+`requires std::invocable<F&, size_t>`. That is one fix for one defect, spelled in two places because it is
+worth catching at the interface and worth being right in the body.
+
+It was a three-line `decay_copy` helper per adaptor until the MSVC 17 rung left the matrix
+([the-views-are-the-adaptors](#the-views-are-the-adaptors)): MSVC 2022 does not implement P0849R8, and the
+other way round it -- `T{x}` -- reads to clang-tidy as a cast to the type it already has. That second
+objection was only ever against the workaround; `auto(x)` is the paper's own spelling and clang-tidy has
+nothing to say about it. Twenty lines went with the two helpers.
 
 The defect was that `invoke_continues` named its parameter and passed that name along. A named parameter is an
 lvalue, so a functor asking for `bool&` or `size_t&` bound to it, compiled, and wrote to a local that the walk

--- a/include/xstd/bits/sequence_adaptor.hpp
+++ b/include/xstd/bits/sequence_adaptor.hpp
@@ -47,16 +47,6 @@ template<class Block>
         return count == digits ? static_cast<Block>(~Block{}) : static_cast<Block>(static_cast<Block>(Block{1} << count) - Block{1});
 }
 
-// [expr.type.conv]'s decay-copy, as a function rather than as auto(x): MSVC 2022 does not implement P0849R8, and
-// T{x} reads to clang-tidy as a cast to the type it already has. Returning by value is the whole of it -- that is
-// what makes the argument at the call below a prvalue. [design.md#the-functor-takes-a-value]
-template<class T>
-[[nodiscard]] constexpr auto decay_copy(T value) noexcept
-        -> T
-{
-        return value;
-}
-
 // Continue unless the functor says otherwise: a void functor always continues, a bool one says. What the set
 // reading's for_each does, over what this reading's iterator dereferences to. [design.md#the-sequence-for-each]
 //
@@ -70,9 +60,9 @@ template<class F>
         -> bool
 {
         if constexpr (std::is_invocable_r_v<bool, F&, bool>) {
-                return f(decay_copy(value));
+                return f(auto(value));
         } else {
-                f(decay_copy(value));
+                f(auto(value));
                 return true;
         }
 }

--- a/include/xstd/bits/set_adaptor.hpp
+++ b/include/xstd/bits/set_adaptor.hpp
@@ -36,16 +36,6 @@ namespace detail::set {
 template<class R> inline constexpr bool is_consecutive = false;
 template<class W, class B> inline constexpr bool is_consecutive<std::ranges::iota_view<W, B>> = true;
 
-// [expr.type.conv]'s decay-copy, as a function rather than as auto(x): MSVC 2022 does not implement P0849R8, and
-// T{x} reads to clang-tidy as a cast to the type it already has. Returning by value is the whole of it -- that is
-// what makes the argument at the call below a prvalue. [design.md#the-functor-takes-a-value]
-template<class T>
-[[nodiscard]] constexpr auto decay_copy(T value) noexcept
-        -> T
-{
-        return value;
-}
-
 // Continue unless the functor says otherwise: a void functor always continues, a bool one says.
 // [design.md#the-set-for-each]
 //
@@ -59,9 +49,9 @@ template<class F>
         -> bool
 {
         if constexpr (std::is_invocable_r_v<bool, F&, std::size_t>) {
-                return f(decay_copy(pos));
+                return f(auto(pos));
         } else {
-                f(decay_copy(pos));
+                f(auto(pos));
                 return true;
         }
 }


### PR DESCRIPTION
One commit, **−28/+14 lines**, no behaviour change. Both `for_each`es still hand their functor a prvalue; only the spelling changes.

```diff
-                return f(decay_copy(pos));
+                return f(auto(pos));
```

and the helper behind it goes, from each of `set_adaptor.hpp` and `sequence_adaptor.hpp`:

```diff
-// [expr.type.conv]'s decay-copy, as a function rather than as auto(x): MSVC 2022 does not implement P0849R8, and
-// T{x} reads to clang-tidy as a cast to the type it already has. Returning by value is the whole of it -- that is
-// what makes the argument at the call below a prvalue. [design.md#the-functor-takes-a-value]
-template<class T>
-[[nodiscard]] constexpr auto decay_copy(T value) noexcept
-        -> T
-{
-        return value;
-}
```

`auto(x)` **is** decay-copy — [expr.type.conv], [P0849R8](https://wg21.link/P0849R8), C++23 — so all four call sites are equivalent in meaning, and the prvalue-forcing that `design.md#the-functor-takes-a-value` depends on is untouched. That property is the point of the whole mechanism: a *named* lvalue binds to a functor taking `std::size_t&` or `bool&`, which then writes to a local the walk throws away; a prvalue makes that a compile error.

`noexcept` and `[[nodiscard]]` go without loss — `auto(pos)` on a `size_t` and `auto(value)` on a `bool` are trivial copies, and the annotations existed only because the thing was a function.

## Why now

The helper's comment gave two reasons and both are spent.

- **MSVC 2022 does not implement P0849R8.** That rung left the matrix in #134, because MSVC 17 cannot deduce through the views' alias templates either. This change is the second dividend of that decision.
- **`T{x}` reads to clang-tidy as a cast to the type it already has.** That was only ever an objection to the *other* way round it. `auto(x)` is the paper's own spelling, and clang-tidy 22 has nothing to say about it.

`design.md#the-functor-takes-a-value` keeps the history rather than dropping it — the helper is the kind of scaffolding a reader would otherwise wonder about, so the section now says what the spelling is and that a rung had to go first.

## Verification

GCC 15 Debug **69/69**. clang 22 `-Weverything -Werror` clean on `set_adaptor`, `sequence_adaptor`, `bit_set_view` and `bit_span`. clang-tidy 22 no findings.

**MSVC is the one thing local verification cannot reach, and it is why this is its own PR rather than part of #134.** Microsoft's conformance table lists P0849R8 at two conflicting versions — VS 2022 17.4 in one section, MSVC Build Tools 14.50 in another — and that table was already wrong once in this branch's history, about P1814: it claimed VS 2019 16.7 for CTAD-through-alias while MSVC 17 demonstrably fails on the shape these views need. Isolated like this, a red rung means one unambiguous thing.

## Related

- Follows #134 (`f7379ef`), which dropped the MSVC 17 rung and recorded the P1814 correction in `design.md#the-views-are-the-adaptors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLhTckKKQENsJPrZMXJJzo

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLhTckKKQENsJPrZMXJJzo)_