### PR TITLE
Drop the last MSVC 17 typename, give std_hash a Hash parameter, and align every include comment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,9 @@
 
 This repository enforces its quality bar through CI rather than through review discretion. A PR is mergeable once every required check below is green.
 
-- **Every compiler/platform leg passes.** See the table in [README.md](README.md) for the current matrix (GCC, Clang, Clang libc++, Clang-CL, MSVC, MinGW, Apple Clang). Every leg counts, including every `Development` leg (`17-SVN`, `24-SVN`, `2026-Preview`), the `libc++` legs, and the VS 2022 legs; none of them are advisory. Each ladder workflow ends in an `all` job that is red unless every one of its legs succeeded, and that gate is what branch protection requires: a leg name changes whenever a rung moves, the gate name does not.
+- **Every compiler/platform leg passes.** See the table in [README.md](README.md) for the current matrix (GCC, Clang, Clang libc++, Clang-CL, MSVC, MinGW, Apple Clang). Every leg counts, including every `Development` leg (`17-SVN`, `24-SVN`, `2026-Preview`), the `libc++` legs, and the `Clang-CL` VS 2022 legs; none of them are advisory. Each ladder workflow ends in an `all` job that is red unless every one of its legs succeeded, and that gate is what branch protection requires: a leg name changes whenever a rung moves, the gate name does not.
 - **`clang-tidy` is clean.** [`.clang-tidy`](.clang-tidy) sets `WarningsAsErrors: '*'`, so any finding over the public headers fails the job outright.
-- **MSVC's `/analyze` is clean.** The [MSVC-Analyze workflow](.github/workflows/msvc-analyze.yml) fills the same role on the MSVC side, on all three Visual Studio rungs.
+- **MSVC's `/analyze` is clean.** The [MSVC-Analyze workflow](.github/workflows/msvc-analyze.yml) fills the same role on the MSVC side, on the two Visual Studio 2026 rungs the `msvc` ladder covers.
 - **No sanitizer failures.** The [Sanitizers workflow](.github/workflows/sanitizers.yml) runs ASan+LSan, UBSan and the implicit-conversion sanitizer, against both libstdc++ and libc++. Leak detection is on.
 - **The public headers stay self-sufficient.** Each header is compiled as its own translation unit (see `test/CMakeLists.txt`); don't rely on include order from another header.
 - **Workflow files pass `actionlint`.** The [Actionlint workflow](.github/workflows/actionlint.yml) validates GitHub Actions syntax and expressions.
@@ -79,8 +79,8 @@ The names to tick under branch protection, exactly as GitHub reports them:
 | `coverage / gcovr` | 100% of lines and branches |
 | `gcc / all` | GCC 15, 16, 17-SVN |
 | `mingw / all` | MinGW 15 and 16 |
-| `msvc / all` | cl on VS 2022, 2026, 2026-Preview |
-| `msvc_analyze / all` | `/analyze` on all three rungs |
+| `msvc / all` | cl on VS 2026 and 2026-Preview |
+| `msvc_analyze / all` | `/analyze` on the same two rungs |
 | `sanitizers / all` | all fifteen sanitizer legs |
 
 Codecov posts two more, `codecov/project` and `codecov/patch`, which carry the same 100% bar for the whole tree and for the diff.

--- a/benchmark/src/bitset/ops.cpp
+++ b/benchmark/src/bitset/ops.cpp
@@ -10,7 +10,7 @@
 // [design.md#two-block-case]
 
 #include <benchmark/benchmark.h>        // ClobberMemory, DoNotOptimize, BENCHMARK_TEMPLATE1, BENCHMARK_MAIN, State
-#include <xstd/bits/bit_set_view.hpp>    // bit_set_view
+#include <xstd/bits/bit_set_view.hpp>   // bit_set_view
 #include <xstd/bits/bitset.hpp>         // aligned::bitset, bitset
 #include <xstd/bits/ext/std/bitset.hpp> // bit_traits over std::bitset
 #include <bitset>                       // bitset

--- a/benchmark/src/sequence/access.cpp
+++ b/benchmark/src/sequence/access.cpp
@@ -13,12 +13,12 @@
 // position, where a lookup costs a cache miss and nothing else. So this one runs 8 KiB to 32 MiB, through L1, L2,
 // L3 and into DRAM, and reports latency per random read rather than bytes per second.
 
