### PR TITLE
Test bitset and bit_array at 128-bit blocks across block boundaries

### DIFF
--- a/test/include/test/block_types.hpp
+++ b/test/include/test/block_types.hpp
@@ -35,6 +35,20 @@ using narrow_word_types = std::tuple
 <       std::uint8_t
 >;
 
+// The widest Block, which crosses a boundary for a reason the narrow ones cannot cover. uint8_t and uint16_t
+// PROMOTE: every block operation on them has an int intermediate, and the code masks back from it. uint32_t
+// upward do not promote at all, so the block's own width is the whole modulus and there is nothing to mask
+// back from. Straddling at narrow words alone therefore exercises only the promoting path, and "the arithmetic
+// follows digits, not the carrier" holds within a block but is untested across one. xstd::uint128 is the
+// extreme of the non-promoting half and the only Block whose carrier is not a standard unsigned integer type,
+// so it is the one worth the extents. [design.md#uint128-support]
+using wide_word_types = std::tuple
+<
+#ifdef TEST_HAS_UINT128
+        xstd::uint128
+#endif
+>;
+
 // One block's worth of extents: empty, a single bit, and exactly one full block -- the same cost at any width.
 template<template<class, std::size_t> class C, class Block>
 using in_block_extents = std::tuple
@@ -67,6 +81,12 @@ using graded_extents = decltype(std::tuple_cat(
         std::declval<decltype(detail::expand<C, in_block_extents>(std::declval<word_types>()))>(),
         std::declval<decltype(detail::expand<C, straddling_extents>(std::declval<narrow_word_types>()))>()
 ));
+
+// The widest Block across block boundaries, for the suites that can afford it: every case they run per type is
+// a static_assert or a single pass over the positions, so three blocks of 128 costs what one block costs.
+// Deliberately NOT folded into graded_extents, which feeds suites whose per-type work is superlinear.
+template<template<class, std::size_t> class C>
+using wide_extents = decltype(detail::expand<C, straddling_extents>(std::declval<wide_word_types>()));
 
 } // namespace test
 

--- a/test/src/bits/bit_array.cpp
+++ b/test/src/bits/bit_array.cpp
@@ -17,13 +17,18 @@
 #include <iterator>                   // contiguous_iterator, random_access_iterator
 #include <ranges>                     // begin, contiguous_range, drop, random_access_range, take
 #include <stdexcept>                  // out_of_range
+#include <tuple>                      // tuple_cat
 #include <utility>                    // declval
 #include <vector>                     // vector
 
 BOOST_AUTO_TEST_SUITE(BitArray)
 
-// Every Block model within one block and the narrow ones across boundaries; the grading is in test/block_types.hpp.
-using Types = test::graded_extents<xstd::basic_bit_array>;
+// Every Block model within one block, the narrow ones across boundaries, and the widest Block across one too;
+// the grading is in test/block_types.hpp. Every case below is a static_assert or one pass over the positions,
+// so the three-block instantiations cost what the one-block ones do.
+using Types = decltype(std::tuple_cat(
+        std::declval<test::graded_extents<xstd::basic_bit_array>>(),
+        std::declval<test::wide_extents<xstd::basic_bit_array>>()));
 
 // The clauses one at a time, so a failure names which one; the umbrella asserts the composite.
 BOOST_AUTO_TEST_CASE_TEMPLATE(IsRegular, T, Types)

--- a/test/src/bits/bitset.cpp
+++ b/test/src/bits/bitset.cpp
@@ -9,12 +9,18 @@
 #include <xstd/bits/bitset_adaptor.hpp> // swap
 #include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
 #include <concepts>                     // regular, totally_ordered
+#include <tuple>                        // tuple_cat
 #include <type_traits>                  // is_nothrow_*, is_trivially_*
 #include <utility>                      // declval
 
 BOOST_AUTO_TEST_SUITE(Bitset)
 
-using Types = test::graded_extents<xstd::basic_bitset>;
+// Every Block model within one block, the narrow ones across boundaries, and the widest Block across one too;
+// the grading is in test/block_types.hpp. Every case below is a static_assert or one pass over the positions,
+// so the three-block instantiations cost what the one-block ones do.
+using Types = decltype(std::tuple_cat(
+        std::declval<test::graded_extents<xstd::basic_bitset>>(),
+        std::declval<test::wide_extents<xstd::basic_bitset>>()));
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(IsRegular, T, Types)
 {


### PR DESCRIPTION
## What

`straddling_extents` ran over `uint8_t` alone, which exercises only half of the block arithmetic:

- **`uint8_t` and `uint16_t` promote.** Every block operation on them has an `int` intermediate, and the code masks back from it.
- **`uint32_t` and wider do not promote at all.** The block's own width is the whole modulus, and there is nothing to mask back from.

Straddling at the narrow word alone therefore left *"the arithmetic follows digits, not the carrier"* tested **within** a block but never **across** one, on the non-promoting half.

This adds `wide_word_types` and `wide_extents` to `test/block_types.hpp` and feeds them to the two suites whose per-type work is a `static_assert` or a single pass over the positions. `xstd::uint128` is the extreme of the non-promoting half and the only Block whose carrier is not a standard unsigned integer type, so it is the one worth the six straddling extents: **127, 129, 255, 256, 257, 384**.

## Why a separate list

`wide_extents` is deliberately kept **out** of `graded_extents`, which also feeds suites whose per-type cost is superlinear. The two suites here pay a static_assert or one linear pass per type, so three blocks of 128 costs what one block costs; folding it into `graded_extents` would charge that to suites that cannot afford it.

Where `TEST_HAS_UINT128` is absent — MSVC, or extensions off — `wide_word_types` is an empty tuple and both lists degrade to exactly what they were.

## Verification

Neither test TU compiles in full in this container, and that is pre-existing and unrelated to this change: libstdc++ 13 has no `std::from_range_t`, GCC 13 has no deducing-this, and Clang 18 has no alias-template CTAD. I confirmed the change adds nothing by diffing the error signatures with and without it — identical sets, line numbers shifted by exactly the added lines.

What I could verify directly, I did, with a focused TU built the way CI builds (`-std=gnu++2b`, so `TEST_HAS_UINT128` is on):

- Both lists expand to **27 types** (21 graded + 6 wide), with **no duplicate type** — real Boost.Test rejects two units under one name, so the combined list must not repeat one.
- For all 27 types of **both** containers: every position set one at a time up through every block boundary and cleared back down from the top, with the population count checked at each step; the highest position set in a partial top block without disturbing the unused tail; equality, hashing, and iteration-versus-subscript agreement. **0 failures.**
- The strict-ANSI configuration (empty `wide_word_types`) compiles and runs clean, degrading to 18 types with `wide=0`.
- `clang-tidy` clean on the added code.

Local `clang-format` is 18 and diverges from this repo's baseline wholesale — an untouched file shows 1017 diff lines, and it wants to rewrite the leading-comma tuple style, `template<class`, and the 120-column comments everywhere. I used untouched files as the control and left formatting alone; the added lines follow the surrounding style. Formatting rests on CI's 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPyqkBWNUZaT5VUx6bbxW1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPyqkBWNUZaT5VUx6bbxW1)_