-#include <benchmark/benchmark.h>        // ClobberMemory, DoNotOptimize, BENCHMARK_TEMPLATE1, BENCHMARK_MAIN, State
-#include <xstd/bits/bit_vector.hpp>     // bit_vector
-#include <algorithm>                    // count
-#include <cstddef>                      // size_t
-#include <cstdint>                      // int64_t, uint64_t
-#include <vector>                       // vector
+#include <benchmark/benchmark.h>    // ClobberMemory, DoNotOptimize, BENCHMARK_TEMPLATE1, BENCHMARK_MAIN, State
+#include <xstd/bits/bit_vector.hpp> // bit_vector
+#include <algorithm>                // count
+#include <cstddef>                  // size_t
+#include <cstdint>                  // int64_t, uint64_t
+#include <vector>                   // vector
 
 namespace {
 

--- a/benchmark/src/views/overhead.cpp
+++ b/benchmark/src/views/overhead.cpp
@@ -18,15 +18,15 @@
 // half a cycle, which is not a faster reading but no reading at all -- while a view's pointer blocks the same
 // folding. Comparing those two measures the folding, not the indirection. [design.md#a-bitset-reads-as-its-storage]
 
-#include <benchmark/benchmark.h>          // ClobberMemory, DoNotOptimize, BENCHMARK_TEMPLATE, BENCHMARK_MAIN, State
-#include <xstd/bits/bit_array.hpp>        // bit_array
-#include <xstd/bits/bit_set_view.hpp>     // bit_set_view
-#include <xstd/bits/bit_span.hpp>         // bit_span
-#include <xstd/bits/bit_static_set.hpp>   // bit_static_set
-#include <xstd/bits/bitset.hpp>           // bitset
-#include <xstd/bits/block_sequence.hpp>   // block_array
-#include <cstddef>                        // size_t
-#include <cstdint>                        // uint64_t
+#include <benchmark/benchmark.h>        // ClobberMemory, DoNotOptimize, BENCHMARK_TEMPLATE, BENCHMARK_MAIN, State
+#include <xstd/bits/bit_array.hpp>      // bit_array
+#include <xstd/bits/bit_set_view.hpp>   // bit_set_view
+#include <xstd/bits/bit_span.hpp>       // bit_span
+#include <xstd/bits/bit_static_set.hpp> // bit_static_set
+#include <xstd/bits/bitset.hpp>         // bitset
+#include <xstd/bits/block_sequence.hpp> // block_array
+#include <cstddef>                      // size_t
+#include <cstdint>                      // uint64_t
 
 namespace {
 

--- a/design.md
+++ b/design.md
@@ -3,8 +3,9 @@
 Why the code is shaped the way it is. The headers carry one line each; the reasoning lives here, and a
 one-line comment ending in `[design.md#anchor]` points at the section that explains it.
 
-Decisions still in flight are recorded on [#80](https://github.com/rhalbersma/xstd-bits/issues/80); this
-file holds what has landed.
+Decisions still in flight live on the [open issues](https://github.com/rhalbersma/xstd-bits/issues), and
+[#80](https://github.com/rhalbersma/xstd-bits/issues/80) is the closed design plan the current shape came
+out of. This file holds what has landed.
 
 ## Storage and containers
 
@@ -751,6 +752,17 @@ diagnostic was the better evidence, and it deserved to be believed over a vendor
 **The break is the MSVC compiler, not the VS 2022 platform.** `clang_cl` keeps all three rungs and passes on
 all of them, 2022 included, because clang-cl is Clang and Clang has had P1814 since 19. So VS 2022's runner,
 STL and platform stay covered; only the MSVC 17 front end is gone from the matrix.
+
+**The rung has paid two dividends so far, and the ledger belongs here with the cost.** Both were workarounds
+that existed for MSVC 17 and nothing else. The first: `decay_copy` became `auto(x)`
+([the-functor-takes-a-value](#the-functor-takes-a-value)), twenty lines for two. The second: the one
+`typename` still written in `test/include/test/set/primitives.hpp`, on the default argument of a constrained
+type-parameter -- `std::integral T = typename X::key_type`, which MSVC 17 rejected without it as `C2061:
+syntax error: identifier 'integral'` while GCC, clang, clang-cl and Apple clang all took it. It was the last
+site in the tree where [P0634R3](https://wg21.link/P0634R3) permits the omission and the keyword was still
+spelled; the remaining `typename X::value_type` sites are template arguments and functional casts, which
+P0634R3 does not reach. The `NOLINTNEXTLINE(readability-redundant-typename)` that had to sit above it went
+with it -- a live suppression, not a dead one: the check exists in clang-tidy 22 and 24.
 
 Being the adaptor rather than deriving from it is what removes the restatements, and they were the whole cost
 of the workaround: a derived class needed its own constructors, its own two deduction guides, and its own

--- a/design.md
+++ b/design.md
@@ -512,8 +512,18 @@ wrapper's member surface, not the cross-cutting protocols -- equality, ordering,
 `std::string` hashing while `std::array`, `std::set` and `std::pair` do not, is history rather than design.
 
 The engine is Boost.Hash2: each adaptor carries a `tag_invoke` hook for `hash_append`, and `std::hash` is
-one detail helper over it, `fnv1a_64` folded by `get_integral_result`, so the algorithm is chosen in exactly
-one place and a caller wanting another brings it through `hash_append`. What a hook appends is the value
+one detail helper over it, a hash folded by `get_integral_result`. The algorithm is chosen in exactly one
+place, and it is chosen as a **default rather than a fact**: `std_hash` takes `Hash h = {}` over a defaulted
+`fnv1a_64`, so overriding it is an argument from outside rather than an edit here. Defaulted on the template
+parameter as well as the function parameter, because a default function argument is not a deduced context and
+`std_hash(v)` would otherwise fail to deduce `Hash`; and taken by value rather than by type alone, so a
+seeded instance substitutes and not only a default-constructed one.
+
+What `std::hash` itself gets is always that default. Its `operator()` takes one argument and has no second to
+forward, so all three specializations take `fnv1a_64` and the parameter is unreachable through them — which
+is why it is asserted directly, in `test/src/bits/detail/hash.cpp`, rather than through a specialization. A
+caller wanting another algorithm has the better door anyway: the adaptors' `hash_append` hooks, reached with
+a hash of their own. What a hook appends is the value
 **through the trait**, never a storage's own hook: the blocks and the width where the trait reads by block,
 every position and the width otherwise. So equal values hash equal whatever holds them, and a set view over
 a `std::bitset` hashes on every library whether or not `_Getword` is reachable. The set reading at a run-time

--- a/design.md
+++ b/design.md
@@ -757,7 +757,7 @@ STL and platform stay covered; only the MSVC 17 front end is gone from the matri
 that existed for MSVC 17 and nothing else. The first: `decay_copy` became `auto(x)`
 ([the-functor-takes-a-value](#the-functor-takes-a-value)), twenty lines for two. The second: the one
 `typename` still written in `test/include/test/set/primitives.hpp`, on the default argument of a constrained
-type-parameter -- `std::integral T = typename X::key_type`, which MSVC 17 rejected without it as `C2061:
+type-parameter -- `std::integral I = typename X::key_type`, which MSVC 17 rejected without it as `C2061:
 syntax error: identifier 'integral'` while GCC, clang, clang-cl and Apple clang all took it. It was the last
 site in the tree where [P0634R3](https://wg21.link/P0634R3) permits the omission and the keyword was still
 spelled; the remaining `typename X::value_type` sites are template arguments and functional casts, which

--- a/design.md
+++ b/design.md
@@ -757,7 +757,7 @@ STL and platform stay covered; only the MSVC 17 front end is gone from the matri
 that existed for MSVC 17 and nothing else. The first: `decay_copy` became `auto(x)`
 ([the-functor-takes-a-value](#the-functor-takes-a-value)), twenty lines for two. The second: the one
 `typename` still written in `test/include/test/set/primitives.hpp`, on the default argument of a constrained
-type-parameter -- `std::integral I = typename X::key_type`, which MSVC 17 rejected without it as `C2061:
+type-parameter -- `std::integral T = typename X::key_type`, which MSVC 17 rejected without it as `C2061:
 syntax error: identifier 'integral'` while GCC, clang, clang-cl and Apple clang all took it. It was the last
 site in the tree where [P0634R3](https://wg21.link/P0634R3) permits the omission and the keyword was still
 spelled; the remaining `typename X::value_type` sites are template arguments and functional casts, which

--- a/include/xstd/bits/bit_inplace_set.hpp
+++ b/include/xstd/bits/bit_inplace_set.hpp
@@ -6,15 +6,15 @@
 #ifndef XSTD_BITS_BIT_INPLACE_SET_HPP
 #define XSTD_BITS_BIT_INPLACE_SET_HPP
 
-#include <version>                                         // IWYU pragma: keep; __cpp_lib_inplace_vector
+#include <version>                                 // IWYU pragma: keep; __cpp_lib_inplace_vector
 
 // The column comes and goes with its storage, and an alias withholds a name rather than a capability. [design.md#the-inplace-column]
 #ifdef __cpp_lib_inplace_vector
-#include <xstd/bits/set_adaptor.hpp>                       // set_adaptor
-#include <xstd/bits/block_sequence.hpp>                    // block_inplace_vector
-#include <xstd/bits/ownership.hpp>                         // ownership
-#include <xstd/ints/concepts/unsigned_integer.hpp>         // unsigned_integer
-#include <cstddef>                                         // size_t
+#include <xstd/bits/set_adaptor.hpp>               // set_adaptor
+#include <xstd/bits/block_sequence.hpp>            // block_inplace_vector
+#include <xstd/bits/ownership.hpp>                 // ownership
+#include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer
+#include <cstddef>                                 // size_t
 
 namespace xstd {
 

--- a/include/xstd/bits/bit_inplace_vector.hpp
+++ b/include/xstd/bits/bit_inplace_vector.hpp
@@ -6,15 +6,15 @@
 #ifndef XSTD_BITS_BIT_INPLACE_VECTOR_HPP
 #define XSTD_BITS_BIT_INPLACE_VECTOR_HPP
 
-#include <version>                                         // IWYU pragma: keep; __cpp_lib_inplace_vector
+#include <version>                                 // IWYU pragma: keep; __cpp_lib_inplace_vector
 
 // The column comes and goes with its storage, and an alias withholds a name rather than a capability. [design.md#the-inplace-column]
 #ifdef __cpp_lib_inplace_vector
-#include <xstd/bits/sequence_adaptor.hpp>                  // sequence_adaptor
-#include <xstd/bits/block_sequence.hpp>                    // block_inplace_vector
-#include <xstd/bits/ownership.hpp>                         // ownership
-#include <xstd/ints/concepts/unsigned_integer.hpp>         // unsigned_integer
-#include <cstddef>                                         // size_t
+#include <xstd/bits/sequence_adaptor.hpp>          // sequence_adaptor
+#include <xstd/bits/block_sequence.hpp>            // block_inplace_vector
+#include <xstd/bits/ownership.hpp>                 // ownership
+#include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer
+#include <cstddef>                                 // size_t
 
 namespace xstd {
 

--- a/include/xstd/bits/block_sequence.hpp
+++ b/include/xstd/bits/block_sequence.hpp
@@ -6,35 +6,35 @@
 #ifndef XSTD_BITS_BLOCK_SEQUENCE_HPP
 #define XSTD_BITS_BLOCK_SEQUENCE_HPP
 
-#include <boost/hash2/hash_append_fwd.hpp>                     // hash_append, hash_append_tag
-#include <xstd/bits/bit_traits.hpp>                            // bit_traits
-#include <xstd/bits/detail/allocator_typedef.hpp>              // allocator_typedef
-#include <xstd/bits/detail/intrin.hpp>                         // countl_zero, countr_zero, popcount
-#include <xstd/bits/detail/pred.hpp>                           // intersects, is_subset_of, not_equal_to
-#include <xstd/ints/concepts/unsigned_integer.hpp>             // unsigned_integer
-#include <xstd/ints/cstdlib/div.hpp>                           // div, div_result
-#include <xstd/ints/limits.hpp>                                // numeric_limits
-#include <xstd/ints/memory.hpp>                                // align_up
-#include <xstd/misc/type_traits/conditional_data_member.hpp>   // XSTD_NO_UNIQUE_ADDRESS, conditional_data_member_t
-#include <algorithm>                                           // all_of, any_of, fill, fill_n, fold_left, max, min, shift_left, shift_right
-#include <array>                                               // array
-#include <cassert>                                             // assert
-#include <compare>                                             // strong_ordering
-#include <concepts>                                            // regular, same_as, swap
-#include <cstddef>                                             // ptrdiff_t, size_t
-#include <functional>                                          // plus
-#include <iterator>                                            // distance, forward_iterator, input_iterator, prev
-#include <limits>                                              // numeric_limits
-#include <memory>                                              // allocator
-#include <ranges>                                              // begin, drop, iota, size, swap, transform, zip
-                                                               // (views::drop_last when P22014R2 is accepted)
-#include <span>                                                // dynamic_extent
-#include <type_traits>                                         // conditional_t, is_const_v, remove_reference_t
-#include <utility>                                             // exchange, move, pair
-#include <vector>                                              // vector
-#include <version>                                             // IWYU pragma: keep; __cpp_lib_inplace_vector
+#include <boost/hash2/hash_append_fwd.hpp>                   // hash_append, hash_append_tag
+#include <xstd/bits/bit_traits.hpp>                          // bit_traits
+#include <xstd/bits/detail/allocator_typedef.hpp>            // allocator_typedef
+#include <xstd/bits/detail/intrin.hpp>                       // countl_zero, countr_zero, popcount
+#include <xstd/bits/detail/pred.hpp>                         // intersects, is_subset_of, not_equal_to
+#include <xstd/ints/concepts/unsigned_integer.hpp>           // unsigned_integer
+#include <xstd/ints/cstdlib/div.hpp>                         // div, div_result
+#include <xstd/ints/limits.hpp>                              // numeric_limits
+#include <xstd/ints/memory.hpp>                              // align_up
+#include <xstd/misc/type_traits/conditional_data_member.hpp> // XSTD_NO_UNIQUE_ADDRESS, conditional_data_member_t
+#include <algorithm>                                         // all_of, any_of, fill, fill_n, fold_left, max, min, shift_left, shift_right
+#include <array>                                             // array
+#include <cassert>                                           // assert
+#include <compare>                                           // strong_ordering
+#include <concepts>                                          // regular, same_as, swap
+#include <cstddef>                                           // ptrdiff_t, size_t
+#include <functional>                                        // plus
+#include <iterator>                                          // distance, forward_iterator, input_iterator, prev
+#include <limits>                                            // numeric_limits
+#include <memory>                                            // allocator
+#include <ranges>                                            // begin, drop, iota, size, swap, transform, zip
+                                                             // (views::drop_last when P22014R2 is accepted)
+#include <span>                                              // dynamic_extent
+#include <type_traits>                                       // conditional_t, is_const_v, remove_reference_t
+#include <utility>                                           // exchange, move, pair
+#include <vector>                                            // vector
+#include <version>                                           // IWYU pragma: keep; __cpp_lib_inplace_vector
 #ifdef __cpp_lib_inplace_vector
-#include <inplace_vector>                                      // inplace_vector
+#include <inplace_vector>                                    // inplace_vector
 #endif
 
 namespace xstd {

--- a/include/xstd/bits/detail/hash.hpp
+++ b/include/xstd/bits/detail/hash.hpp
@@ -6,14 +6,14 @@
 #ifndef XSTD_BITS_DETAIL_HASH_HPP
 #define XSTD_BITS_DETAIL_HASH_HPP
 
-#include <boost/hash2/fnv1a.hpp>              // fnv1a_64
+#include <boost/hash2/fnv1a.hpp>               // fnv1a_64
 #include <boost/hash2/get_integral_result.hpp> // get_integral_result
-#include <boost/hash2/hash_append.hpp>        // hash_append
-#include <xstd/bits/bit_traits.hpp>           // block_readable, count, find_first, find_next
-#include <cstddef>                            // size_t
-#include <cstdint>                            // uint64_t
-#include <limits>                             // numeric_limits
-#include <ranges>                             // iota
+#include <boost/hash2/hash_append.hpp>         // hash_append
+#include <xstd/bits/bit_traits.hpp>            // block_readable, count, find_first, find_next
+#include <cstddef>                             // size_t
+#include <cstdint>                             // uint64_t
+#include <limits>                              // numeric_limits
+#include <ranges>                              // iota
 
 namespace xstd::detail::bits {
 
@@ -59,12 +59,17 @@ constexpr auto hash_append_positions(Hash& h, Flavor const& f, Bits const& c)
         boost::hash2::hash_append(h, f, count<Traits>(c));
 }
 
-// The one place std::hash chooses an algorithm; a caller wanting another brings it through hash_append. [design.md#the-hashing-invariant]
-template<class T>
-[[nodiscard]] constexpr auto std_hash(T const& v) noexcept
+// The one place std::hash chooses an algorithm, and it chooses fnv1a_64 as a default rather than a fact: the
+// parameter is what lets the choice be overridden from outside instead of edited here. Defaulted on the template
+// parameter as well as the function parameter, since a default function argument is not a deduced context and
+// std_hash(v) would not deduce Hash from it. By value rather than by type alone, so a seeded instance substitutes
+// and not just a default-constructed one. std::hash's own operator() takes one argument and cannot forward a
+// second, so its three specializations always take the default; a caller wanting another algorithm reaches the
+// adaptors' hash_append hooks directly. [design.md#the-hashing-invariant]
+template<class T, class Hash = boost::hash2::fnv1a_64>
+[[nodiscard]] constexpr auto std_hash(T const& v, Hash h = {}) noexcept
         -> std::size_t
 {
-        boost::hash2::fnv1a_64 h;
         boost::hash2::hash_append(h, {}, v);
         return boost::hash2::get_integral_result<std::size_t>(h);
 }

--- a/include/xstd/bits/format.hpp
+++ b/include/xstd/bits/format.hpp
@@ -6,9 +6,9 @@
 #ifndef XSTD_BITS_FORMAT_HPP
 #define XSTD_BITS_FORMAT_HPP
 
-#include <xstd/bits/bit_proxy.hpp>  // bit_sequence_reference, bit_set_reference
-#include <cstddef>                  // size_t
-#include <format>                   // formatter
+#include <xstd/bits/bit_proxy.hpp> // bit_sequence_reference, bit_set_reference
+#include <cstddef>                 // size_t
+#include <format>                  // formatter
 
 // std::format over the containers, which needs nothing said about the containers themselves. [design.md#formatting-the-proxies]
 //

--- a/include/xstd/bits/inplace_bitset.hpp
+++ b/include/xstd/bits/inplace_bitset.hpp
@@ -6,14 +6,14 @@
 #ifndef XSTD_BITS_INPLACE_BITSET_HPP
 #define XSTD_BITS_INPLACE_BITSET_HPP
 
-#include <version>                                         // IWYU pragma: keep; __cpp_lib_inplace_vector
+#include <version>                                 // IWYU pragma: keep; __cpp_lib_inplace_vector
 
 // The column comes and goes with its storage, and an alias withholds a name rather than a capability. [design.md#the-inplace-column]
 #ifdef __cpp_lib_inplace_vector
-#include <xstd/bits/bitset_adaptor.hpp>                    // bitset_adaptor
-#include <xstd/bits/block_sequence.hpp>                    // block_inplace_vector
-#include <xstd/ints/concepts/unsigned_integer.hpp>         // unsigned_integer
-#include <cstddef>                                         // size_t
+#include <xstd/bits/bitset_adaptor.hpp>            // bitset_adaptor
+#include <xstd/bits/block_sequence.hpp>            // block_inplace_vector
+#include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer
+#include <cstddef>                                 // size_t
 
 namespace xstd {
 

--- a/test/include/test/bitset/primitives.hpp
+++ b/test/include/test/bitset/primitives.hpp
@@ -6,18 +6,18 @@
 #ifndef TEST_BITSET_PRIMITIVES_HPP
 #define TEST_BITSET_PRIMITIVES_HPP
 
-#include <boost/test/unit_test.hpp>      // BOOST_CHECK, BOOST_CHECK_EQUAL, BOOST_CHECK_NE, BOOST_CHECK_THROW
-#include <test/dynamic.hpp>              // dynamic
-#include <xstd/bits/ownership.hpp>       // owned_storage
+#include <boost/test/unit_test.hpp>   // BOOST_CHECK, BOOST_CHECK_EQUAL, BOOST_CHECK_NE, BOOST_CHECK_THROW
+#include <test/dynamic.hpp>           // dynamic
+#include <xstd/bits/ownership.hpp>    // owned_storage
 #include <xstd/bits/bit_set_view.hpp> // view
-#include <cstddef>                       // size_t
-#include <functional>                    // hash
-#include <memory>                        // addressof
-#include <set>                           // set
-#include <sstream>                       // istringstream, stringstream
-#include <stdexcept>                     // invalid_argument, out_of_range
-#include <string>                        // string
-#include <string_view>                   // string_view
+#include <cstddef>                    // size_t
+#include <functional>                 // hash
+#include <memory>                     // addressof
+#include <set>                        // set
+#include <sstream>                    // istringstream, stringstream
+#include <stdexcept>                  // invalid_argument, out_of_range
+#include <string>                     // string
+#include <string_view>                // string_view
 
 namespace test::bitset {
 

--- a/test/include/test/flat_set.hpp
+++ b/test/include/test/flat_set.hpp
@@ -6,7 +6,7 @@
 #ifndef TEST_FLAT_SET_HPP
 #define TEST_FLAT_SET_HPP
 
-#include <version> // __cpp_lib_flat_set
+#include <version>  // __cpp_lib_flat_set
 #ifdef __cpp_lib_flat_set
 #define TEST_HAS_FLAT_SET
 #include <flat_set> // IWYU pragma: export; flat_set

--- a/test/include/test/sequence/ordering.hpp
+++ b/test/include/test/sequence/ordering.hpp
@@ -6,13 +6,13 @@
 #ifndef TEST_SEQUENCE_ORDERING_HPP
 #define TEST_SEQUENCE_ORDERING_HPP
 
-#include <boost/test/unit_test.hpp>           // BOOST_CHECK_EQUAL
-#include <test/bitset/factory.hpp>            // make_bitset
-#include <xstd/bits/bit_span.hpp> // bit_span
-#include <algorithm>                          // equal, lexicographical_compare, lexicographical_compare_three_way
-#include <compare>                            // is_gt, is_lt, strong_ordering
-#include <cstddef>                            // size_t
-#include <vector>                             // vector
+#include <boost/test/unit_test.hpp> // BOOST_CHECK_EQUAL
+#include <test/bitset/factory.hpp>  // make_bitset
+#include <xstd/bits/bit_span.hpp>   // bit_span
+#include <algorithm>                // equal, lexicographical_compare, lexicographical_compare_three_way
+#include <compare>                  // is_gt, is_lt, strong_ordering
+#include <cstddef>                  // size_t
+#include <vector>                   // vector
 
 namespace test::sequence {
 

--- a/test/include/test/set/composable.hpp
+++ b/test/include/test/set/composable.hpp
@@ -10,7 +10,7 @@
 #include <range/v3/view/set_algorithm.hpp> // set_difference, set_intersection, set_symmetric_difference, set_union
 #include <algorithm>                       // includes
 #include <ranges>                          // to
-                                                // filter, transform
+                                           // filter, transform
 
 namespace test::set::composable {
 

--- a/test/include/test/set/exhaustive.hpp
+++ b/test/include/test/set/exhaustive.hpp
@@ -8,12 +8,12 @@
 
 #include <xstd/bits/bit_traits.hpp> // static_bit_extent
 #include <xstd/bits/ownership.hpp>  // owned_storage
-#include <algorithm>        // max
-#include <array>            // array
-#include <cassert>          // assert
-#include <cstddef>          // size_t
-#include <initializer_list> // initializer_list
-#include <ranges>           // iota, to
+#include <algorithm>                // max
+#include <array>                    // array
+#include <cassert>                  // assert
+#include <cstddef>                  // size_t
+#include <initializer_list>         // initializer_list
+#include <ranges>                   // iota, to
 
 #ifdef _MSC_VER
         // xstd::bit_static_set<0> gives bogus "unreachable code" warnings

--- a/test/include/test/set/ordering.hpp
+++ b/test/include/test/set/ordering.hpp
@@ -6,14 +6,14 @@
 #ifndef TEST_SET_ORDERING_HPP
 #define TEST_SET_ORDERING_HPP
 
-#include <boost/test/unit_test.hpp>      // BOOST_CHECK_EQUAL
-#include <test/bitset/factory.hpp>       // make_bitset
+#include <boost/test/unit_test.hpp>   // BOOST_CHECK_EQUAL
+#include <test/bitset/factory.hpp>    // make_bitset
 #include <xstd/bits/bit_set_view.hpp> // bit_set_view
-#include <algorithm>                     // lexicographical_compare
-#include <compare>                       // is_gt, is_lt, strong_ordering
-#include <cstddef>                       // size_t
-#include <cstdint>                       // uint64_t
-#include <set>                           // set
+#include <algorithm>                  // lexicographical_compare
+#include <compare>                    // is_gt, is_lt, strong_ordering
+#include <cstddef>                    // size_t
+#include <cstdint>                    // uint64_t
+#include <set>                        // set
 
 namespace test::set {
 

--- a/test/include/test/set/primitives.hpp
+++ b/test/include/test/set/primitives.hpp
@@ -40,21 +40,21 @@ struct ref_same_as_pred<xstd::set_adaptor<Bits, Own, Traits>>
 template<class X, class R, class T>
 inline constexpr auto ref_same_as = ref_same_as_pred<X>::template value<R, T>;
 
-template<class X, std::integral I = X::key_type>
+template<class X, std::integral T = X::key_type>
 struct nested_types
 {
-        static_assert(std::same_as<typename X::value_type, I>);                         // [container.reqmts]/2
-        static_assert(requires { std::declval<X>().erase(std::declval<I>()); });        // [container.reqmts]/3
+        static_assert(std::same_as<typename X::value_type, T>);                         // [container.reqmts]/2
+        static_assert(requires { std::declval<X>().erase(std::declval<T>()); });        // [container.reqmts]/3
 
-        static_assert(ref_same_as<X, typename X::reference, I&>);                       // [container.reqmts]/4
-        static_assert(ref_same_as<X, typename X::const_reference, I const&>);           // [container.reqmts]/5
+        static_assert(ref_same_as<X, typename X::reference, T&>);                       // [container.reqmts]/4
+        static_assert(ref_same_as<X, typename X::const_reference, T const&>);           // [container.reqmts]/5
 
         static_assert(std::forward_iterator<typename X::iterator>);                     // [container.reqmts]/6
-        static_assert(std::same_as<std::iter_value_t<typename X::iterator>, I>);
+        static_assert(std::same_as<std::iter_value_t<typename X::iterator>, T>);
         static_assert(std::convertible_to<typename X::iterator, typename X::const_iterator>);
 
         static_assert(std::forward_iterator<typename X::const_iterator>);               // [container.reqmts]/7
-        static_assert(std::same_as<std::iter_value_t<typename X::const_iterator>, I>);
+        static_assert(std::same_as<std::iter_value_t<typename X::const_iterator>, T>);
 
                                                                                         // [container.reqmts]/8
         static_assert(std::same_as<typename X::difference_type, std::iter_difference_t<typename X::iterator>>);
@@ -62,13 +62,13 @@ struct nested_types
 
         static_assert(std::bidirectional_iterator<typename X::reverse_iterator>);       // [container.rev.reqmts]/2
         static_assert(std::same_as<typename X::reverse_iterator, std::reverse_iterator<typename X::iterator>>);
-        static_assert(std::same_as<std::iter_value_t<typename X::reverse_iterator>, I>);
+        static_assert(std::same_as<std::iter_value_t<typename X::reverse_iterator>, T>);
 
         static_assert(std::bidirectional_iterator<typename X::const_reverse_iterator>); // [container.rev.reqmts]/3
         static_assert(std::same_as<typename X::const_reverse_iterator, std::reverse_iterator<typename X::const_iterator>>);
-        static_assert(std::same_as<std::iter_value_t<typename X::const_reverse_iterator>, I>);
+        static_assert(std::same_as<std::iter_value_t<typename X::const_reverse_iterator>, T>);
 
-        using Key = I;
+        using Key = T;
         static_assert(std::same_as<typename X::key_type, Key>);                         // [associative.reqmts.general]/9
         static_assert(std::same_as<typename X::value_type, Key>);                       // [associative.reqmts.general]/12
         static_assert(requires { std::declval<X>().erase(std::declval<Key>()); });      // [associative.reqmts.general]/13

--- a/test/include/test/set/primitives.hpp
+++ b/test/include/test/set/primitives.hpp
@@ -40,21 +40,21 @@ struct ref_same_as_pred<xstd::set_adaptor<Bits, Own, Traits>>
 template<class X, class R, class T>
 inline constexpr auto ref_same_as = ref_same_as_pred<X>::template value<R, T>;
 
-template<class X, std::integral T = X::key_type>
+template<class X, std::integral I = X::key_type>
 struct nested_types
 {
-        static_assert(std::same_as<typename X::value_type, T>);                         // [container.reqmts]/2
-        static_assert(requires { std::declval<X>().erase(std::declval<T>()); });        // [container.reqmts]/3
+        static_assert(std::same_as<typename X::value_type, I>);                         // [container.reqmts]/2
+        static_assert(requires { std::declval<X>().erase(std::declval<I>()); });        // [container.reqmts]/3
 
-        static_assert(ref_same_as<X, typename X::reference, T&>);                       // [container.reqmts]/4
-        static_assert(ref_same_as<X, typename X::const_reference, T const&>);           // [container.reqmts]/5
+        static_assert(ref_same_as<X, typename X::reference, I&>);                       // [container.reqmts]/4
+        static_assert(ref_same_as<X, typename X::const_reference, I const&>);           // [container.reqmts]/5
 
         static_assert(std::forward_iterator<typename X::iterator>);                     // [container.reqmts]/6
-        static_assert(std::same_as<std::iter_value_t<typename X::iterator>, T>);
+        static_assert(std::same_as<std::iter_value_t<typename X::iterator>, I>);
         static_assert(std::convertible_to<typename X::iterator, typename X::const_iterator>);
 
         static_assert(std::forward_iterator<typename X::const_iterator>);               // [container.reqmts]/7
-        static_assert(std::same_as<std::iter_value_t<typename X::const_iterator>, T>);
+        static_assert(std::same_as<std::iter_value_t<typename X::const_iterator>, I>);
 
                                                                                         // [container.reqmts]/8
         static_assert(std::same_as<typename X::difference_type, std::iter_difference_t<typename X::iterator>>);
@@ -62,13 +62,13 @@ struct nested_types
 
         static_assert(std::bidirectional_iterator<typename X::reverse_iterator>);       // [container.rev.reqmts]/2
         static_assert(std::same_as<typename X::reverse_iterator, std::reverse_iterator<typename X::iterator>>);
-        static_assert(std::same_as<std::iter_value_t<typename X::reverse_iterator>, T>);
+        static_assert(std::same_as<std::iter_value_t<typename X::reverse_iterator>, I>);
 
         static_assert(std::bidirectional_iterator<typename X::const_reverse_iterator>); // [container.rev.reqmts]/3
         static_assert(std::same_as<typename X::const_reverse_iterator, std::reverse_iterator<typename X::const_iterator>>);
-        static_assert(std::same_as<std::iter_value_t<typename X::const_reverse_iterator>, T>);
+        static_assert(std::same_as<std::iter_value_t<typename X::const_reverse_iterator>, I>);
 
-        using Key = T;
+        using Key = I;
         static_assert(std::same_as<typename X::key_type, Key>);                         // [associative.reqmts.general]/9
         static_assert(std::same_as<typename X::value_type, Key>);                       // [associative.reqmts.general]/12
         static_assert(requires { std::declval<X>().erase(std::declval<Key>()); });      // [associative.reqmts.general]/13

--- a/test/include/test/set/primitives.hpp
+++ b/test/include/test/set/primitives.hpp
@@ -40,12 +40,7 @@ struct ref_same_as_pred<xstd::set_adaptor<Bits, Own, Traits>>
 template<class X, class R, class T>
 inline constexpr auto ref_same_as = ref_same_as_pred<X>::template value<R, T>;
 
-// typename stays here, and only here, of the eight sites P0634R3 made it redundant. MSVC 2022 rejects the
-// default argument of a constrained type-parameter without it -- "error C2061: syntax error: identifier
-// 'integral'" -- while GCC, clang, clang-cl and Apple clang all take it. The seven in sequence/concepts.hpp are
-// requires(...) parameter lists, which MSVC does accept.
-// NOLINTNEXTLINE(readability-redundant-typename)
-template<class X, std::integral T = typename X::key_type>
+template<class X, std::integral T = X::key_type>
 struct nested_types
 {
         static_assert(std::same_as<typename X::value_type, T>);                         // [container.reqmts]/2

--- a/test/include/test/set/primitives.hpp
+++ b/test/include/test/set/primitives.hpp
@@ -6,19 +6,19 @@
 #ifndef TEST_SET_PRIMITIVES_HPP
 #define TEST_SET_PRIMITIVES_HPP
 
-#include <boost/test/unit_test.hpp>     // BOOST_CHECK, BOOST_CHECK_EQUAL
+#include <boost/test/unit_test.hpp>  // BOOST_CHECK, BOOST_CHECK_EQUAL
 #include <xstd/bits/set_adaptor.hpp> // set_adaptor
-#include <xstd/bits/ownership.hpp>     // ownership
-#include <algorithm>                    // equal_range, lexicographical_compare_three_way
-#include <compare>                      // is_gteq, is_gt, is_lteq, is_lt, strong_ordering
-#include <concepts>                     // convertible_to, default_initializable, equality_comparable, integral, same_as, unsigned_integral
-#include <cstddef>                      // ptrdiff_t
-#include <functional>                   // hash
-#include <initializer_list>             // initializer_list
-#include <iterator>                     // distance, empty, iter_difference_t, iter_value_t, next, prev, reverse_iterator, size, ssize
-#include <ranges>                       // count, equal, find, lexicographical_compare, lower_bound, , subrange, upper_bound
-#include <type_traits>                  // add_const_t, common_type_t, make_signed_t, remove_reference_t
-#include <utility>                      // declval, pair
+#include <xstd/bits/ownership.hpp>   // ownership
+#include <algorithm>                 // equal_range, lexicographical_compare_three_way
+#include <compare>                   // is_gteq, is_gt, is_lteq, is_lt, strong_ordering
+#include <concepts>                  // convertible_to, default_initializable, equality_comparable, integral, same_as, unsigned_integral
+#include <cstddef>                   // ptrdiff_t
+#include <functional>                // hash
+#include <initializer_list>          // initializer_list
+#include <iterator>                  // distance, empty, iter_difference_t, iter_value_t, next, prev, reverse_iterator, size, ssize
+#include <ranges>                    // count, equal, find, lexicographical_compare, lower_bound, , subrange, upper_bound
+#include <type_traits>               // add_const_t, common_type_t, make_signed_t, remove_reference_t
+#include <utility>                   // declval, pair
 
 namespace test::set {
 

--- a/test/src/bits/bit_inplace_set.cpp
+++ b/test/src/bits/bit_inplace_set.cpp
@@ -3,21 +3,21 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/test/unit_test.hpp>              // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL, BOOST_CHECK_THROW
-#include <test/inplace_vector.hpp>               // IWYU pragma: keep; TEST_HAS_INPLACE_VECTOR, has_inplace_vector
+#include <boost/test/unit_test.hpp>      // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL, BOOST_CHECK_THROW
+#include <test/inplace_vector.hpp>       // IWYU pragma: keep; TEST_HAS_INPLACE_VECTOR, has_inplace_vector
 #ifdef TEST_HAS_INPLACE_VECTOR
-#include <test/set/concepts.hpp>                 // bit_set
-#include <xstd/bits/set_adaptor.hpp>             // set_adaptor
-#include <xstd/bits/bit_inplace_set.hpp>         // basic_bit_inplace_set, bit_inplace_set
-#include <xstd/bits/block_sequence.hpp>          // block_inplace_vector
-#include <xstd/bits/ownership.hpp>               // ownership
-#include <algorithm>                             // equal
-#include <concepts>                              // same_as
-#include <cstddef>                               // size_t
-#include <cstdint>                               // uint8_t
-#include <new>                                   // bad_alloc
-#include <ranges>                                // iota, to
-#include <set>                                   // set
+#include <test/set/concepts.hpp>         // bit_set
+#include <xstd/bits/set_adaptor.hpp>     // set_adaptor
+#include <xstd/bits/bit_inplace_set.hpp> // basic_bit_inplace_set, bit_inplace_set
+#include <xstd/bits/block_sequence.hpp>  // block_inplace_vector
+#include <xstd/bits/ownership.hpp>       // ownership
+#include <algorithm>                     // equal
+#include <concepts>                      // same_as
+#include <cstddef>                       // size_t
+#include <cstdint>                       // uint8_t
+#include <new>                           // bad_alloc
+#include <ranges>                        // iota, to
+#include <set>                           // set
 #endif
 
 BOOST_AUTO_TEST_SUITE(BitInplaceSet)

--- a/test/src/bits/bit_inplace_vector.cpp
+++ b/test/src/bits/bit_inplace_vector.cpp
@@ -3,21 +3,21 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/test/unit_test.hpp>              // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL, BOOST_CHECK_THROW
-#include <test/inplace_vector.hpp>               // IWYU pragma: keep; TEST_HAS_INPLACE_VECTOR, has_inplace_vector
+#include <boost/test/unit_test.hpp>         // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL, BOOST_CHECK_THROW
+#include <test/inplace_vector.hpp>          // IWYU pragma: keep; TEST_HAS_INPLACE_VECTOR, has_inplace_vector
 #ifdef TEST_HAS_INPLACE_VECTOR
-#include <test/sequence/concepts.hpp>            // bit_sequence, inplace_vector_bool, inplace_vector_bool_ranges
-#include <xstd/bits/sequence_adaptor.hpp>        // sequence_adaptor
-#include <xstd/bits/bit_inplace_vector.hpp>      // basic_bit_inplace_vector, bit_inplace_vector
-#include <xstd/bits/block_sequence.hpp>          // block_inplace_vector
-#include <xstd/bits/ownership.hpp>               // ownership
-#include <algorithm>                             // equal
-#include <concepts>                              // same_as
-#include <cstddef>                               // size_t
-#include <cstdint>                               // uint8_t
-#include <new>                                   // bad_alloc
-#include <ranges>                                // count, iota, to, transform
-#include <vector>                                // vector
+#include <test/sequence/concepts.hpp>       // bit_sequence, inplace_vector_bool, inplace_vector_bool_ranges
+#include <xstd/bits/sequence_adaptor.hpp>   // sequence_adaptor
+#include <xstd/bits/bit_inplace_vector.hpp> // basic_bit_inplace_vector, bit_inplace_vector
+#include <xstd/bits/block_sequence.hpp>     // block_inplace_vector
+#include <xstd/bits/ownership.hpp>          // ownership
+#include <algorithm>                        // equal
+#include <concepts>                         // same_as
+#include <cstddef>                          // size_t
+#include <cstdint>                          // uint8_t
+#include <new>                              // bad_alloc
+#include <ranges>                           // count, iota, to, transform
+#include <vector>                           // vector
 #endif
 
 BOOST_AUTO_TEST_SUITE(BitInplaceVector)

--- a/test/src/bits/bit_proxy.cpp
+++ b/test/src/bits/bit_proxy.cpp
@@ -8,8 +8,8 @@
 #include <test/minimal_traits.hpp>                // minimal_traits
 #include <test/value_reference.hpp>               // value_reference
 #include <xstd/bits/bit_proxy.hpp>                // bit_sequence_iterator, bit_sequence_reference, bit_set_iterator, bit_set_reference
-#include <xstd/bits/bit_set_view.hpp>            // bit_set_view
-#include <xstd/bits/bit_span.hpp>                // bit_span
+#include <xstd/bits/bit_set_view.hpp>             // bit_set_view
+#include <xstd/bits/bit_span.hpp>                 // bit_span
 #include <xstd/bits/bit_traits.hpp>               // bit_traits, find_next, find_prev
 #include <xstd/bits/block_sequence.hpp>           // block_array
 #include <xstd/bits/ext/boost/dynamic_bitset.hpp> // bit_traits over boost::dynamic_bitset

--- a/test/src/bits/bit_span.cpp
+++ b/test/src/bits/bit_span.cpp
@@ -5,7 +5,7 @@
 
 #include <boost/test/unit_test.hpp>               // BOOST_CHECK, BOOST_CHECK_EQUAL, BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
 #include <test/sequence/ordering.hpp>             // ordering_agrees_with_vector_bool
-#include <xstd/bits/sequence_adaptor.hpp>       // sequence_adaptor
+#include <xstd/bits/sequence_adaptor.hpp>         // sequence_adaptor
 #include <xstd/bits/bit_array.hpp>                // bit_array
 #include <xstd/bits/bit_static_set.hpp>           // bit_static_set
 #include <xstd/bits/bitset.hpp>                   // bitset
@@ -13,7 +13,7 @@
 #include <xstd/bits/ext/boost/dynamic_bitset.hpp> // bit_traits over boost::dynamic_bitset
 #include <xstd/bits/ext/std/bitset.hpp>           // bit_traits over std::bitset
 #include <xstd/bits/ownership.hpp>                // ownership
-#include <xstd/bits/bit_span.hpp>     // bit_span
+#include <xstd/bits/bit_span.hpp>                 // bit_span
 #include <algorithm>                              // equal
 #include <array>                                  // array
 #include <bitset>                                 // bitset

--- a/test/src/bits/bit_subspan.cpp
+++ b/test/src/bits/bit_subspan.cpp
@@ -5,7 +5,7 @@
 
 #include <boost/dynamic_bitset.hpp>               // dynamic_bitset
 #include <boost/test/unit_test.hpp>               // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL, BOOST_CHECK_THROW
-#include <xstd/bits/sequence_adaptor.hpp>       // sequence_adaptor
+#include <xstd/bits/sequence_adaptor.hpp>         // sequence_adaptor
 #include <xstd/bits/bit_array.hpp>                // bit_array
 #include <xstd/bits/bit_span.hpp>                 // bit_span
 #include <xstd/bits/bit_subspan.hpp>              // bit_subspan

--- a/test/src/bits/bit_traits.cpp
+++ b/test/src/bits/bit_traits.cpp
@@ -3,13 +3,13 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/test/unit_test.hpp>      // BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL
-#include <test/block_types.hpp>          // graded_extents
-#include <xstd/bits/bit_traits.hpp>      // all, any, bit_storage, bit_traits, block_readable, count, none, scan_*, static_bit_extent, word_at
-#include <xstd/bits/block_sequence.hpp>  // block_array
-#include <cstddef>                       // size_t
-#include <cstdint>                       // uint8_t
-#include <set>                           // set
+#include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL
+#include <test/block_types.hpp>         // graded_extents
+#include <xstd/bits/bit_traits.hpp>     // all, any, bit_storage, bit_traits, block_readable, count, none, scan_*, static_bit_extent, word_at
+#include <xstd/bits/block_sequence.hpp> // block_array
+#include <cstddef>                      // size_t
+#include <cstdint>                      // uint8_t
+#include <set>                          // set
 
 // Two adapters over identical storage, differing only in whether they hand their blocks over. [design.md#detection-by-absence]
 namespace {

--- a/test/src/bits/bit_vector.cpp
+++ b/test/src/bits/bit_vector.cpp
@@ -3,26 +3,26 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/test/unit_test.hpp>          // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL
-#include <test/sequence/concepts.hpp>        // bit_sequence
-#include <xstd/bits/sequence_adaptor.hpp>  // sequence_adaptor
-#include <xstd/bits/bit_vector.hpp>          // bit_vector
-#include <xstd/bits/block_sequence.hpp>      // block_vector
-#include <xstd/bits/ownership.hpp>           // ownership
-#include <xstd/bits/bit_array.hpp>           // basic_bit_array
-#include <xstd/bits/bit_span.hpp>            // bit_span
-#include <algorithm>                         // copy, equal
-#include <concepts>                          // same_as
-#include <cstddef>                           // size_t
-#include <cstdint>                           // uint8_t
-#include <functional>                        // hash
-#include <iterator>                          // next
-#include <memory>                            // allocator
-#include <ranges>                            // equal, from_range, iota, next, transform
-#include <type_traits>                       // is_default_constructible_v
-#include <utility>                           // move
-#include <vector>                            // vector
-#include <version>                           // IWYU pragma: keep; __cpp_lib_containers_ranges
+#include <boost/test/unit_test.hpp>       // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL
+#include <test/sequence/concepts.hpp>     // bit_sequence
+#include <xstd/bits/sequence_adaptor.hpp> // sequence_adaptor
+#include <xstd/bits/bit_vector.hpp>       // bit_vector
+#include <xstd/bits/block_sequence.hpp>   // block_vector
+#include <xstd/bits/ownership.hpp>        // ownership
+#include <xstd/bits/bit_array.hpp>        // basic_bit_array
+#include <xstd/bits/bit_span.hpp>         // bit_span
+#include <algorithm>                      // copy, equal
+#include <concepts>                       // same_as
+#include <cstddef>                        // size_t
+#include <cstdint>                        // uint8_t
+#include <functional>                     // hash
+#include <iterator>                       // next
+#include <memory>                         // allocator
+#include <ranges>                         // equal, from_range, iota, next, transform
+#include <type_traits>                    // is_default_constructible_v
+#include <utility>                        // move
+#include <vector>                         // vector
+#include <version>                        // IWYU pragma: keep; __cpp_lib_containers_ranges
 
 BOOST_AUTO_TEST_SUITE(BitVector)
 

--- a/test/src/bits/bitset.cpp
+++ b/test/src/bits/bitset.cpp
@@ -3,14 +3,14 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/test/unit_test.hpp>      // BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
-#include <test/block_types.hpp>          // graded_extents
-#include <xstd/bits/bitset_adaptor.hpp>    // swap
-#include <xstd/bits/bitset.hpp>          // bitset
-#include <xstd/bits/bit_set_view.hpp> // bit_set_view
-#include <concepts>                      // regular, totally_ordered
-#include <type_traits>                   // is_nothrow_*, is_trivially_*
-#include <utility>                       // declval
+#include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
+#include <test/block_types.hpp>         // graded_extents
+#include <xstd/bits/bitset_adaptor.hpp> // swap
+#include <xstd/bits/bitset.hpp>         // bitset
+#include <xstd/bits/bit_set_view.hpp>   // bit_set_view
+#include <concepts>                     // regular, totally_ordered
+#include <type_traits>                  // is_nothrow_*, is_trivially_*
+#include <utility>                      // declval
 
 BOOST_AUTO_TEST_SUITE(Bitset)
 

--- a/test/src/bits/block_sequence.cpp
+++ b/test/src/bits/block_sequence.cpp
@@ -3,25 +3,25 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/test/unit_test.hpp>    // BOOST_CHECK_EQUAL, BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
-#include <test/block_types.hpp>        // digits_v, graded_extents, word_types
-#include <test/inplace_vector.hpp>     // IWYU pragma: keep; TEST_HAS_INPLACE_VECTOR
-#include <test/uint128.hpp>            // IWYU pragma: keep; TEST_HAS_UINT128, uint128
-#include <xstd/bits/bit_traits.hpp>    // bit_storage, bit_traits, block_readable, static_bit_extent
+#include <boost/test/unit_test.hpp>     // BOOST_CHECK_EQUAL, BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
+#include <test/block_types.hpp>         // digits_v, graded_extents, word_types
+#include <test/inplace_vector.hpp>      // IWYU pragma: keep; TEST_HAS_INPLACE_VECTOR
+#include <test/uint128.hpp>             // IWYU pragma: keep; TEST_HAS_UINT128, uint128
+#include <xstd/bits/bit_traits.hpp>     // bit_storage, bit_traits, block_readable, static_bit_extent
 #include <xstd/bits/block_sequence.hpp> // block_array, block_inplace_vector, block_sequence, block_vector, contiguous_block_container
-#include <algorithm>                   // count, lexicographical_compare_three_way, min
-#include <concepts>                    // regular, same_as
-#include <array>                       // array
-#include <compare>                     // strong_ordering
-#include <cstddef>                     // size_t
-#include <cstdint>                     // uint8_t, uint64_t
-#include <memory>                      // addressof, allocator
-#include <initializer_list>            // initializer_list
-#include <iterator>                    // contiguous_iterator, iter_reference_t, random_access_iterator
-#include <new>                         // IWYU pragma: keep; bad_alloc, behind TEST_HAS_INPLACE_VECTOR
-#include <ranges>                      // begin, contiguous_range, iota, iterator_t, size, sized_range
-#include <tuple>                       // get, tuple
-#include <vector>                      // vector
+#include <algorithm>                    // count, lexicographical_compare_three_way, min
+#include <concepts>                     // regular, same_as
+#include <array>                        // array
+#include <compare>                      // strong_ordering
+#include <cstddef>                      // size_t
+#include <cstdint>                      // uint8_t, uint64_t
+#include <memory>                       // addressof, allocator
+#include <initializer_list>             // initializer_list
+#include <iterator>                     // contiguous_iterator, iter_reference_t, random_access_iterator
+#include <new>                          // IWYU pragma: keep; bad_alloc, behind TEST_HAS_INPLACE_VECTOR
+#include <ranges>                       // begin, contiguous_range, iota, iterator_t, size, sized_range
+#include <tuple>                        // get, tuple
+#include <vector>                       // vector
 
 BOOST_AUTO_TEST_SUITE(BitBlocks)
 

--- a/test/src/bits/detail/hash.cpp
+++ b/test/src/bits/detail/hash.cpp
@@ -8,7 +8,6 @@
 #include <boost/test/unit_test.hpp>  // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL
 #include <xstd/bits/bitset.hpp>      // bitset
 #include <xstd/bits/detail/hash.hpp> // std_hash
-#include <cstddef>                   // size_t
 #include <cstdint>                   // uint64_t
 #include <functional>                // hash
 
@@ -30,7 +29,7 @@ BOOST_AUTO_TEST_CASE(TheDefaultIsFnv1a64)
 BOOST_AUTO_TEST_CASE(ASeededInstanceSubstitutes)
 {
         auto const value = set_type(0b1010'0101);
-        constexpr auto seed = std::uint64_t(0x9E37'79B9'7F4A'7C15);
+        constexpr auto seed = std::uint64_t{0x9E37'79B9'7F4A'7C15};
 
         // By value, not by type alone: this is what a defaulted template parameter on its own could not express.
         BOOST_CHECK_EQUAL(

--- a/test/src/bits/detail/hash.cpp
+++ b/test/src/bits/detail/hash.cpp
@@ -1,0 +1,67 @@
+//          Copyright Rein Halbersma 2014-2026.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/hash2/fnv1a.hpp>     // fnv1a_32, fnv1a_64
+#include <boost/hash2/xxhash.hpp>    // xxhash_64
+#include <boost/test/unit_test.hpp>  // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL
+#include <xstd/bits/bitset.hpp>      // bitset
+#include <xstd/bits/detail/hash.hpp> // std_hash
+#include <cstddef>                   // size_t
+#include <cstdint>                   // uint64_t
+#include <functional>                // hash
+
+// std_hash's Hash parameter is the one thing std::hash cannot reach, so it is asserted here rather than through a
+// specialization. [design.md#the-hashing-invariant]
+BOOST_AUTO_TEST_SUITE(DetailHash)
+
+using set_type = xstd::bitset<8>;
+
+BOOST_AUTO_TEST_CASE(TheDefaultIsFnv1a64)
+{
+        auto const value = set_type(0b1010'0101);
+        BOOST_CHECK_EQUAL(xstd::detail::bits::std_hash(value), xstd::detail::bits::std_hash(value, boost::hash2::fnv1a_64()));
+
+        // And it is the default std::hash takes, since its operator() has no second argument to pass. [design.md#the-hashing-invariant]
+        BOOST_CHECK_EQUAL(std::hash<set_type>()(value), xstd::detail::bits::std_hash(value, boost::hash2::fnv1a_64()));
+}
+
+BOOST_AUTO_TEST_CASE(ASeededInstanceSubstitutes)
+{
+        auto const value = set_type(0b1010'0101);
+        constexpr auto seed = std::uint64_t(0x9E37'79B9'7F4A'7C15);
+
+        // By value, not by type alone: this is what a defaulted template parameter on its own could not express.
+        BOOST_CHECK_EQUAL(
+                xstd::detail::bits::std_hash(value, boost::hash2::fnv1a_64(seed)),
+                xstd::detail::bits::std_hash(value, boost::hash2::fnv1a_64(seed))
+        );
+        BOOST_CHECK(xstd::detail::bits::std_hash(value, boost::hash2::fnv1a_64(seed)) != xstd::detail::bits::std_hash(value));
+}
+
+BOOST_AUTO_TEST_CASE(AnotherAlgorithmSubstitutes)
+{
+        auto const value = set_type(0b1010'0101);
+        BOOST_CHECK(xstd::detail::bits::std_hash(value, boost::hash2::xxhash_64()) != xstd::detail::bits::std_hash(value));
+        BOOST_CHECK(xstd::detail::bits::std_hash(value, boost::hash2::fnv1a_32()) != xstd::detail::bits::std_hash(value));
+}
+
+// The invariant is per algorithm, and holds under a substituted one too: equal values hash equal. [design.md#the-hashing-invariant]
+BOOST_AUTO_TEST_CASE(EqualValuesHashEqualUnderASubstitutedHash)
+{
+        auto const lhs = set_type(0b1010'0101);
+        auto const rhs = set_type(0b1010'0101);
+        auto const other = set_type(0b0101'1010);
+
+        BOOST_CHECK_EQUAL(
+                xstd::detail::bits::std_hash(lhs, boost::hash2::xxhash_64()),
+                xstd::detail::bits::std_hash(rhs, boost::hash2::xxhash_64())
+        );
+        BOOST_CHECK(
+                xstd::detail::bits::std_hash(lhs, boost::hash2::xxhash_64()) !=
+                xstd::detail::bits::std_hash(other, boost::hash2::xxhash_64())
+        );
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/src/bits/dynamic_bitset.cpp
+++ b/test/src/bits/dynamic_bitset.cpp
@@ -3,27 +3,27 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/dynamic_bitset.hpp>               // dynamic_bitset, to_string
-#include <boost/test/unit_test.hpp>               // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL, BOOST_CHECK_THROW
-#include <xstd/bits/bitset_adaptor.hpp>             // bitset_adaptor
-#include <xstd/bits/block_sequence.hpp>           // block_vector
-#include <xstd/bits/dynamic_bitset.hpp>           // dynamic_bitset
-#include <algorithm>                              // equal
-#include <array>                                  // array
-#include <compare>                                // is_eq, is_gt, is_lt
-#include <concepts>                               // regular, same_as, totally_ordered
-#include <cstddef>                                // size_t
-#include <cstdint>                                // uint8_t, uint64_t
-#include <functional>                             // hash
-#include <iterator>                               // back_inserter
-#include <memory>                                 // allocator
-#include <ranges>                                 // equal, iota
-#include <sstream>                                // istringstream, ostringstream
-#include <stdexcept>                              // invalid_argument, out_of_range, overflow_error
-#include <string>                                 // string
-#include <tuple>                                  // tuple
-#include <utility>                                // as_const, pair
-#include <vector>                                 // vector
+#include <boost/dynamic_bitset.hpp>     // dynamic_bitset, to_string
+#include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL, BOOST_CHECK_THROW
+#include <xstd/bits/bitset_adaptor.hpp> // bitset_adaptor
+#include <xstd/bits/block_sequence.hpp> // block_vector
+#include <xstd/bits/dynamic_bitset.hpp> // dynamic_bitset
+#include <algorithm>                    // equal
+#include <array>                        // array
+#include <compare>                      // is_eq, is_gt, is_lt
+#include <concepts>                     // regular, same_as, totally_ordered
+#include <cstddef>                      // size_t
+#include <cstdint>                      // uint8_t, uint64_t
+#include <functional>                   // hash
+#include <iterator>                     // back_inserter
+#include <memory>                       // allocator
+#include <ranges>                       // equal, iota
+#include <sstream>                      // istringstream, ostringstream
+#include <stdexcept>                    // invalid_argument, out_of_range, overflow_error
+#include <string>                       // string
+#include <tuple>                        // tuple
+#include <utility>                      // as_const, pair
+#include <vector>                       // vector
 
 BOOST_AUTO_TEST_SUITE(DynamicBitset)
 

--- a/test/src/bits/ext/boost.cpp
+++ b/test/src/bits/ext/boost.cpp
@@ -3,12 +3,12 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/test/unit_test.hpp>      // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
-#include <xstd/bits/bit_traits.hpp>      // bit_storage, bit_traits, static_bit_extent
-#include <xstd/bits/ext/boost.hpp>       // the Boost adaptors, asked for by name
+#include <boost/test/unit_test.hpp>   // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
+#include <xstd/bits/bit_traits.hpp>   // bit_storage, bit_traits, static_bit_extent
+#include <xstd/bits/ext/boost.hpp>    // the Boost adaptors, asked for by name
 #include <xstd/bits/bit_set_view.hpp> // bit_set_view
-#include <ranges>                        // bidirectional_range
-#include <span>                          // dynamic_extent
+#include <ranges>                     // bidirectional_range
+#include <span>                       // dynamic_extent
 
 BOOST_AUTO_TEST_SUITE(Ext)
 BOOST_AUTO_TEST_SUITE(Boost)

--- a/test/src/bits/ext/boost/dynamic_bitset.cpp
+++ b/test/src/bits/ext/boost/dynamic_bitset.cpp
@@ -7,8 +7,8 @@
 #include <test/dynamic.hpp>                       // dynamic
 #include <xstd/bits/bit_traits.hpp>               // bit_storage, bit_traits, block_readable, static_bit_extent
 #include <xstd/bits/ext/boost/dynamic_bitset.hpp> // the trait that makes dynamic_bitset viewable
-#include <xstd/bits/bit_span.hpp>     // bit_span
-#include <xstd/bits/bit_set_view.hpp>          // bit_set_view
+#include <xstd/bits/bit_span.hpp>                 // bit_span
+#include <xstd/bits/bit_set_view.hpp>             // bit_set_view
 #include <algorithm>                              // lexicographical_compare
 #include <compare>                                // is_lt, strong_ordering
 #include <concepts>                               // regular, totally_ordered

--- a/test/src/bits/ext/std.cpp
+++ b/test/src/bits/ext/std.cpp
@@ -3,12 +3,12 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/test/unit_test.hpp>      // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
-#include <xstd/bits/bit_traits.hpp>      // bit_storage, bit_traits, static_bit_extent
-#include <xstd/bits/ext/std.hpp>         // the std adaptors, asked for by name
+#include <boost/test/unit_test.hpp>   // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
+#include <xstd/bits/bit_traits.hpp>   // bit_storage, bit_traits, static_bit_extent
+#include <xstd/bits/ext/std.hpp>      // the std adaptors, asked for by name
 #include <xstd/bits/bit_set_view.hpp> // bit_set_view
-#include <bitset>                        // bitset
-#include <ranges>                        // bidirectional_range
+#include <bitset>                     // bitset
+#include <ranges>                     // bidirectional_range
 
 BOOST_AUTO_TEST_SUITE(Ext)
 BOOST_AUTO_TEST_SUITE(Std)

--- a/test/src/bits/ext/std/bitset.cpp
+++ b/test/src/bits/ext/std/bitset.cpp
@@ -3,19 +3,19 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/test/unit_test.hpp>           // BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
-#include <xstd/bits/bit_traits.hpp>           // bit_storage, bit_traits, block_readable, static_bit_extent
-#include <xstd/bits/bitset.hpp>               // bitset
-#include <xstd/bits/ext/std/bitset.hpp>       // bit_traits over std::bitset
-#include <xstd/bits/bit_span.hpp> // bit_span
-#include <xstd/bits/bit_set_view.hpp>      // bit_set_view
-#include <bitset>                             // bitset
-#include <concepts>                           // regular, totally_ordered
-#include <cstddef>                            // size_t
-#include <limits>                             // numeric_limits
-#include <ranges>                             // bidirectional_range, random_access_range, range
-#include <tuple>                              // tuple
-#include <type_traits>                        // is_nothrow_*, is_trivially_*
+#include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
+#include <xstd/bits/bit_traits.hpp>     // bit_storage, bit_traits, block_readable, static_bit_extent
+#include <xstd/bits/bitset.hpp>         // bitset
+#include <xstd/bits/ext/std/bitset.hpp> // bit_traits over std::bitset
+#include <xstd/bits/bit_span.hpp>       // bit_span
+#include <xstd/bits/bit_set_view.hpp>   // bit_set_view
+#include <bitset>                       // bitset
+#include <concepts>                     // regular, totally_ordered
+#include <cstddef>                      // size_t
+#include <limits>                       // numeric_limits
+#include <ranges>                       // bidirectional_range, random_access_range, range
+#include <tuple>                        // tuple
+#include <type_traits>                  // is_nothrow_*, is_trivially_*
 
 BOOST_AUTO_TEST_SUITE(Ext)
 BOOST_AUTO_TEST_SUITE(Std)

--- a/test/src/bits/format.cpp
+++ b/test/src/bits/format.cpp
@@ -3,15 +3,15 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/test/unit_test.hpp>      // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
-#include <xstd/bits/bit_array.hpp>       // bit_array
-#include <xstd/bits/bit_set.hpp>         // bit_set
-#include <xstd/bits/bit_set_view.hpp>    // bit_set_view
-#include <xstd/bits/bit_span.hpp>        // bit_span
-#include <xstd/bits/bit_static_set.hpp>  // bit_static_set
-#include <xstd/bits/bit_vector.hpp>      // bit_vector
-#include <xstd/bits/format.hpp>          // IWYU pragma: keep; the formatter over the two proxies, which is what every case below reaches
-#include <format>                        // format
+#include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
+#include <xstd/bits/bit_array.hpp>      // bit_array
+#include <xstd/bits/bit_set.hpp>        // bit_set
+#include <xstd/bits/bit_set_view.hpp>   // bit_set_view
+#include <xstd/bits/bit_span.hpp>       // bit_span
+#include <xstd/bits/bit_static_set.hpp> // bit_static_set
+#include <xstd/bits/bit_vector.hpp>     // bit_vector
+#include <xstd/bits/format.hpp>         // IWYU pragma: keep; the formatter over the two proxies, which is what every case below reaches
+#include <format>                       // format
 
 BOOST_AUTO_TEST_SUITE(Format)
 

--- a/test/src/bits/generated.cpp
+++ b/test/src/bits/generated.cpp
@@ -3,11 +3,11 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/test/unit_test.hpp>         // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK
-#include <xstd/bits.hpp>                    // bit_array, bit_set, bit_static_set, bit_vector, bitset, dynamic_bitset, and the inplace column
-#include <compare>                          // three_way_comparable
-#include <concepts>                         // copyable, default_initializable, movable, swappable, totally_ordered
-#include <type_traits>                      // is_nothrow_move_assignable_v, is_nothrow_move_constructible_v
+#include <boost/test/unit_test.hpp> // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK
+#include <xstd/bits.hpp>            // bit_array, bit_set, bit_static_set, bit_vector, bitset, dynamic_bitset, and the inplace column
+#include <compare>                  // three_way_comparable
+#include <concepts>                 // copyable, default_initializable, movable, swappable, totally_ordered
+#include <type_traits>              // is_nothrow_move_assignable_v, is_nothrow_move_constructible_v
 
 // What the compiler generates for each cell, held to the table rather than to whichever cell was read last. [design.md#the-generated-table]
 BOOST_AUTO_TEST_SUITE(Generated)

--- a/test/src/bits/inplace_bitset.cpp
+++ b/test/src/bits/inplace_bitset.cpp
@@ -3,19 +3,19 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/test/unit_test.hpp>              // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL, BOOST_CHECK_THROW
-#include <test/inplace_vector.hpp>               // IWYU pragma: keep; TEST_HAS_INPLACE_VECTOR, has_inplace_vector
+#include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL, BOOST_CHECK_THROW
+#include <test/inplace_vector.hpp>      // IWYU pragma: keep; TEST_HAS_INPLACE_VECTOR, has_inplace_vector
 #ifdef TEST_HAS_INPLACE_VECTOR
-#include <xstd/bits/bitset_adaptor.hpp>          // bitset_adaptor
-#include <xstd/bits/inplace_bitset.hpp>          // basic_inplace_bitset, inplace_bitset
-#include <xstd/bits/block_sequence.hpp>          // block_inplace_vector
-#include <xstd/bits/bit_set_view.hpp>            // bit_set_view
-#include <concepts>                              // regular, same_as, totally_ordered
-#include <cstddef>                               // size_t
-#include <cstdint>                               // uint8_t
-#include <new>                                   // bad_alloc
-#include <string>                                // string
-#include <utility>                               // declval
+#include <xstd/bits/bitset_adaptor.hpp> // bitset_adaptor
+#include <xstd/bits/inplace_bitset.hpp> // basic_inplace_bitset, inplace_bitset
+#include <xstd/bits/block_sequence.hpp> // block_inplace_vector
+#include <xstd/bits/bit_set_view.hpp>   // bit_set_view
+#include <concepts>                     // regular, same_as, totally_ordered
+#include <cstddef>                      // size_t
+#include <cstdint>                      // uint8_t
+#include <new>                          // bad_alloc
+#include <string>                       // string
+#include <utility>                      // declval
 #endif
 
 BOOST_AUTO_TEST_SUITE(InplaceBitset)

--- a/test/src/bits/sequence_adaptor.cpp
+++ b/test/src/bits/sequence_adaptor.cpp
@@ -3,27 +3,27 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/test/unit_test.hpp>          // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL, BOOST_CHECK_THROW
-#include <test/block_types.hpp>              // graded_extents
-#include <xstd/bits/sequence_adaptor.hpp>  // sequence_adaptor
-#include <xstd/bits/bit_array.hpp>           // bit_array
-#include <xstd/bits/bit_traits.hpp>          // bit_traits, block_readable
-#include <xstd/bits/bit_span.hpp>            // bit_span
-#include <xstd/bits/block_sequence.hpp>      // block_array, block_vector
-#include <xstd/bits/ext/std/bitset.hpp>      // bit_traits over std::bitset
-#include <xstd/bits/ownership.hpp>           // ownership
-#include <algorithm>                         // all_of, any_of, count, equal, lexicographical_compare_three_way, mismatch, none_of
-#include <bitset>                            // bitset
-#include <compare>                           // strong_ordering
-#include <concepts>                          // copyable, equality_comparable, regular, same_as, totally_ordered
-#include <cstddef>                           // size_t
-#include <cstdint>                           // uint64_t
-#include <iterator>                          // reverse_iterator
-#include <limits>                            // numeric_limits
-#include <ranges>                            // random_access_range
-#include <stdexcept>                         // out_of_range
-#include <type_traits>                       // is_const_v
-#include <vector>                            // vector
+#include <boost/test/unit_test.hpp>       // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL, BOOST_CHECK_THROW
+#include <test/block_types.hpp>           // graded_extents
+#include <xstd/bits/sequence_adaptor.hpp> // sequence_adaptor
+#include <xstd/bits/bit_array.hpp>        // bit_array
+#include <xstd/bits/bit_traits.hpp>       // bit_traits, block_readable
+#include <xstd/bits/bit_span.hpp>         // bit_span
+#include <xstd/bits/block_sequence.hpp>   // block_array, block_vector
+#include <xstd/bits/ext/std/bitset.hpp>   // bit_traits over std::bitset
+#include <xstd/bits/ownership.hpp>        // ownership
+#include <algorithm>                      // all_of, any_of, count, equal, lexicographical_compare_three_way, mismatch, none_of
+#include <bitset>                         // bitset
+#include <compare>                        // strong_ordering
+#include <concepts>                       // copyable, equality_comparable, regular, same_as, totally_ordered
+#include <cstddef>                        // size_t
+#include <cstdint>                        // uint64_t
+#include <iterator>                       // reverse_iterator
+#include <limits>                         // numeric_limits
+#include <ranges>                         // random_access_range
+#include <stdexcept>                      // out_of_range
+#include <type_traits>                    // is_const_v
+#include <vector>                         // vector
 
 namespace {
 

--- a/test/src/bits/set_adaptor.cpp
+++ b/test/src/bits/set_adaptor.cpp
@@ -5,7 +5,7 @@
 
 #include <boost/test/unit_test.hpp>               // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL
 #include <test/minimal_traits.hpp>                // minimal_traits
-#include <xstd/bits/set_adaptor.hpp>            // set_adaptor
+#include <xstd/bits/set_adaptor.hpp>              // set_adaptor
 #include <xstd/bits/bit_set.hpp>                  // bit_set
 #include <xstd/bits/bit_set_view.hpp>             // bit_set_view
 #include <xstd/bits/bit_static_set.hpp>           // bit_static_set

--- a/test/src/bits/std_set/o1.cpp
+++ b/test/src/bits/std_set/o1.cpp
@@ -3,7 +3,7 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <test/set/exhaustive.hpp> // all_cardinality_sets, all_singleton_arrays, all_singleton_ilists, all_singleton_sets,
+#include <test/set/exhaustive.hpp>      // all_cardinality_sets, all_singleton_arrays, all_singleton_ilists, all_singleton_sets,
                                         // all_valid, empty_set, full_set
 #include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE_TEMPLATE
 #include <test/flat_set.hpp>            // TEST_HAS_FLAT_SET, is_flat_set

--- a/test/src/bits/std_set/o2.cpp
+++ b/test/src/bits/std_set/o2.cpp
@@ -3,9 +3,9 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#include <test/set/composable.hpp> // includes, set_difference, set_intersection, set_symmetric_difference, set_union,
+#include <test/set/composable.hpp>      // includes, set_difference, set_intersection, set_symmetric_difference, set_union,
                                         // decrement, increment
-#include <test/set/exhaustive.hpp> // all_doubleton_arrays, all_doubleton_ilists, all_doubleton_sets,
+#include <test/set/exhaustive.hpp>      // all_doubleton_arrays, all_doubleton_ilists, all_doubleton_sets,
                                         // all_singleton_sets, all_singleton_set_pairs, all_valid
 #include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE_TEMPLATE
 #include <test/flat_set.hpp>            // TEST_HAS_FLAT_SET, is_flat_set


### PR DESCRIPTION
Three separable changes, each with its own commit.

## 1. The last MSVC 17 `typename`

`test/include/test/set/primitives.hpp` had one `typename` left, on the default argument of a constrained type-parameter:

```cpp
// NOLINTNEXTLINE(readability-redundant-typename)
template<class X, std::integral T = typename X::key_type>
```

It existed only because MSVC 17 rejected the omission — `error C2061: syntax error: identifier 'integral'` — while GCC, clang, clang-cl and Apple clang all took it. [P0634R3](https://wg21.link/P0634R3) permits it, so with the VS 2022 MSVC rung gone (#134) it becomes:

```cpp
template<class X, std::integral T = X::key_type>
```

**MSVC 18 accepts this** — `msvc` and `msvc_analyze` both green, on two separate heads. That settles it with a compiler rather than a vendor table, which matters here: Microsoft's conformance table misled me twice on this exact area during #134.

The `NOLINTNEXTLINE` goes too, and it was suppressing a **live** check, verified against a standalone repro of the old spelling:

```
probe.cpp:2:37: warning: redundant 'typename' [readability-redundant-typename]
```

Last such site in the tree — the remaining `typename X::value_type` spellings are template arguments and functional casts, positions P0634R3 does not reach.

**Stale rung counts.** `CONTRIBUTING.md` still advertised a VS 2022 MSVC rung in three places: the `msvc / all` row, the `msvc_analyze / all` row, and the `/analyze` bullet. The leg-coverage sentence said "the VS 2022 legs" unqualified; those are now specifically the `Clang-CL` ones. `design.md`'s preamble pointed at #80 as the live record of in-flight decisions — that issue is closed, so it now points at the open issues.

## 2. `std_hash` takes the algorithm as a defaulted parameter

`xstd::detail::bits::std_hash` chose `fnv1a_64` in its body; it now takes it:

```cpp
template<class T, class Hash = boost::hash2::fnv1a_64>
[[nodiscard]] constexpr auto std_hash(T const& v, Hash h = {}) noexcept -> std::size_t
```

Defaulted on the **template** parameter as well as the function parameter, because a default function argument is not a deduced context and `std_hash(v)` would otherwise fail to deduce `Hash`. Taken **by value** rather than by type alone, so a seeded instance substitutes and not only a default-constructed one.

`std::hash` cannot reach past the default — its `operator()` takes one argument and has no second to forward — so all three specializations still get `fnv1a_64`. That is exactly why the parameter is asserted directly, in a new `test/src/bits/detail/hash.cpp`, rather than through a specialization: otherwise it would be a knob nothing exercises, which the coverage gate would not catch. Four cases: the default *is* `fnv1a_64` and is what `std::hash` gets; a seeded `fnv1a_64` substitutes and differs from unseeded; `xxhash_64` and `fnv1a_32` substitute; and equal values still hash equal under a substituted algorithm.

`detail/` is exempt from the header-mirroring rule and test targets are globbed, so no CMake change was needed. `design.md#the-hashing-invariant` records the shape.

## 3. Include-comment alignment, tree-wide

Two faults. Some include blocks were internally misaligned, the longest include pushing its own comment one column past the rest. Others were aligned but over-indented — `inplace_bitset.hpp` and its two siblings at column 59 against a minimum of 51, `block_sequence.hpp` at 63 against 61.

The rule, now applied everywhere: **one column per file, exactly one space past the longest `#include` in it**, with wrapped comment continuation lines indented to that same column. Per file rather than per block, and the multi-block files settle it — `inplace_bitset.hpp`, `block_sequence.hpp` and `benchmark/src/set/sieve.cpp` each split their includes across an `#ifdef` and each aligned every block to a single column. A per-block minimum would have put `#include <version>` at column 19 with the guarded block at 51 in the same file.

94 files scanned, 38 changed, 319 lines. Whitespace inside comments only; no include text changed.

## Verification

- **CI: all fourteen checks green** on `db11721`, `msvc` and `msvc_analyze` included.
- GCC 15 Debug: clean build, no diagnostics, **70/70 tests**.
- clang-tidy 22 and 24, run directly against the compile database, clean on both files with non-comment changes: `test/src/bits/detail/hash.cpp` and `test/src/bits/std_set/o0.cpp` (the TU instantiating `nested_types`). The other 38 files change comment whitespace only.

One process note, since an earlier revision of this description overstated it: running clang-tidy *through the build* (`cmake --build build/tidy`) only lints files it recompiles, so it reported clean on a file CI then flagged twice. The two findings that caught — an unused `<cstddef>` and a functional-style cast in the new test — are fixed in `db11721`, and the direct per-file runs above are what actually establish the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLhTckKKQENsJPrZMXJJzo
