### PR TITLE
Carry the blocks to xstd's bit basis, so an integer class can be one

### DIFF
--- a/.github/workflows/consumption.yml
+++ b/.github/workflows/consumption.yml
@@ -28,5 +28,5 @@ jobs:
       vcpkg: true
       # The revisions CMakeLists.txt pins; install(EXPORT) cannot export a FetchContent build tree, so installed dependencies are required.
       dependency_repos: |
-        https://github.com/rhalbersma/xstd-ints.git 4f53008bec1c56535c839ba2ef8bec2b4985de63
+        https://github.com/rhalbersma/xstd-ints.git a053f05062a12657eeaef47637b8c0be4483fc35
         https://github.com/rhalbersma/xstd-misc.git 4ef4886c093afdb41f1979eda2a5cff51acf076b

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ if(NOT xstd-ints_FOUND)
         xstd-ints
         GIT_REPOSITORY https://github.com/rhalbersma/xstd-ints.git
         # Pinned to a commit on xstd-ints' main, not a branch head; move consumption.yml's dependency_repos with it.
-        GIT_TAG 4f53008bec1c56535c839ba2ef8bec2b4985de63
+        GIT_TAG a053f05062a12657eeaef47637b8c0be4483fc35
     )
     FetchContent_MakeAvailable(xstd-ints)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ target_sources(
         include/xstd/bits/dynamic_bitset.hpp
         include/xstd/bits/detail/pred.hpp
         include/xstd/bits/detail/random_access.hpp
+        include/xstd/bits/detail/shift.hpp
         include/xstd/bits/ext/boost.hpp
         include/xstd/bits/ext/boost/dynamic_bitset.hpp
         include/xstd/bits/ext/std.hpp

--- a/design.md
+++ b/design.md
@@ -2165,17 +2165,29 @@ Block's namespace is an **associated** one and ADL contributes whatever template
 Boost.Int128 declares exactly such a set. Each proxy therefore also declares comparisons that are exact in
 both operands, which win outright.
 
-**The macro is held to the basis, not to `std`.** `TEST_HAS_UINT128` is on wherever `xstd::uint128` is a
-usable Block: on an MSVC-ABI target always, and elsewhere where `__SIZEOF_INT128__` is defined outside
-`__STRICT_ANSI__` — which is why the matrix compiles as `gnu++23`. The assert beside it is an **implication**,
-that where the macro is on the basis is really there. The equality it replaces asked `std::unsigned_integral`,
-which is the wrong question in both directions: false for every integer class that works as a Block, so it
-denied the MSVC half outright, and true in dialects where `<bit>` still declines the type. The converse is not
-worth asserting either — a basis the macro declines to use costs coverage, not correctness.
+**Two facts, two flags, because one flag conflated them.** `TEST_HAS_UINT128` names the compiler's 128-bit
+**builtin**: a scalar, and a `std::unsigned_integral`. It feeds `word_types`, which every suite grades over, and
+`test/src/bits/block/type_traits.cpp`, which asserts exactly those `std` traits of each word — both right to
+assume a builtin. `TEST_HAS_MSVC_INT128` names what an MSVC-ABI target has instead, `std::_Unsigned128` under
+the same `xstd::uint128` spelling: a usable Block, but a class, so not `is_integral`, not `is_unsigned`, and not
+something `<bit>` will take.
 
-The two third-party classes are optional: `test/ext_int128.hpp` detects each by `__has_include`, so a build
-without them drops it from the Block lists rather than failing. They earn their place by being the types that
-catch a container assuming a Block is a scalar — both defects above were invisible to every builtin.
+Widening the one flag to cover both put a class-typed Block into `word_types`, and so into every suite at once,
+which broke sixteen MSVC targets — the `std_bitset` and `std_set` comparisons among them, whose helpers assume a
+Block is a `std` integral and whose per-type cost is superlinear. So the three integer classes sit together in
+`wide_word_types`, feeding only the two suites that pay a `static_assert` or one linear pass per type. MSVC's is
+named beside Abseil's and Boost's, which is what it behaves like, rather than beside the builtin whose spelling
+it shares.
+
+The assert beside each flag is an **implication**, that where the flag is on the basis is really there. The
+equality it replaces asked `std::unsigned_integral`, which is the wrong question in both directions: false for
+every integer class that works as a Block, and true in dialects where `<bit>` still declines the type. The
+converse is not worth asserting either — a basis a flag declines to use costs coverage, not correctness.
+
+Abseil's and Boost's are optional: `test/ext_int128.hpp` detects each by `__has_include`, so a build without
+them drops it from the Block lists rather than failing. MSVC's needs no dependency at all. All three earn their
+place by being the types that catch a container assuming a Block is a scalar — every defect above was invisible
+to every builtin.
 
 ### exception-escape-nolints
 

--- a/design.md
+++ b/design.md
@@ -2155,15 +2155,23 @@ separate header could not be relied on to sort below the adapters.
 **A Block being a class breaks two assumptions that a scalar hid.** `detail::bits::pred`'s `intersects`
 returned `lhs & rhs` into a `bool`, which copy-initializes and so needs an **implicit** conversion; an integer
 class offers only an explicit `operator bool`. Its two neighbours never needed the cast, `not` and `!=` both
-reaching `bool` by a **contextual** conversion, which an explicit operator satisfies. And both bit proxies
-carried a templated implicit conversion to any class type constructible from their `value_type`. An integer
-class is such a class, so every operator on a proxy acquired a second, equally good reading — convert both
-sides to `bool`, or convert both sides to the Block — which cost the proxy `equality_comparable` and with it
-`std::ranges::equal`. The conversion now excludes `xstd::integer`: a proxy stands for one bit, and a bit is
-not an integer. That alone is not enough, because a proxy names its Block among its template arguments, so the
-Block's namespace is an **associated** one and ADL contributes whatever templated comparisons it declares —
-Boost.Int128 declares exactly such a set. Each proxy therefore also declares comparisons that are exact in
-both operands, which win outright.
+reaching `bool` by a **contextual** conversion, which an explicit operator satisfies. And the sequence proxy in
+`random_access.hpp` carried a templated implicit conversion to any class type constructible from its
+`value_type`. An integer class is such a class, so every operator on that proxy acquired a second, equally good
+reading — convert both sides to `bool`, or convert both sides to the Block — which cost it
+`equality_comparable` and with it `std::ranges::equal`. The conversion now excludes `xstd::integer`: a proxy
+stands for one bit, and a bit is not an integer. That alone is not enough, because a proxy names its Block
+among its template arguments, so the Block's namespace is an **associated** one and ADL contributes whatever
+templated comparisons it declares — Boost.Int128 declares exactly such a set. It therefore also declares
+comparisons that are exact in both operands, which win outright.
+
+The set proxy in `bidirectional.hpp` is deliberately **untouched**, and the attempt to keep it in step was a
+mistake worth recording. Nothing had failed there: a set over an integer-class Block already worked, because
+that proxy stands for a position rather than a bit and its `value_type` is `size_t`. Giving it the same exact
+comparisons broke a case no integer class is involved in at all — `std::ranges::equal` over **two different**
+instantiations of it, which is how `bit_set_view<B>` is compared against the view deduced from `B`'s own
+storage, and which those homogeneous overloads no longer serve. A fix that no failure asked for cost a working
+path, at a Block as ordinary as `uint64_t`.
 
 **Two facts, two flags, because one flag conflated them.** `TEST_HAS_UINT128` names the compiler's 128-bit
 **builtin**: a scalar, and a `std::unsigned_integral`. It feeds `word_types`, which every suite grades over, and

--- a/design.md
+++ b/design.md
@@ -2211,8 +2211,14 @@ ever wrong.
 
 ### clang-tidy-false-positives
 
-Five findings are suppressed because the checker cannot see what makes them right:
+Six findings are suppressed because the checker cannot see what makes them right:
 
+- `bugprone-signed-bitwise` on `detail/bits::shl` and `::shr`, whose count is cast to `int`. The two checks
+  that govern this leave no third option, and both were measured: `absl::uint128` declares a single shift,
+  `operator<<(uint128, int)`, so an **unsigned** count reaches it by a signedness-changing conversion and
+  `-Wsign-conversion` rejects it, while an **int** count is a signed operand of a bitwise operator and
+  `bugprone-signed-bitwise` rejects that. The type's own operator decides which is right, and the count is a
+  bit position within one block, so the signedness the check objects to cannot be reached.
 - `bugprone-unhandled-self-assignment` on the bitset proxy's `operator=`, which owns no storage: `b[i] = b[i]`
   reads the bit and writes it back.
 - `bugprone-string-constructor` on `to_string`, which sees the `N == 0` instantiation where the string is
@@ -2226,7 +2232,7 @@ Five findings are suppressed because the checker cannot see what makes them righ
   program-defined type. clang-tidy 22 and 23 read the qualified definition as modifying the namespace; 24 no
   longer does, and the suppression stays until the whole ladder is past 23.
 
-A sixth had a fix rather than a suppression. `modernize-use-nullptr` reads the `0` in `(a <=> b) < 0` as a
+A seventh had a fix rather than a suppression. `modernize-use-nullptr` reads the `0` in `(a <=> b) < 0` as a
 null pointer constant, which is the same false positive `-Wno-zero-as-null-pointer-constant` already covers on
 the compiler side. Every site in the test sources says `std::is_lt`, `std::is_gt` or `std::is_eq` instead --
 the standard's own names for those three questions, which are clearer than the comparison against a literal

--- a/design.md
+++ b/design.md
@@ -2129,18 +2129,53 @@ not).
 
 ### uint128-support
 
-`xstd::uint128` names a type on every compiler the matrix runs, but the library can only carry it where
-`<bit>` will: `detail::bits::intrin` forwards `countl_zero`, `countr_zero` and `popcount` straight through,
-and those take `std::unsigned_integral` alone. That is three separate facts.
+A Block is any `xstd::unsigned_integer`, and three families of them are 128 bits wide: the compiler's own
+`unsigned __int128` on GCC and Clang; the Microsoft STL's `std::_Unsigned128`, which is what `xstd::uint128`
+names on every MSVC-ABI target, clang-cl included; and the two third-party classes xstd adapts,
+`absl::uint128` and `boost::int128::uint128`. Only the first is a scalar. The other three are **classes**, and
+that difference is the whole of this section.
 
-GCC and Clang have the built-in. libstdc++ and libc++ hand it the `numeric_limits` specialization that carries
-it into the concept **only outside `__STRICT_ANSI__`**, which is why the matrix compiles as `gnu++23`. And the
-Microsoft STL's `std::_Unsigned128` is a class type, so `<bit>` declines it whatever the mode — that block
-waits on an `xstd::countl_zero`, not on anything here.
+`detail::bits::intrin` used to forward `countl_zero`, `countr_zero` and `popcount` straight to `<bit>`, whose
+domain is `std::unsigned_integral` — a **closed** concept no class can join. So the seam was constrained on an
+open concept and implemented against a closed one: every 128-bit integer class satisfied the interface and
+then failed inside the body. It now forwards to `xstd::countl_zero` and friends, which are that same domain
+plus one overload per integer class, reading the words each type already holds. This is the change of body the
+seam was left open for, and it is what makes the other three families usable.
 
-The condition worth testing is the concept, which no `#if` can spell, so the assert holds the macro to it in
-both directions. The day that seam grows its own implementation, or a new pairing lands on the matrix, the
-build says so there rather than at fifteen instantiation lists or, worse, nowhere.
+Three consequences follow, none of them obvious from the forwarding change alone.
+
+**The calls are qualified, so they bind where they are written.** `xstd::popcount(block)` is a dependent call
+by a qualified name, and ADL does not apply to qualified names, so its candidates are the overloads visible at
+`intrin.hpp` — not at the instantiation. An adapter included afterwards declares its overload too late to be
+one. A translation unit reaching for an integer-class Block therefore includes that adapter first; the test
+tree does it in `test/block_types.hpp`, above every container header. The same rule decides where
+`test::block_basis` can be spelled, which is why it sits in that header rather than in one of its own: a
+separate header could not be relied on to sort below the adapters.
+
+**A Block being a class breaks two assumptions that a scalar hid.** `detail::bits::pred`'s `intersects`
+returned `lhs & rhs` into a `bool`, which copy-initializes and so needs an **implicit** conversion; an integer
+class offers only an explicit `operator bool`. Its two neighbours never needed the cast, `not` and `!=` both
+reaching `bool` by a **contextual** conversion, which an explicit operator satisfies. And both bit proxies
+carried a templated implicit conversion to any class type constructible from their `value_type`. An integer
+class is such a class, so every operator on a proxy acquired a second, equally good reading — convert both
+sides to `bool`, or convert both sides to the Block — which cost the proxy `equality_comparable` and with it
+`std::ranges::equal`. The conversion now excludes `xstd::integer`: a proxy stands for one bit, and a bit is
+not an integer. That alone is not enough, because a proxy names its Block among its template arguments, so the
+Block's namespace is an **associated** one and ADL contributes whatever templated comparisons it declares —
+Boost.Int128 declares exactly such a set. Each proxy therefore also declares comparisons that are exact in
+both operands, which win outright.
+
+**The macro is held to the basis, not to `std`.** `TEST_HAS_UINT128` is on wherever `xstd::uint128` is a
+usable Block: on an MSVC-ABI target always, and elsewhere where `__SIZEOF_INT128__` is defined outside
+`__STRICT_ANSI__` — which is why the matrix compiles as `gnu++23`. The assert beside it is an **implication**,
+that where the macro is on the basis is really there. The equality it replaces asked `std::unsigned_integral`,
+which is the wrong question in both directions: false for every integer class that works as a Block, so it
+denied the MSVC half outright, and true in dialects where `<bit>` still declines the type. The converse is not
+worth asserting either — a basis the macro declines to use costs coverage, not correctness.
+
+The two third-party classes are optional: `test/ext_int128.hpp` detects each by `__has_include`, so a build
+without them drops it from the Block lists rather than failing. They earn their place by being the types that
+catch a container assuming a Block is a scalar — both defects above were invisible to every builtin.
 
 ### exception-escape-nolints
 

--- a/include/xstd/bits/bit_traits.hpp
+++ b/include/xstd/bits/bit_traits.hpp
@@ -7,6 +7,7 @@
 #define XSTD_BITS_BIT_TRAITS_HPP
 
 #include <xstd/bits/detail/intrin.hpp>             // countl_zero, countr_zero, popcount
+#include <xstd/bits/detail/shift.hpp>              // shl, shr
 #include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer
 #include <cassert>                                 // assert
 #include <concepts>                                // convertible_to, regular, same_as
@@ -113,7 +114,7 @@ template<class Traits, class Bits>
         auto const offset = n % digits;
 
         // No offset != 0 guard: >> 0 is the identity, and #88 measured it as pure cost. [design.md#offset-guards]
-        if (auto const block = static_cast<block_type>(Traits::block(c, start) >> offset); block != block_type{}) {
+        if (auto const block = shr(Traits::block(c, start), offset); block != block_type{}) {
                 return n + detail::bits::countr_zero(block);
         }
         // The mirror of scan_prev_by_block's guard, cursor included, for the same two reasons.

--- a/include/xstd/bits/detail/bidirectional.hpp
+++ b/include/xstd/bits/detail/bidirectional.hpp
@@ -6,12 +6,13 @@
 #ifndef XSTD_BITS_DETAIL_BIDIRECTIONAL_HPP
 #define XSTD_BITS_DETAIL_BIDIRECTIONAL_HPP
 
-#include <xstd/bits/bit_traits.hpp> // bit_storage, bit_traits, find_next, find_prev, zero_width
-#include <cassert>                  // assert
-#include <cstddef>                  // ptrdiff_t, size_t
-#include <format>                   // formatter
-#include <iterator>                 // bidirectional_iterator_tag
-#include <type_traits>              // is_class_v, is_convertible_v, is_nothrow_constructible_v, remove_const_t
+#include <xstd/bits/bit_traits.hpp>       // bit_storage, bit_traits, find_next, find_prev, zero_width
+#include <xstd/ints/concepts/integer.hpp> // integer
+#include <cassert>                        // assert
+#include <cstddef>                        // ptrdiff_t, size_t
+#include <format>                         // formatter
+#include <iterator>                       // bidirectional_iterator_tag
+#include <type_traits>                    // is_class_v, is_convertible_v, is_nothrow_constructible_v, remove_const_t
 
 // The iterator is the primitive: a pointer and a position, reaching the bits through Traits alone. [design.md#the-iterator-is-the-primitive]
 // The set reading's pair, named after the category its iterator models; the sequence reading's is random_access.hpp.
@@ -128,11 +129,31 @@ public:
         }
 
         // A strong index type initializes from *it in one step; one with an explicit constructor takes the size_t route. [design.md#read-only-set-proxy]
+        //
+        // Not an integer, though: a Block that is an integer CLASS is constructible from size_t and brings a
+        // full set of operators, which would give every operator on this proxy two equally good readings. A
+        // strong index type is not an xstd::integer -- it has no signed/unsigned pair -- so the exclusion costs
+        // this conversion nothing it was meant to serve. The same pairing as random_access.hpp, kept in step
+        // with it. [design.md#uint128-support]
         template<class T>
         [[nodiscard]] constexpr explicit(false) operator T() const noexcept(std::is_nothrow_constructible_v<T, value_type>)  // NOLINT(misc-explicit-constructor)
-                requires std::is_class_v<T> and std::is_convertible_v<value_type, T>
+                requires std::is_class_v<T> and std::is_convertible_v<value_type, T> and (not xstd::integer<T>)
         {
                 return m_idx;
+        }
+
+        // Exact in both operands, so a comparison never reaches for a conversion, and never loses to a templated
+        // one the Block's own namespace contributes by ADL. [design.md#uint128-support]
+        [[nodiscard]] friend constexpr auto operator==(bidirectional_bit_reference lhs, bidirectional_bit_reference rhs) noexcept
+                -> bool
+        {
+                return lhs.m_idx == rhs.m_idx;
+        }
+
+        [[nodiscard]] friend constexpr auto operator==(bidirectional_bit_reference lhs, value_type rhs) noexcept
+                -> bool
+        {
+                return lhs.m_idx == rhs;
         }
 
         // fmt's protocol, found by ADL on the proxy: the same value the conversion yields.

--- a/include/xstd/bits/detail/bidirectional.hpp
+++ b/include/xstd/bits/detail/bidirectional.hpp
@@ -6,13 +6,12 @@
 #ifndef XSTD_BITS_DETAIL_BIDIRECTIONAL_HPP
 #define XSTD_BITS_DETAIL_BIDIRECTIONAL_HPP
 
-#include <xstd/bits/bit_traits.hpp>       // bit_storage, bit_traits, find_next, find_prev, zero_width
-#include <xstd/ints/concepts/integer.hpp> // integer
-#include <cassert>                        // assert
-#include <cstddef>                        // ptrdiff_t, size_t
-#include <format>                         // formatter
-#include <iterator>                       // bidirectional_iterator_tag
-#include <type_traits>                    // is_class_v, is_convertible_v, is_nothrow_constructible_v, remove_const_t
+#include <xstd/bits/bit_traits.hpp> // bit_storage, bit_traits, find_next, find_prev, zero_width
+#include <cassert>                  // assert
+#include <cstddef>                  // ptrdiff_t, size_t
+#include <format>                   // formatter
+#include <iterator>                 // bidirectional_iterator_tag
+#include <type_traits>              // is_class_v, is_convertible_v, is_nothrow_constructible_v, remove_const_t
 
 // The iterator is the primitive: a pointer and a position, reaching the bits through Traits alone. [design.md#the-iterator-is-the-primitive]
 // The set reading's pair, named after the category its iterator models; the sequence reading's is random_access.hpp.
@@ -129,31 +128,11 @@ public:
         }
 
         // A strong index type initializes from *it in one step; one with an explicit constructor takes the size_t route. [design.md#read-only-set-proxy]
-        //
-        // Not an integer, though: a Block that is an integer CLASS is constructible from size_t and brings a
-        // full set of operators, which would give every operator on this proxy two equally good readings. A
-        // strong index type is not an xstd::integer -- it has no signed/unsigned pair -- so the exclusion costs
-        // this conversion nothing it was meant to serve. The same pairing as random_access.hpp, kept in step
-        // with it. [design.md#uint128-support]
         template<class T>
         [[nodiscard]] constexpr explicit(false) operator T() const noexcept(std::is_nothrow_constructible_v<T, value_type>)  // NOLINT(misc-explicit-constructor)
-                requires std::is_class_v<T> and std::is_convertible_v<value_type, T> and (not xstd::integer<T>)
+                requires std::is_class_v<T> and std::is_convertible_v<value_type, T>
         {
                 return m_idx;
-        }
-
-        // Exact in both operands, so a comparison never reaches for a conversion, and never loses to a templated
-        // one the Block's own namespace contributes by ADL. [design.md#uint128-support]
-        [[nodiscard]] friend constexpr auto operator==(bidirectional_bit_reference lhs, bidirectional_bit_reference rhs) noexcept
-                -> bool
-        {
-                return lhs.m_idx == rhs.m_idx;
-        }
-
-        [[nodiscard]] friend constexpr auto operator==(bidirectional_bit_reference lhs, value_type rhs) noexcept
-                -> bool
-        {
-                return lhs.m_idx == rhs;
         }
 
         // fmt's protocol, found by ADL on the proxy: the same value the conversion yields.

--- a/include/xstd/bits/detail/contiguous_bit_container.hpp
+++ b/include/xstd/bits/detail/contiguous_bit_container.hpp
@@ -10,6 +10,7 @@
 #include <xstd/bits/detail/allocator_typedef.hpp>            // allocator_typedef
 #include <xstd/bits/detail/intrin.hpp>                       // countl_zero, countr_zero, popcount
 #include <xstd/bits/detail/pred.hpp>                         // intersects, is_subset_of, not_equal_to
+#include <xstd/bits/detail/shift.hpp>                        // shl, shr
 #include <xstd/ints/concepts/unsigned_integer.hpp>           // unsigned_integer
 #include <xstd/ints/cstdlib/div.hpp>                         // div, div_result
 #include <xstd/ints/limits.hpp>                              // numeric_limits
@@ -89,7 +90,7 @@ private:
 
         // Width zero named, not computed: MSVC folds both ?: arms and answers C4293. [design.md#padding]
         static constexpr auto static_num_unused_bits = has_static_size ? static_num_bits - N : 0UZ;
-        static constexpr auto static_used_bits       = has_static_size and N == 0 ? zero : static_cast<block_type>(ones >> static_num_unused_bits);
+        static constexpr auto static_used_bits       = has_static_size and N == 0 ? zero : shr(ones, static_num_unused_bits);
         static constexpr auto static_unused_bits     = static_cast<block_type>(~static_used_bits);
         static constexpr auto static_has_unused_bits = has_static_size and static_used_bits != ones;
 
@@ -191,7 +192,7 @@ public:
                                 return std::strong_ordering::equal;
                         }
                         auto const offset = detail::bits::countr_zero(diff);
-                        if (detail::bits::intersects(this->m_blocks[index], static_cast<block_type>(unit << offset))) {
+                        if (detail::bits::intersects(this->m_blocks[index], shl(unit, offset))) {
                                 return other.any_above(index, offset) ? std::strong_ordering::less : std::strong_ordering::greater;
                         }
                         return this->any_above(index, offset) ? std::strong_ordering::greater : std::strong_ordering::less;
@@ -211,7 +212,7 @@ public:
                                 return std::strong_ordering::equal;
                         }
                         auto const offset = detail::bits::countr_zero(diff);
-                        return detail::bits::intersects(this->m_blocks[index], static_cast<block_type>(unit << offset))
+                        return detail::bits::intersects(this->m_blocks[index], shl(unit, offset))
                                 ? std::strong_ordering::greater
                                 : std::strong_ordering::less
                         ;
@@ -299,7 +300,7 @@ public:
                 auto const [ index, offset ] = index_offset(n);
                 assert(index < num_blocks());
                 if (offset == 0UZ or index == last_block()) {
-                        return static_cast<block_type>(m_blocks[index] >> offset);
+                        return shr(m_blocks[index], offset);
                 }
                 return straddled_block(index, bits_per_block - offset, offset);
         }
@@ -313,12 +314,12 @@ public:
                 auto const bits = static_cast<block_type>(value & mask);
 
                 // Each step lands back in block_type: a promoted operand feeding the next bitwise operator is what bugprone-signed-bitwise reads. [design.md#block-writes]
-                auto const low_kept = static_cast<block_type>(m_blocks[index] & static_cast<block_type>(~static_cast<block_type>(mask << offset)));
-                m_blocks[index] = static_cast<block_type>(low_kept | static_cast<block_type>(bits << offset));
+                auto const low_kept = static_cast<block_type>(m_blocks[index] & static_cast<block_type>(~shl(mask, offset)));
+                m_blocks[index] = static_cast<block_type>(low_kept | shl(bits, offset));
                 if (offset != 0UZ and index != last_block()) {
                         auto const shift = bits_per_block - offset;
-                        auto const high_kept = static_cast<block_type>(m_blocks[index + 1UZ] & static_cast<block_type>(~static_cast<block_type>(mask >> shift)));
-                        m_blocks[index + 1UZ] = static_cast<block_type>(high_kept | static_cast<block_type>(bits >> shift));
+                        auto const high_kept = static_cast<block_type>(m_blocks[index + 1UZ] & static_cast<block_type>(~shr(mask, shift)));
+                        m_blocks[index + 1UZ] = static_cast<block_type>(high_kept | shr(bits, shift));
                 }
                 erase_unused();
         }
@@ -400,13 +401,13 @@ public:
                         return size();
                 }
                 if constexpr (has_static_size and static_num_blocks == 1) {
-                        if (auto const block = static_cast<block_type>(m_blocks[0] >> n); block != zero) {
+                        if (auto const block = shr(m_blocks[0], n); block != zero) {
                                 return n + detail::bits::countr_zero(block);
                         }
                 } else if constexpr (has_static_size and static_num_blocks == 2) {
                         // Indexed, not branched: an if cost 10 instructions at -O3. [design.md#two-block-case]
                         auto const [ index, offset ] = index_offset(n);
-                        if (auto const block = static_cast<block_type>(m_blocks[index] >> offset); block != zero) {
+                        if (auto const block = shr(m_blocks[index], offset); block != zero) {
                                 return n + detail::bits::countr_zero(block);
                         }
                         if (index == 0 and m_blocks[1] != zero) {
@@ -415,7 +416,7 @@ public:
                 } else {
                         // No offset != 0 guard: >> 0 is the identity. [design.md#offset-guards]
                         auto [ index, offset ] = index_offset(n);
-                        if (auto const block = static_cast<block_type>(m_blocks[index] >> offset); block != zero) {
+                        if (auto const block = shr(m_blocks[index], offset); block != zero) {
                                 return n + detail::bits::countr_zero(block);
                         }
                         ++index;
@@ -446,11 +447,11 @@ public:
                 assert(any());
                 --n;
                 if constexpr (has_static_size and static_num_blocks == 1) {
-                        return n - detail::bits::countl_zero(static_cast<block_type>(m_blocks[0] << (left_bit - n)));
+                        return n - detail::bits::countl_zero(shl(m_blocks[0], left_bit - n));
                 } else if constexpr (has_static_size and static_num_blocks == 2) {
                         // Naming the fallback block removes the general path's start-index guard. [design.md#offset-guards]
                         auto const [ index, offset ] = index_offset(n);
-                        if (auto const block = static_cast<block_type>(m_blocks[index] << (left_bit - offset)); block != zero) {
+                        if (auto const block = shl(m_blocks[index], left_bit - offset); block != zero) {
                                 return n - detail::bits::countl_zero(block);
                         }
                         // Reaching here at index 0 would break the precondition the general path asserts instead.
@@ -460,7 +461,7 @@ public:
                 } else {
                         auto [ index, offset ] = index_offset(n);
                         if (auto const reverse_offset = left_bit - offset; reverse_offset != 0) {
-                                if (auto const block = static_cast<block_type>(m_blocks[index] << reverse_offset); block != zero) {
+                                if (auto const block = shl(m_blocks[index], reverse_offset); block != zero) {
                                         return n - detail::bits::countl_zero(block);
                                 }
                                 --index;
@@ -550,7 +551,7 @@ public:
                 assert(is_valid(n));
                 if constexpr (has_static_size and static_num_blocks == 1) {
                         // m_blocks[0] <<= n narrows the promoted int back to a block_type implicitly, which -fsanitize=implicit-conversion aborts on once a bit shifts out.
-                        m_blocks[0] = static_cast<block_type>(m_blocks[0] << n);
+                        m_blocks[0] = shl(m_blocks[0], n);
                 } else {
                         auto const [ n_blocks, L_shift ] = xstd::div(n, bits_per_block);
                         // Restated because GCC drops the range through xstd::div. [design.md#gcc-array-bounds]
@@ -563,7 +564,7 @@ public:
                                         // Read one block lower than the destination: the splice of [i - n_blocks - 1, i - n_blocks]. [design.md#the-funnel-shift]
                                         m_blocks[i] = straddled_block(i - n_blocks - 1UZ, L_shift, R_shift);
                                 }
-                                m_blocks[n_blocks] = static_cast<block_type>(m_blocks[0] << L_shift);
+                                m_blocks[n_blocks] = shl(m_blocks[0], L_shift);
                         }
                         std::ranges::fill_n(std::ranges::begin(m_blocks), static_cast<std::ptrdiff_t>(n_blocks), zero);
                 }
@@ -577,7 +578,7 @@ public:
                 assert(is_valid(n));
                 if constexpr (has_static_size and static_num_blocks == 1) {
                         // m_blocks[0] >>= n narrows the promoted int back to a block_type implicitly, which -fsanitize=implicit-conversion instruments.
-                        m_blocks[0] = static_cast<block_type>(m_blocks[0] >> n);
+                        m_blocks[0] = shr(m_blocks[0], n);
                 } else {
                         auto const [ n_blocks, R_shift ] = xstd::div(n, bits_per_block);
                         // See operator<<=: the same bound, for the same reason.
@@ -590,7 +591,7 @@ public:
                                         // Which is word_at(i * bits_per_block + n), reached without recomputing the division. [design.md#the-funnel-shift]
                                         m_blocks[i] = straddled_block(i + n_blocks, L_shift, R_shift);
                                 }
-                                m_blocks[last_block() - n_blocks] = static_cast<block_type>(m_blocks[last_block()] >> R_shift);
+                                m_blocks[last_block() - n_blocks] = shr(m_blocks[last_block()], R_shift);
                         }
                         std::ranges::fill_n(std::ranges::prev(std::ranges::end(m_blocks), static_cast<std::ptrdiff_t>(n_blocks)), static_cast<std::ptrdiff_t>(n_blocks), zero);
                 }
@@ -701,8 +702,8 @@ public:
         {
                 auto const offset = size() % bits_per_block;
                 if (offset != 0UZ) {
-                        m_blocks[last_block()] |= static_cast<block_type>(value << offset);
-                        m_blocks.push_back(static_cast<block_type>(value >> (bits_per_block - offset)));
+                        m_blocks[last_block()] |= shl(value, offset);
+                        m_blocks.push_back(shr(value, bits_per_block - offset));
                 } else if (size() != 0UZ) {
                         m_blocks.push_back(value);
                 } else {
@@ -956,7 +957,7 @@ private:
                 -> bool
         {
                 assert(not test((index * bits_per_block) + offset));
-                if (static_cast<block_type>(m_blocks[index] >> offset) != zero) {
+                if (shr(m_blocks[index], offset) != zero) {
                         return true;
                 }
                 if constexpr (has_static_size and static_num_blocks == 1) {
@@ -988,8 +989,8 @@ private:
                 assert(0UZ < R_shift and R_shift < bits_per_block);
                 assert(index + 1UZ < num_blocks());
                 return static_cast<block_type>(
-                        static_cast<block_type>(m_blocks[index + 1UZ] << L_shift) |
-                        static_cast<block_type>(m_blocks[index] >> R_shift)
+                        shl(m_blocks[index + 1UZ], L_shift) |
+                        shr(m_blocks[index], R_shift)
                 );
         }
 
@@ -1006,7 +1007,7 @@ private:
         {
                 for (auto pos = n; pos < n + len; pos += bits_per_block) {
                         auto const count = std::ranges::min(bits_per_block, n + len - pos);
-                        f(pos, count == bits_per_block ? ones : static_cast<block_type>(static_cast<block_type>(unit << count) - unit));
+                        f(pos, count == bits_per_block ? ones : static_cast<block_type>(shl(unit, count) - unit));
                 }
         }
 
@@ -1029,7 +1030,7 @@ private:
         [[nodiscard]] constexpr auto used_bits() const noexcept
                 -> block_type
         {
-                return size() == 0 ? zero : static_cast<block_type>(ones >> ((num_blocks() * bits_per_block) - size()));
+                return size() == 0 ? zero : shr(ones, (num_blocks() * bits_per_block) - size());
         }
 
         [[nodiscard]] constexpr auto is_valid(std::size_t n [[maybe_unused]]) const noexcept
@@ -1062,7 +1063,7 @@ private:
                 -> std::pair<block_reference_t<decltype(self)>, block_type>
         {
                 auto const [ index, offset ] = index_offset(n);
-                return { std::forward<decltype(self)>(self).m_blocks[index], static_cast<block_type>(unit << offset) };
+                return { std::forward<decltype(self)>(self).m_blocks[index], shl(unit, offset) };
         }
 
         constexpr auto erase_unused() noexcept

--- a/include/xstd/bits/detail/hash.hpp
+++ b/include/xstd/bits/detail/hash.hpp
@@ -6,6 +6,7 @@
 #ifndef XSTD_BITS_DETAIL_HASH_HPP
 #define XSTD_BITS_DETAIL_HASH_HPP
 
+#include <xstd/bits/detail/shift.hpp> // shl, shr
 #include <xstd/bits/bit_traits.hpp>            // block_readable, count, find_first, find_next
 #include <boost/hash2/fnv1a.hpp>               // fnv1a_64
 #include <boost/hash2/get_integral_result.hpp> // get_integral_result
@@ -25,7 +26,7 @@ constexpr auto hash_append_block(Hash& h, Flavor const& f, Block b)
         constexpr auto half = static_cast<unsigned>(std::numeric_limits<std::uint64_t>::digits);
         if constexpr (std::numeric_limits<Block>::digits > std::numeric_limits<std::uint64_t>::digits) {
                 boost::hash2::hash_append(h, f, static_cast<std::uint64_t>(b));
-                boost::hash2::hash_append(h, f, static_cast<std::uint64_t>(b >> half));
+                boost::hash2::hash_append(h, f, static_cast<std::uint64_t>(shr(b, half)));
         } else {
                 boost::hash2::hash_append(h, f, b);
         }

--- a/include/xstd/bits/detail/intrin.hpp
+++ b/include/xstd/bits/detail/intrin.hpp
@@ -6,29 +6,39 @@
 #ifndef XSTD_BITS_DETAIL_INTRIN_HPP
 #define XSTD_BITS_DETAIL_INTRIN_HPP
 
+#include <xstd/ints/bit.hpp>                       // countl_zero, countr_zero, popcount
 #include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer
-#include <bit>                                     // countl_zero, countr_zero, popcount
 #include <cstddef>                                 // size_t
 
-// The seam: constrained on xstd::unsigned_integer but forwarding to <bit>, so an xstd::popcount lands as a change of body, not interface.
+// The seam, now closed on the xstd side. It was always constrained on xstd::unsigned_integer, an OPEN concept
+// that a 128-bit integer class can join; it forwarded to <bit>, whose domain is std::unsigned_integral, a CLOSED
+// one that no class can. Every such Block therefore satisfied the interface and then failed inside the body.
+// xstd::popcount and friends are that same domain plus an overload per integer class, so this is the change of
+// body the seam was left open for: MSVC's std::_Unsigned128, absl::uint128 and boost::int128::uint128 become
+// usable Blocks, and the built-ins keep forwarding to <bit> unchanged. [design.md#uint128-support]
+//
+// The qualified call binds at THIS definition, so a Block's overload must be declared before this header is
+// parsed. The overloads for the built-ins arrive with <xstd/ints/bit.hpp> above; an integer class carries its
+// own beside the header that introduces it, so a translation unit reaching for one includes that ext header
+// first. The test tree does it in test/block_types.hpp, ahead of every container header.
 namespace xstd::detail::bits {
 
 [[nodiscard]] constexpr auto countl_zero(xstd::unsigned_integer auto block) noexcept
         -> std::size_t
 {
-        return static_cast<std::size_t>(std::countl_zero(block));
-} 
+        return static_cast<std::size_t>(xstd::countl_zero(block));
+}
 
 [[nodiscard]] constexpr auto countr_zero(xstd::unsigned_integer auto block) noexcept
         -> std::size_t
 {
-        return static_cast<std::size_t>(std::countr_zero(block));
-}   
+        return static_cast<std::size_t>(xstd::countr_zero(block));
+}
 
 [[nodiscard]] constexpr auto popcount(xstd::unsigned_integer auto block) noexcept
         -> std::size_t
 {
-        return static_cast<std::size_t>(std::popcount(block));
+        return static_cast<std::size_t>(xstd::popcount(block));
 }
 
 }       // namespace xstd::detail::bits

--- a/include/xstd/bits/detail/pred.hpp
+++ b/include/xstd/bits/detail/pred.hpp
@@ -10,15 +10,17 @@
 
 namespace xstd::detail::bits {
 
-// The cast is load-bearing for an integer-class Block. Returning lhs & rhs copy-initializes the bool, which
-// takes an IMPLICIT conversion, and a 128-bit integer class offers only an explicit operator bool. The two
-// predicates below never needed it: not and != both reach bool by a contextual conversion, which an explicit
-// operator satisfies. [design.md#uint128-support]
+// Compared against a zero Block rather than converted to a bool, which is the question the name asks: a
+// conversion leaves the reader to translate "true" back into "has a bit in common". Zero is spelled as
+// contiguous_bit_container spells it. The one spelling that does not work is returning lhs & rhs bare, which
+// copy-initializes the bool and so takes an IMPLICIT conversion, where a 128-bit integer class offers only an
+// explicit operator bool; the two predicates below reach bool contextually, which an explicit operator
+// satisfies. [design.md#uint128-support]
 template<xstd::unsigned_integer Block>
 [[nodiscard]] constexpr auto intersects(Block lhs, Block rhs) noexcept
         -> bool
 {
-        return static_cast<bool>(lhs & rhs);
+        return (lhs & rhs) != static_cast<Block>(0);
 }   
 
 template<xstd::unsigned_integer Block>

--- a/include/xstd/bits/detail/pred.hpp
+++ b/include/xstd/bits/detail/pred.hpp
@@ -10,11 +10,15 @@
 
 namespace xstd::detail::bits {
 
+// The cast is load-bearing for an integer-class Block. Returning lhs & rhs copy-initializes the bool, which
+// takes an IMPLICIT conversion, and a 128-bit integer class offers only an explicit operator bool. The two
+// predicates below never needed it: not and != both reach bool by a contextual conversion, which an explicit
+// operator satisfies. [design.md#uint128-support]
 template<xstd::unsigned_integer Block>
 [[nodiscard]] constexpr auto intersects(Block lhs, Block rhs) noexcept
         -> bool
 {
-        return lhs & rhs;
+        return static_cast<bool>(lhs & rhs);
 }   
 
 template<xstd::unsigned_integer Block>

--- a/include/xstd/bits/detail/random_access.hpp
+++ b/include/xstd/bits/detail/random_access.hpp
@@ -180,7 +180,13 @@ public:
         // names its Block among its template arguments, so the Block's namespace is an associated one and ADL
         // brings in whatever templated comparisons it declares -- Boost.Int128 declares exactly such a set.
         // These two are exact in both operands and win outright, which is what keeps the proxy
-        // equality_comparable and std::ranges::equal working over it. [design.md#uint128-support]
+        // equality_comparable and std::ranges::equal working over it.
+        //
+        // Only here, and not on bidirectional.hpp's set proxy, which needs none of this: its value_type is a
+        // position rather than a bit, a set over an integer-class Block already worked, and giving it the same
+        // pair broke comparing two DIFFERENT instantiations of it -- which is how a view named on the adaptor
+        // is compared against one deduced from the storage, at a Block as ordinary as uint64_t.
+        // [design.md#uint128-support]
         [[nodiscard]] friend constexpr auto operator==(random_access_bit_reference lhs, random_access_bit_reference rhs) noexcept
                 -> bool
         {

--- a/include/xstd/bits/detail/random_access.hpp
+++ b/include/xstd/bits/detail/random_access.hpp
@@ -6,14 +6,15 @@
 #ifndef XSTD_BITS_DETAIL_RANDOM_ACCESS_HPP
 #define XSTD_BITS_DETAIL_RANDOM_ACCESS_HPP
 
-#include <xstd/bits/bit_traits.hpp> // bit_storage, bit_traits
-#include <cassert>                  // assert
-#include <compare>                  // strong_ordering
-#include <concepts>                 // same_as
-#include <cstddef>                  // ptrdiff_t, size_t
-#include <format>                   // formatter
-#include <iterator>                 // random_access_iterator_tag
-#include <type_traits>              // is_class_v, is_const_v, is_convertible_v, is_nothrow_constructible_v, remove_const_t
+#include <xstd/bits/bit_traits.hpp>       // bit_storage, bit_traits
+#include <xstd/ints/concepts/integer.hpp> // integer
+#include <cassert>                        // assert
+#include <compare>                        // strong_ordering
+#include <concepts>                       // same_as
+#include <cstddef>                        // ptrdiff_t, size_t
+#include <format>                         // formatter
+#include <iterator>                       // random_access_iterator_tag
+#include <type_traits>                    // is_class_v, is_const_v, is_convertible_v, is_nothrow_constructible_v, remove_const_t
 
 // The iterator is the primitive: a pointer and a position, reaching the bits through Traits alone. [design.md#the-iterator-is-the-primitive]
 // The sequence reading's pair, named after the category its iterator models; the set reading's is bidirectional.hpp.
@@ -160,11 +161,36 @@ public:
                 return Traits::at(*m_ptr, m_idx);
         }
 
+        // Not to an integer, though, however class-shaped it is. A Block that is an integer CLASS -- MSVC's
+        // std::_Unsigned128, absl::uint128, boost::int128::uint128 -- is constructible from bool and brings a
+        // full set of operators, so without this exclusion every operator on a proxy has two equally good
+        // readings: convert both sides to bool, or convert both sides to the Block. That ambiguity is not
+        // confined to ==; it takes ! and every other operator the integer class declares with it, which is why
+        // the exclusion belongs here on the conversion rather than on each operator in turn. The proxy stands
+        // for one bit, and a bit is not an integer. [design.md#uint128-support]
         template<class T>
         [[nodiscard]] constexpr explicit(false) operator T() const noexcept(std::is_nothrow_constructible_v<T, value_type>)  // NOLINT(misc-explicit-constructor)
-                requires std::is_class_v<T> and std::is_convertible_v<value_type, T>
+                requires std::is_class_v<T> and std::is_convertible_v<value_type, T> and (not xstd::integer<T>)
         {
                 return Traits::at(*m_ptr, m_idx);
+        }
+
+        // Exact matches, so a comparison never reaches for a conversion. The exclusion above stops the proxy
+        // becoming the Block, but it cannot stop the Block's own operators from being CANDIDATES: the proxy
+        // names its Block among its template arguments, so the Block's namespace is an associated one and ADL
+        // brings in whatever templated comparisons it declares -- Boost.Int128 declares exactly such a set.
+        // These two are exact in both operands and win outright, which is what keeps the proxy
+        // equality_comparable and std::ranges::equal working over it. [design.md#uint128-support]
+        [[nodiscard]] friend constexpr auto operator==(random_access_bit_reference lhs, random_access_bit_reference rhs) noexcept
+                -> bool
+        {
+                return static_cast<value_type>(lhs) == static_cast<value_type>(rhs);
+        }
+
+        [[nodiscard]] friend constexpr auto operator==(random_access_bit_reference lhs, value_type rhs) noexcept
+                -> bool
+        {
+                return static_cast<value_type>(lhs) == rhs;
         }
 
         // const-qualified and returning a const reference, the proxy shape P2321R2 gave std::vector<bool>::reference.

--- a/include/xstd/bits/detail/shift.hpp
+++ b/include/xstd/bits/detail/shift.hpp
@@ -16,23 +16,31 @@
 //
 // Said once here rather than at each of the two dozen shift sites: a cast repeated that many times is a cast
 // that will be forgotten at the next one, and forgetting it breaks only the integer-class Blocks, on only the
-// builds that have them -- which is how the first count of these sites came out too low. The narrowing cast back to Block is the other half of every one of those sites, so it
-// belongs here too. Named shl/shr because this header's callers already use std::shift_left and
-// std::shift_right for the range algorithms. [design.md#uint128-support]
+// builds that have them -- which is how the first count of these sites came out too low. The narrowing cast
+// back to Block is the other half of every one of those sites, so it belongs here too. Named shl/shr because
+// this header's callers already use std::shift_left and std::shift_right for the range algorithms.
+// [design.md#uint128-support]
+//
+// int and not unsigned, and the two checks that govern this leave no third option, both measured:
+// absl::uint128 declares one shift, operator<<(uint128, int), so an unsigned count reaches it by a
+// signedness-changing conversion and -Wsign-conversion rejects that, while an int count is a signed operand of
+// a bitwise operator and bugprone-signed-bitwise rejects THAT. The type's own operator decides which one is
+// right, and the count is a bit position within one block, so the signedness the check objects to cannot be
+// reached. [design.md#clang-tidy-false-positives]
 namespace xstd::detail::bits {
 
 template<xstd::unsigned_integer Block>
 [[nodiscard]] constexpr auto shl(Block block, std::size_t n) noexcept
         -> Block
 {
-        return static_cast<Block>(block << static_cast<int>(n));
+        return static_cast<Block>(block << static_cast<int>(n));  // NOLINT(bugprone-signed-bitwise)
 }
 
 template<xstd::unsigned_integer Block>
 [[nodiscard]] constexpr auto shr(Block block, std::size_t n) noexcept
         -> Block
 {
-        return static_cast<Block>(block >> static_cast<int>(n));
+        return static_cast<Block>(block >> static_cast<int>(n));  // NOLINT(bugprone-signed-bitwise)
 }
 
 }       // namespace xstd::detail::bits

--- a/include/xstd/bits/detail/shift.hpp
+++ b/include/xstd/bits/detail/shift.hpp
@@ -1,0 +1,40 @@
+//          Copyright Rein Halbersma 2014-2026.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef XSTD_BITS_DETAIL_SHIFT_HPP
+#define XSTD_BITS_DETAIL_SHIFT_HPP
+
+#include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer
+#include <cstddef>                                 // size_t
+
+// A shift count reaches a Block as int, not as the size_t the containers count positions in. A builtin Block
+// takes it either way, but an integer CLASS declares its shift with a fixed parameter -- absl::uint128's is
+// int -- so a size_t narrows there and -Wconversion rejects it. Every count in this library is a bit position
+// within one block, so it is always far inside int's range.
+//
+// Said once here rather than at each of the two dozen shift sites: a cast repeated that many times is a cast
+// that will be forgotten at the next one, and forgetting it breaks only the integer-class Blocks, on only the
+// builds that have them -- which is how the first count of these sites came out too low. The narrowing cast back to Block is the other half of every one of those sites, so it
+// belongs here too. Named shl/shr because this header's callers already use std::shift_left and
+// std::shift_right for the range algorithms. [design.md#uint128-support]
+namespace xstd::detail::bits {
+
+template<xstd::unsigned_integer Block>
+[[nodiscard]] constexpr auto shl(Block block, std::size_t n) noexcept
+        -> Block
+{
+        return static_cast<Block>(block << static_cast<int>(n));
+}
+
+template<xstd::unsigned_integer Block>
+[[nodiscard]] constexpr auto shr(Block block, std::size_t n) noexcept
+        -> Block
+{
+        return static_cast<Block>(block >> static_cast<int>(n));
+}
+
+}       // namespace xstd::detail::bits
+
+#endif // XSTD_BITS_DETAIL_SHIFT_HPP

--- a/include/xstd/bits/sequence_adaptor.hpp
+++ b/include/xstd/bits/sequence_adaptor.hpp
@@ -10,6 +10,7 @@
 #include <xstd/bits/detail/allocator_typedef.hpp> // allocator_typedef, no_typedef
 #include <xstd/bits/detail/hash.hpp>              // hash_append_bits, std_hash
 #include <xstd/bits/detail/intrin.hpp>            // countr_zero, popcount
+#include <xstd/bits/detail/shift.hpp>             // shl, shr
 #include <xstd/bits/detail/random_access.hpp>     // random_access_bit_iterator, random_access_bit_reference
 #include <xstd/bits/ownership.hpp>                // owned_bits_t, owned_storage, owned_traits_t, owner_of, ownership, owns
 #include <boost/container_hash/is_range.hpp>      // is_range
@@ -44,7 +45,7 @@ template<class Block>
 {
         constexpr auto digits = static_cast<std::size_t>(std::numeric_limits<Block>::digits);
         // No shift by digits, which is undefined: a full word is every bit, spelled without one.
-        return count == digits ? static_cast<Block>(~Block{}) : static_cast<Block>(static_cast<Block>(Block{1} << count) - Block{1});
+        return count == digits ? static_cast<Block>(~Block{}) : static_cast<Block>(detail::bits::shl(Block{1}, count) - Block{1});
 }
 
 // Continue unless the functor says otherwise: a void functor always continues, a bool one says. What the set
@@ -84,7 +85,7 @@ constexpr auto walk_words(Bits const& c, std::size_t offset, std::size_t size, F
                 auto const count = std::ranges::min(digits, size - k);
                 auto const word = detail::bits::word_at<Traits>(c, offset + k);
                 for (auto n = 0UZ; n < count; ++n) {
-                        if (not invoke_continues(f, (static_cast<block_type>(word >> n) & block_type{1}) != block_type{})) {
+                        if (not invoke_continues(f, (detail::bits::shr(word, n) & block_type{1}) != block_type{})) {
                                 return;
                         }
                 }
@@ -890,7 +891,7 @@ private:
                 auto n = 0UZ;
                 for (auto&& e : rg) {
                         if (static_cast<value_type>(e)) {
-                                word |= static_cast<block_type>(block_type{1} << n);
+                                word |= detail::bits::shl(block_type{1}, n);
                         }
                         if (++n == digits) {
                                 m_bits.append(word);

--- a/include/xstd/bits/set_adaptor.hpp
+++ b/include/xstd/bits/set_adaptor.hpp
@@ -10,6 +10,7 @@
 #include <xstd/bits/detail/bidirectional.hpp> // bidirectional_bit_iterator, bidirectional_bit_reference
 #include <xstd/bits/detail/hash.hpp>          // hash_append_bits, hash_append_positions, std_hash
 #include <xstd/bits/detail/intrin.hpp>        // countl_zero, countr_zero
+#include <xstd/bits/detail/shift.hpp>         // shl, shr
 #include <xstd/bits/ownership.hpp>            // owned_bits_t, owned_storage, owned_traits_t, owner_of, ownership, owns
 #include <boost/container_hash/is_range.hpp>  // is_range
 #include <boost/hash2/hash_append.hpp>        // hash_append_tag
@@ -95,7 +96,7 @@ constexpr auto walk_blocks_descending(Bits const& c, F& f)
                         if (not invoke_continues(f, (digits * index) + offset)) {
                                 return;
                         }
-                        block = static_cast<block_type>(block ^ static_cast<block_type>(block_type{1} << offset));
+                        block = static_cast<block_type>(block ^ detail::bits::shl(block_type{1}, offset));
                 }
         }
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -174,6 +174,78 @@ if(unmirrored_headers)
     )
 endif()
 
+# The two 128-bit integer CLASSES the Block lists reach for, and neither a hard dependency: test/ext_int128.hpp
+# detects each by __has_include, so a build without them simply drops it from the lists. They earn their place
+# by being classes -- the builtin xstd::uint128 is a scalar the compiler lowers, while an operator on these is
+# an ordinary function returning class type, which is what catches a container assuming a Block is a scalar.
+# The declarations and tags mirror xstd-ints, which adapts the same two. [design.md#uint128-support]
+option(${project_option_prefix}_TEST_FETCH_BOOST_INT128 "Fetch Boost.Int128 when no installed copy is found" ON)
+
+find_package(boost_int128 CONFIG QUIET)
+if(NOT TARGET Boost::int128 AND ${project_option_prefix}_TEST_FETCH_BOOST_INT128)
+    include(FetchContent)
+    FetchContent_Declare(
+        boost_int128
+        GIT_REPOSITORY https://github.com/cppalliance/int128.git
+        # A development commit rather than v3.1.0, the types having lost their
+        # _t suffix after it was cut. Pinned rather than tracking a branch.
+        GIT_TAG f437657470186b79f1f314bc2c76a112bcc2529c
+        # Its CMakeLists.txt builds its own test suite under BUILD_TESTING;
+        # naming a subdirectory without one keeps the download and drops that.
+        SOURCE_SUBDIR does-not-exist
+    )
+    FetchContent_MakeAvailable(boost_int128)
+
+    # SYSTEM because these headers are not written to this project's warning
+    # level; an installed copy arrives as an imported target, already system.
+    add_library(Boost::int128 INTERFACE IMPORTED)
+    target_include_directories(Boost::int128 SYSTEM INTERFACE ${boost_int128_SOURCE_DIR}/include)
+endif()
+
+if(TARGET Boost::int128)
+    set(${project_id}_test_boost_int128 Boost::int128)
+else()
+    set(${project_id}_test_boost_int128)
+endif()
+
+option(${project_option_prefix}_TEST_FETCH_ABSL_INT128 "Fetch Abseil when no installed copy is found" ON)
+
+find_package(absl CONFIG QUIET)
+if(NOT TARGET absl::int128 AND ${project_option_prefix}_TEST_FETCH_ABSL_INT128)
+    include(FetchContent)
+    FetchContent_Declare(
+        absl_int128
+        GIT_REPOSITORY https://github.com/abseil/abseil-cpp.git
+        # A release tag, the spelling of these two types being settled.
+        GIT_TAG 20260526.0
+        # Abseil's CMakeLists.txt configures the whole library and its tests;
+        # naming a subdirectory without one keeps the download and drops that,
+        # leaving the one translation unit these two types need.
+        SOURCE_SUBDIR does-not-exist
+    )
+    FetchContent_MakeAvailable(absl_int128)
+
+    # int128.cc is where operator/ and operator% live on a platform with no
+    # 128-bit intrinsic to lower them to; the rest of the type is header-only.
+    add_library(${project_id}_test_absl_int128_lib STATIC ${absl_int128_SOURCE_DIR}/absl/numeric/int128.cc)
+
+    # Built to the same standard as the tests, not to the compiler's default:
+    # absl::strong_ordering is std::strong_ordering only where the library
+    # sees C++20's <compare>, and the two spellings must not meet at a link.
+    target_compile_features(${project_id}_test_absl_int128_lib PUBLIC cxx_std_${${project_option_prefix}_CXX_STANDARD})
+
+    # SYSTEM for the reason Boost::int128's includes are.
+    target_include_directories(${project_id}_test_absl_int128_lib SYSTEM PUBLIC ${absl_int128_SOURCE_DIR})
+
+    add_library(absl::int128 ALIAS ${project_id}_test_absl_int128_lib)
+endif()
+
+if(TARGET absl::int128)
+    set(${project_id}_test_absl_int128 absl::int128)
+else()
+    set(${project_id}_test_absl_int128)
+endif()
+
 set(current_include_dir ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 # The workloads the containers are exercised against, shared with benchmark/ and deliberately outside include/:
@@ -201,6 +273,8 @@ foreach(t ${targets})
         Boost::unit_test_framework
         fmt::fmt
         range-v3::range-v3
+        ${${project_id}_test_boost_int128}
+        ${${project_id}_test_absl_int128}
     )
 
     target_include_directories(

--- a/test/include/test/block_types.hpp
+++ b/test/include/test/block_types.hpp
@@ -42,6 +42,9 @@ concept block_basis =
 // MSVC half outright, and true in dialects where <bit> still declines the type. The converse is not worth
 // asserting either: a basis a flag declines to use costs coverage, not correctness. [design.md#uint128-support]
 static_assert(not has_uint128 or block_basis<xstd::uint128>);
+#ifdef TEST_HAS_MSVC_INT128
+static_assert(block_basis<xstd::uint128>);
+#endif
 #ifdef TEST_HAS_ABSL_INT128
 static_assert(block_basis<absl::uint128>);
 #endif
@@ -77,18 +80,23 @@ using narrow_word_types = std::tuple
 // untested across one.
 //
 // Second, and only since the blocks reach xstd's bit basis rather than <bit> directly: a Block need not be a
-// scalar at all. All three below are 128 bits wide and none of them promotes, but xstd::uint128 is the
-// compiler's own extension on every target except an MSVC-ABI one, where it is std::_Unsigned128 -- and these
-// two are CLASSES outright, whose operators are ordinary functions returning class type. That is what catches
-// a container quietly assuming a Block is a scalar, as detail/pred.hpp's intersects did: it returned lhs & rhs
-// into a bool, which a builtin converts to implicitly and an integer class, whose operator bool is explicit,
-// does not. [design.md#uint128-support]
+// scalar at all. Each entry below is 128 bits wide and none of them promotes, but only the first is a scalar,
+// and only where xstd::uint128 is the compiler's builtin -- on an MSVC-ABI target that same spelling is
+// std::_Unsigned128, and it joins absl's and boost's as a CLASS, whose operators are ordinary functions
+// returning class type. That is what catches a container quietly assuming a Block is a scalar, as
+// detail/pred.hpp's intersects did: it returned lhs & rhs into a bool, which a builtin converts to implicitly
+// and an integer class, whose operator bool is explicit, does not.
+//
+// The classes are here and NOT in word_types on purpose. word_types feeds graded_extents, which every suite
+// grades over, including the std_bitset and std_set comparisons whose per-type cost is superlinear -- and whose
+// helpers assume a Block is a std integral. These two suites pay a static_assert or one linear pass per type,
+// which is what a class-typed Block can be afforded in today. [design.md#uint128-support]
 //
 // One optional tuple per candidate, concatenated: a type that is not there contributes an empty tuple, so the
 // list composes without any comma bookkeeping between the #ifs.
 using wide_word_types = decltype(std::tuple_cat(
         std::declval<std::tuple<
-#ifdef TEST_HAS_UINT128
+#if defined(TEST_HAS_UINT128) || defined(TEST_HAS_MSVC_INT128)
                 xstd::uint128
 #endif
         >>(),

--- a/test/include/test/block_types.hpp
+++ b/test/include/test/block_types.hpp
@@ -6,15 +6,48 @@
 #ifndef TEST_BLOCK_TYPES_HPP
 #define TEST_BLOCK_TYPES_HPP
 
-#include <test/uint128.hpp>     // TEST_HAS_UINT128, uint128
-#include <xstd/ints/limits.hpp> // numeric_limits
-#include <cstddef>              // size_t
-#include <cstdint>              // uint8_t, uint16_t, uint32_t, uint64_t
-#include <tuple>                // tuple, tuple_cat
-#include <utility>              // declval
+#include <test/ext_int128.hpp>                     // TEST_HAS_ABSL_INT128, TEST_HAS_BOOST_INT128, uint128
+#include <test/uint128.hpp>                        // TEST_HAS_UINT128, uint128
+#include <xstd/ints/bit.hpp>                       // countl_zero, countr_zero, popcount
+#include <xstd/ints/concepts/unsigned_integer.hpp> // unsigned_integer
+#include <xstd/ints/limits.hpp>                    // numeric_limits
+#include <cstddef>                                 // size_t
+#include <cstdint>                                 // uint8_t, uint16_t, uint32_t, uint64_t
+#include <tuple>                                   // tuple, tuple_cat
+#include <utility>                                 // declval
 
 // The Block models and the extents worth instantiating, assembled once: all three containers take <class Block, size_t N>.
 namespace test {
+
+// What the containers actually require of a Block: the concept they constrain on, and the three functions
+// detail/intrin.hpp calls. std::unsigned_integral is NOT this question and must not stand in for it -- it is
+// closed, so every 128-bit integer CLASS fails it while serving as a Block perfectly well.
+//
+// This must be spelled HERE, below every adapter include above, and not in a header of its own. The calls are
+// qualified, so their candidates are the overloads visible at THIS point; an adapter included afterwards
+// declares its overload too late to be one, and the concept would then answer false for a type that works. A
+// separate header could not be relied on to land below them, the include lists here being sorted by name.
+template<class Block>
+concept block_basis =
+        xstd::unsigned_integer<Block> and
+        requires (Block x) {
+                xstd::countl_zero(x);
+                xstd::countr_zero(x);
+                xstd::popcount(x);
+        };
+
+// Each flag held to the basis it claims. An implication, NOT an equality: where a flag is on, the basis is
+// really there. The equality this replaces asked std::unsigned_integral of xstd::uint128, which is the wrong
+// question in both directions -- false for every integer class that works as a Block, so it would deny the
+// MSVC half outright, and true in dialects where <bit> still declines the type. The converse is not worth
+// asserting either: a basis a flag declines to use costs coverage, not correctness. [design.md#uint128-support]
+static_assert(not has_uint128 or block_basis<xstd::uint128>);
+#ifdef TEST_HAS_ABSL_INT128
+static_assert(block_basis<absl::uint128>);
+#endif
+#ifdef TEST_HAS_BOOST_INT128
+static_assert(block_basis<boost::int128::uint128>);
+#endif
 
 template<class Block>
 inline constexpr auto digits_v = static_cast<std::size_t>(xstd::numeric_limits<Block>::digits);
@@ -35,19 +68,41 @@ using narrow_word_types = std::tuple
 <       std::uint8_t
 >;
 
-// The widest Block, which crosses a boundary for a reason the narrow ones cannot cover. uint8_t and uint16_t
-// PROMOTE: every block operation on them has an int intermediate, and the code masks back from it. uint32_t
-// upward do not promote at all, so the block's own width is the whole modulus and there is nothing to mask
-// back from. Straddling at narrow words alone therefore exercises only the promoting path, and "the arithmetic
-// follows digits, not the carrier" holds within a block but is untested across one. xstd::uint128 is the
-// extreme of the non-promoting half and the only Block whose carrier is not a standard unsigned integer type,
-// so it is the one worth the extents. [design.md#uint128-support]
-using wide_word_types = std::tuple
-<
+// The widest Blocks, which cross a boundary for two reasons the narrow ones cannot cover.
+//
+// First, promotion. uint8_t and uint16_t PROMOTE: every block operation on them has an int intermediate, and
+// the code masks back from it. uint32_t upward do not promote at all, so the block's own width is the whole
+// modulus and there is nothing to mask back from. Straddling at narrow words alone therefore exercises only
+// the promoting path, and "the arithmetic follows digits, not the carrier" holds within a block but is
+// untested across one.
+//
+// Second, and only since the blocks reach xstd's bit basis rather than <bit> directly: a Block need not be a
+// scalar at all. All three below are 128 bits wide and none of them promotes, but xstd::uint128 is the
+// compiler's own extension on every target except an MSVC-ABI one, where it is std::_Unsigned128 -- and these
+// two are CLASSES outright, whose operators are ordinary functions returning class type. That is what catches
+// a container quietly assuming a Block is a scalar, as detail/pred.hpp's intersects did: it returned lhs & rhs
+// into a bool, which a builtin converts to implicitly and an integer class, whose operator bool is explicit,
+// does not. [design.md#uint128-support]
+//
+// One optional tuple per candidate, concatenated: a type that is not there contributes an empty tuple, so the
+// list composes without any comma bookkeeping between the #ifs.
+using wide_word_types = decltype(std::tuple_cat(
+        std::declval<std::tuple<
 #ifdef TEST_HAS_UINT128
-        xstd::uint128
+                xstd::uint128
 #endif
->;
+        >>(),
+        std::declval<std::tuple<
+#ifdef TEST_HAS_ABSL_INT128
+                absl::uint128
+#endif
+        >>(),
+        std::declval<std::tuple<
+#ifdef TEST_HAS_BOOST_INT128
+                boost::int128::uint128
+#endif
+        >>()
+));
 
 // One block's worth of extents: empty, a single bit, and exactly one full block -- the same cost at any width.
 template<template<class, std::size_t> class C, class Block>

--- a/test/include/test/block_types.hpp
+++ b/test/include/test/block_types.hpp
@@ -41,6 +41,12 @@ concept block_basis =
 // question in both directions -- false for every integer class that works as a Block, so it would deny the
 // MSVC half outright, and true in dialects where <bit> still declines the type. The converse is not worth
 // asserting either: a basis a flag declines to use costs coverage, not correctness. [design.md#uint128-support]
+// The two flags name the SAME spelling, xstd::uint128, and mean different types by it: the builtin on one kind
+// of target, std::_Unsigned128 on the other. Exactly one can hold, and asking only what the compiler supports
+// is what breaks that -- clang-cl has __int128 and still gets the class. Both on would put a class into
+// word_types, which every suite grades over, and name the type twice in the wide list below.
+static_assert(not (has_uint128 and has_msvc_int128));
+
 static_assert(not has_uint128 or block_basis<xstd::uint128>);
 #ifdef TEST_HAS_MSVC_INT128
 static_assert(block_basis<xstd::uint128>);

--- a/test/include/test/ext_int128.hpp
+++ b/test/include/test/ext_int128.hpp
@@ -1,0 +1,41 @@
+//          Copyright Rein Halbersma 2014-2026.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef TEST_EXT_INT128_HPP
+#define TEST_EXT_INT128_HPP
+
+// The two 128-bit integer classes xstd knows only through an adapter, as Blocks. Neither is a hard dependency,
+// so each is detected by the header it would bring rather than by a macro the build must remember to pass --
+// which is how xstd-ints detects the same two. They are worth a Block each for a reason the builtin cannot
+// cover: the builtin is a scalar the compiler lowers, while these are CLASSES whose operators are ordinary
+// functions, so they are the ones that catch a container assuming a Block is a scalar. [design.md#uint128-support]
+#if __has_include(<absl/numeric/int128.h>)
+#include <xstd/ints/ext/absl/int128.hpp> // IWYU pragma: export; uint128
+#define TEST_HAS_ABSL_INT128
+#endif
+
+#if __has_include(<boost/int128.hpp>)
+#include <xstd/ints/ext/boost/int128.hpp> // IWYU pragma: export; uint128
+#define TEST_HAS_BOOST_INT128
+#endif
+
+// As with test/uint128.hpp, the check that these are really usable Blocks lives in test/block_types.hpp.
+namespace test {
+
+#ifdef TEST_HAS_ABSL_INT128
+inline constexpr bool has_absl_int128 = true;
+#else
+inline constexpr bool has_absl_int128 = false;
+#endif
+
+#ifdef TEST_HAS_BOOST_INT128
+inline constexpr bool has_boost_int128 = true;
+#else
+inline constexpr bool has_boost_int128 = false;
+#endif
+
+} // namespace test
+
+#endif // TEST_EXT_INT128_HPP

--- a/test/include/test/ext_int128.hpp
+++ b/test/include/test/ext_int128.hpp
@@ -6,11 +6,24 @@
 #ifndef TEST_EXT_INT128_HPP
 #define TEST_EXT_INT128_HPP
 
-// The two 128-bit integer classes xstd knows only through an adapter, as Blocks. Neither is a hard dependency,
-// so each is detected by the header it would bring rather than by a macro the build must remember to pass --
-// which is how xstd-ints detects the same two. They are worth a Block each for a reason the builtin cannot
-// cover: the builtin is a scalar the compiler lowers, while these are CLASSES whose operators are ordinary
-// functions, so they are the ones that catch a container assuming a Block is a scalar. [design.md#uint128-support]
+// The 128-bit integer CLASSES, as Blocks. They are worth a Block each for a reason the builtin cannot cover:
+// the builtin is a scalar the compiler lowers, while an operator on these is an ordinary function returning
+// class type, so they are the ones that catch a container assuming a Block is a scalar.
+//
+// Three of them, and the first needs no dependency at all: on an MSVC-ABI target (clang-cl included)
+// xstd::uint128 IS the Microsoft STL's std::_Unsigned128, a class, and xstd-ints gives it the same bit basis it
+// gives the other two. That is the one 128-bit Block those targets have -- test/uint128.hpp's flag names the
+// builtin, which they do not have -- so it is named here, beside the classes it behaves like rather than beside
+// the builtin it shares a spelling with.
+//
+// Abseil's and Boost's are not hard dependencies, so each is detected by the header it would bring rather than
+// by a macro the build must remember to pass -- which is how xstd-ints detects the same two.
+// [design.md#uint128-support]
+#ifdef _MSC_VER
+#include <xstd/ints/cstdint/int128.hpp> // IWYU pragma: export; uint128
+#define TEST_HAS_MSVC_INT128
+#endif
+
 #if __has_include(<absl/numeric/int128.h>)
 #include <xstd/ints/ext/absl/int128.hpp> // IWYU pragma: export; uint128
 #define TEST_HAS_ABSL_INT128
@@ -23,6 +36,12 @@
 
 // As with test/uint128.hpp, the check that these are really usable Blocks lives in test/block_types.hpp.
 namespace test {
+
+#ifdef TEST_HAS_MSVC_INT128
+inline constexpr bool has_msvc_int128 = true;
+#else
+inline constexpr bool has_msvc_int128 = false;
+#endif
 
 #ifdef TEST_HAS_ABSL_INT128
 inline constexpr bool has_absl_int128 = true;

--- a/test/include/test/uint128.hpp
+++ b/test/include/test/uint128.hpp
@@ -12,13 +12,16 @@
 // __SIZEOF_INT128__ and, to reach <bit> through that concept, a dialect that is not __STRICT_ANSI__ -- the tests
 // compile as gnu++, which is why CMAKE_CXX_EXTENSIONS is ON.
 //
-// Deliberately NOT true on an MSVC-ABI target, where xstd::uint128 is the Microsoft STL's std::_Unsigned128
-// instead. That is a usable Block, and test/ext_int128.hpp carries it as one -- but it is a CLASS, so it is not
-// std::is_integral, not std::is_unsigned, and not something <bit> will take. This flag feeds word_types, which
-// every suite grades over, and test/src/bits/block/type_traits.cpp, which asserts exactly those std traits of
-// each word. Both are right to assume a builtin; the integer classes belong in the wide list beside absl's and
-// boost's, which is where all three of them are. [design.md#uint128-support]
-#if defined(__SIZEOF_INT128__) && !defined(__STRICT_ANSI__)
+// And NOT an MSVC-ABI target, which is the term that is easy to drop and costly to lose. There xstd::uint128 is
+// the Microsoft STL's std::_Unsigned128 whatever the compiler can do, and clang-cl is the case that proves the
+// point: it is clang, so it HAS __int128 and defines __SIZEOF_INT128__, but the alias still names the class. A
+// gate that asks only what the compiler supports therefore goes true there and puts a class into word_types,
+// which every suite grades over, and into test/src/bits/block/type_traits.cpp, which asserts std::is_integral,
+// std::is_unsigned and <bit> of each word. Both are right to assume a builtin, and neither survives a class.
+//
+// std::_Unsigned128 is a usable Block all the same; test/ext_int128.hpp carries it as one, beside Abseil's and
+// Boost's, which is what it behaves like. [design.md#uint128-support]
+#if defined(__SIZEOF_INT128__) && !defined(__STRICT_ANSI__) && !defined(_MSC_VER)
 #define TEST_HAS_UINT128
 #endif
 

--- a/test/include/test/uint128.hpp
+++ b/test/include/test/uint128.hpp
@@ -7,23 +7,26 @@
 #define TEST_UINT128_HPP
 
 #include <xstd/ints/cstdint/int128.hpp> // IWYU pragma: export; uint128
-#include <concepts>                     // unsigned_integral
 
-// A built-in wide enough to name, a library mode that will own it, and a <bit> that will take it.
-#if defined(__SIZEOF_INT128__) && !defined(__STRICT_ANSI__) && !defined(_MSC_VER)
+// Where xstd::uint128 is a usable Block. Two spellings, because xstd::uint128 is two different types: on an
+// MSVC-ABI target (clang-cl included) it is the Microsoft STL's std::_Unsigned128, a CLASS, which is always
+// there and now carries its own bit basis; everywhere else it is the compiler's own extension, which needs
+// __SIZEOF_INT128__ and, to reach <bit> through std::unsigned_integral, a dialect that is not __STRICT_ANSI__ --
+// the tests compile as gnu++, which is why CMAKE_CXX_EXTENSIONS is ON. [design.md#uint128-support]
+#if defined(_MSC_VER) || (defined(__SIZEOF_INT128__) && !defined(__STRICT_ANSI__))
 #define TEST_HAS_UINT128
 #endif
 
-// Three terms for three facts, and the assert below holds the macro to the concept no #if can spell. [design.md#uint128-support]
 namespace test {
 
+// The macro as a value, for the lists that cannot ask an #if. What holds it honest -- that where it is on the
+// Block really has a basis -- is asserted in test/block_types.hpp, with the same check for the other two. It
+// cannot be asserted here: it has to be written below EVERY adapter, and this header is only one of them.
 #ifdef TEST_HAS_UINT128
 inline constexpr bool has_uint128 = true;
 #else
 inline constexpr bool has_uint128 = false;
 #endif
-
-static_assert(has_uint128 == std::unsigned_integral<xstd::uint128>);
 
 } // namespace test
 

--- a/test/include/test/uint128.hpp
+++ b/test/include/test/uint128.hpp
@@ -8,20 +8,25 @@
 
 #include <xstd/ints/cstdint/int128.hpp> // IWYU pragma: export; uint128
 
-// Where xstd::uint128 is a usable Block. Two spellings, because xstd::uint128 is two different types: on an
-// MSVC-ABI target (clang-cl included) it is the Microsoft STL's std::_Unsigned128, a CLASS, which is always
-// there and now carries its own bit basis; everywhere else it is the compiler's own extension, which needs
-// __SIZEOF_INT128__ and, to reach <bit> through std::unsigned_integral, a dialect that is not __STRICT_ANSI__ --
-// the tests compile as gnu++, which is why CMAKE_CXX_EXTENSIONS is ON. [design.md#uint128-support]
-#if defined(_MSC_VER) || (defined(__SIZEOF_INT128__) && !defined(__STRICT_ANSI__))
+// Where xstd::uint128 is the compiler's own 128-bit BUILTIN: a scalar, and a std::unsigned_integral. It needs
+// __SIZEOF_INT128__ and, to reach <bit> through that concept, a dialect that is not __STRICT_ANSI__ -- the tests
+// compile as gnu++, which is why CMAKE_CXX_EXTENSIONS is ON.
+//
+// Deliberately NOT true on an MSVC-ABI target, where xstd::uint128 is the Microsoft STL's std::_Unsigned128
+// instead. That is a usable Block, and test/ext_int128.hpp carries it as one -- but it is a CLASS, so it is not
+// std::is_integral, not std::is_unsigned, and not something <bit> will take. This flag feeds word_types, which
+// every suite grades over, and test/src/bits/block/type_traits.cpp, which asserts exactly those std traits of
+// each word. Both are right to assume a builtin; the integer classes belong in the wide list beside absl's and
+// boost's, which is where all three of them are. [design.md#uint128-support]
+#if defined(__SIZEOF_INT128__) && !defined(__STRICT_ANSI__)
 #define TEST_HAS_UINT128
 #endif
 
 namespace test {
 
 // The macro as a value, for the lists that cannot ask an #if. What holds it honest -- that where it is on the
-// Block really has a basis -- is asserted in test/block_types.hpp, with the same check for the other two. It
-// cannot be asserted here: it has to be written below EVERY adapter, and this header is only one of them.
+// Block really has a basis -- is asserted in test/block_types.hpp, with the same check for the integer classes.
+// It cannot be asserted here: it has to be written below EVERY adapter, and this header is only one of them.
 #ifdef TEST_HAS_UINT128
 inline constexpr bool has_uint128 = true;
 #else

--- a/test/src/bits/bitset.cpp
+++ b/test/src/bits/bitset.cpp
@@ -7,7 +7,7 @@
 #include <xstd/bits/bit_set_view.hpp>   // bit_set_view
 #include <xstd/bits/bitset.hpp>         // bitset
 #include <xstd/bits/bitset_adaptor.hpp> // swap
-#include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
+#include <boost/test/unit_test.hpp>     // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL
 #include <concepts>                     // regular, totally_ordered
 #include <tuple>                        // tuple_cat
 #include <type_traits>                  // is_nothrow_*, is_trivially_*
@@ -54,6 +54,38 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(IsTrivial, T, Types)
         static_assert(    std::is_trivially_copy_assignable_v<T>);
         static_assert(    std::is_trivially_move_constructible_v<T>);
         static_assert(    std::is_trivially_move_assignable_v<T>);
+}
+
+// all() and none() read the blocks pairwise -- the whole ones against the last block's mask -- and their two
+// arms short-circuit, so each needs a value that stops at the first block and one that runs past it. At the
+// wide extents the only callers were set()'s and reset()'s own asserts, which by construction can see the true
+// answer alone. One bit short of full and one bit above empty, at every position in turn, asks both arms both
+// ways; the pass is linear in the width, which is what this suite spends per type.
+BOOST_AUTO_TEST_CASE_TEMPLATE(AllAnyAndNoneReadEveryBlock, T, Types)
+{
+        auto b = T();
+        BOOST_CHECK(     b.none());
+        BOOST_CHECK(not  b.any() );
+        BOOST_CHECK_EQUAL(b.all(), b.size() == 0);
+
+        b.set();
+        BOOST_CHECK(     b.all() );
+        BOOST_CHECK_EQUAL(b.any(),  b.size() != 0);
+        BOOST_CHECK_EQUAL(b.none(), b.size() == 0);
+
+        for (auto i = 0UZ; i < b.size(); ++i) {
+                b.set();
+                b.reset(i);
+                BOOST_CHECK(not b.all() );
+                BOOST_CHECK_EQUAL(b.any(),  b.size() != 1);
+                BOOST_CHECK_EQUAL(b.none(), b.size() == 1);
+
+                b.reset();
+                b.set(i);
+                BOOST_CHECK(    b.any() );
+                BOOST_CHECK(not b.none());
+                BOOST_CHECK_EQUAL(b.all(), b.size() == 1);
+        }
 }
 
 // The proxy from bit_span: b[i] = b[j] must move the bit, not the proxy, or swap breaks.

--- a/test/src/bits/detail/random_access.cpp
+++ b/test/src/bits/detail/random_access.cpp
@@ -4,8 +4,10 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 
 #include <test/block_types.hpp>                      // graded_extents
+#include <test/ext_int128.hpp>                       // TEST_HAS_ABSL_INT128, TEST_HAS_BOOST_INT128, uint128
 #include <test/minimal_traits.hpp>                   // minimal_traits
 #include <test/value_reference.hpp>                  // value_reference
+#include <xstd/bits/bit_array.hpp>                   // basic_bit_array
 #include <xstd/bits/bit_span.hpp>                    // bit_span
 #include <xstd/bits/bit_traits.hpp>                  // bit_traits
 #include <xstd/bits/detail/contiguous_bit_array.hpp> // contiguous_bit_array
@@ -16,7 +18,7 @@
 #include <boost/test/unit_test.hpp>                  // BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_CHECK, BOOST_CHECK_EQUAL
 #include <algorithm>                                 // equal, ranges::reverse, ranges::sort, reverse, sort
 #include <bitset>                                    // bitset
-#include <concepts>                                  // convertible_to, random_access_iterator, same_as, sortable
+#include <concepts>                                  // convertible_to, equality_comparable, random_access_iterator, same_as, sortable
 #include <cstddef>                                   // ptrdiff_t, size_t
 #include <cstdint>                                   // uint64_t
 #include <iterator>                                  // iter_move, next, prev, reverse_iterator
@@ -373,6 +375,50 @@ BOOST_AUTO_TEST_CASE(TheValueArrivesByImplicitConversion)
         BOOST_CHECK(a[5] == true);
         BOOST_CHECK(a[4] == false);
 }
+
+// ... but not to an integer, however class-shaped it is. The conversion above takes any class constructible
+// from bool, and a 128-bit integer class is one -- which would give every operator on a proxy two equally good
+// readings, convert both sides to bool or convert both sides to the Block, and cost the proxy the
+// equality_comparable that ranges::equal needs. A bit is not an integer, and this pins that both ways: the
+// conversion is gone and the comparison still works. Nothing here is reachable with a builtin Block, which is
+// the whole reason the integer classes are worth a Block. [design.md#uint128-support]
+#if defined(TEST_HAS_ABSL_INT128) || defined(TEST_HAS_BOOST_INT128)
+BOOST_AUTO_TEST_CASE(AProxyNeverBecomesAnIntegerBlock)
+{
+#ifdef TEST_HAS_ABSL_INT128
+        {
+                using B = xstd::basic_bit_array<absl::uint128, 257>;
+                static_assert(    std::convertible_to<B::reference, bool>);
+                static_assert(not std::convertible_to<B::reference, absl::uint128>);
+                static_assert(std::equality_comparable<B::reference>);
+                static_assert(std::equality_comparable<B::const_reference>);
+
+                auto a = B();
+                a[0] = true;
+                a[256] = true;
+                BOOST_CHECK(a[0] == a[256]);
+                BOOST_CHECK(a[0] != a[1]);
+                BOOST_CHECK(a[0] == true);
+        }
+#endif
+#ifdef TEST_HAS_BOOST_INT128
+        {
+                using B = xstd::basic_bit_array<boost::int128::uint128, 257>;
+                static_assert(    std::convertible_to<B::reference, bool>);
+                static_assert(not std::convertible_to<B::reference, boost::int128::uint128>);
+                static_assert(std::equality_comparable<B::reference>);
+                static_assert(std::equality_comparable<B::const_reference>);
+
+                auto a = B();
+                a[0] = true;
+                a[256] = true;
+                BOOST_CHECK(a[0] == a[256]);
+                BOOST_CHECK(a[0] != a[1]);
+                BOOST_CHECK(a[0] == true);
+        }
+#endif
+}
+#endif
 
 // & . * and * . & are both the identity, which makes the pair a round trip rather than two one-way conversions.
 BOOST_AUTO_TEST_CASE(TheProxyPairRoundTrips)

--- a/test/src/bits/detail/random_access.cpp
+++ b/test/src/bits/detail/random_access.cpp
@@ -382,9 +382,25 @@ BOOST_AUTO_TEST_CASE(TheValueArrivesByImplicitConversion)
 // equality_comparable that ranges::equal needs. A bit is not an integer, and this pins that both ways: the
 // conversion is gone and the comparison still works. Nothing here is reachable with a builtin Block, which is
 // the whole reason the integer classes are worth a Block. [design.md#uint128-support]
-#if defined(TEST_HAS_ABSL_INT128) || defined(TEST_HAS_BOOST_INT128)
+#if defined(TEST_HAS_MSVC_INT128) || defined(TEST_HAS_ABSL_INT128) || defined(TEST_HAS_BOOST_INT128)
 BOOST_AUTO_TEST_CASE(AProxyNeverBecomesAnIntegerBlock)
 {
+#ifdef TEST_HAS_MSVC_INT128
+        {
+                using B = xstd::basic_bit_array<xstd::uint128, 257>;
+                static_assert(    std::convertible_to<B::reference, bool>);
+                static_assert(not std::convertible_to<B::reference, xstd::uint128>);
+                static_assert(std::equality_comparable<B::reference>);
+                static_assert(std::equality_comparable<B::const_reference>);
+
+                auto a = B();
+                a[0] = true;
+                a[256] = true;
+                BOOST_CHECK(a[0] == a[256]);
+                BOOST_CHECK(a[0] != a[1]);
+                BOOST_CHECK(a[0] == true);
+        }
+#endif
 #ifdef TEST_HAS_ABSL_INT128
         {
                 using B = xstd::basic_bit_array<absl::uint128, 257>;


### PR DESCRIPTION
## What

`detail/bits/intrin` was constrained on `xstd::unsigned_integer` — an **open** concept a 128-bit integer class can join — and forwarded to `<bit>`, whose domain is `std::unsigned_integral`, a **closed** one that no class can. Every such Block satisfied the interface and then failed inside the body. It now forwards to `xstd::countl_zero` and friends, which are that same domain plus one overload per integer class.

That makes three more Block families usable as the widest Block: MSVC's `std::_Unsigned128` (so every MSVC-ABI target, clang-cl included), `absl::uint128`, and `boost::int128::uint128`. The builtins keep forwarding to `<bit>` unchanged.

## Three defects only a class-typed Block can reach

None is visible to any builtin, which is exactly why the integer classes earn a Block.

**`pred`'s `intersects`** returned `lhs & rhs` into a `bool`. That copy-initializes, so it needs an *implicit* conversion, and an integer class offers only an explicit `operator bool`. Its two neighbours never needed the cast — `not` and `!=` both reach `bool` by a *contextual* conversion.

**The sequence proxy** in `random_access.hpp` converted implicitly to any class constructible from its `value_type`. An integer class is one, so every operator on it acquired a second equally good reading — both sides to `bool`, or both sides to the Block — costing it `equality_comparable` and with it `ranges::equal`. The conversion now excludes `xstd::integer`: a proxy stands for one bit, and a bit is not an integer. That alone was not enough, and the reason took measuring: a proxy names its Block among its **template arguments**, so the Block's namespace is *associated* and ADL contributes whatever templated comparisons it declares — Boost.Int128 declares exactly such a set. It therefore also declares comparisons exact in both operands.

**Every Block shift counts in `int`.** A count is a `size_t`, and an integer class declares its shift with a fixed parameter (`absl::uint128`'s is `int`), so it narrows — `-Werror=conversion` on GCC, C4244/C4267 on MSVC. `detail/bits::shl`/`shr` say it once rather than at each of the **27** sites; a first sweep found sixteen, because the count is often an expression and a site only reports where a class-typed Block reaches it.

## Two facts, two flags

`TEST_HAS_UINT128` names the compiler's 128-bit **builtin** — a scalar, and a `std::unsigned_integral`. It feeds `word_types`, which every suite grades over, and `block/type_traits.cpp`, which asserts exactly those `std` traits of each word. Both are right to assume a builtin.

`TEST_HAS_MSVC_INT128` names what an MSVC-ABI target has instead: `std::_Unsigned128` under the same `xstd::uint128` spelling, a usable Block but a class. **Widening the one flag to cover both was a mistake** — it put a class-typed Block into `word_types` and so into every suite at once, breaking sixteen MSVC targets including the superlinear `std_bitset`/`std_set` comparisons. The three integer classes now sit together in `wide_word_types`, feeding only the two suites that pay a `static_assert` or one linear pass per type.

The assert beside each flag is an **implication**: where the flag is on, the basis is really there. The equality it replaces asked `std::unsigned_integral`, wrong in both directions — false for every integer class that works as a Block, true in dialects where `<bit>` still declines the type. (The same trap xstd-ints hit in `e3cd251`.)

## What I changed and then reverted

The set proxy in `bidirectional.hpp` was given the same exact comparisons as the sequence proxy, for symmetry. **Nothing had failed there** — a set over an integer-class Block already worked, since that proxy stands for a position and its `value_type` is `size_t`. The symmetry broke a case with no integer class in it at all: `ranges::equal` over **two different instantiations** of that proxy, which is how `bit_set_view<B>` is compared against the view deduced from `B`, at Block = `uint64_t`. Reverted, with the reason recorded in `design.md` and in the surviving comment.

One consequence worth recording: `xstd::popcount(block)` is a dependent call by a **qualified** name, and ADL does not apply to qualified names — its candidates are those visible where it is *written*, not where it is instantiated. That is why `test::block_basis` sits in `block_types.hpp` below every adapter rather than in a header of its own, which the alphabetical include lists would have sorted above them.

## Dependencies

Abseil's and Boost's are optional, detected by `__has_include` exactly as xstd-ints detects them, with the same CMake declarations and pinned tags; a build without them drops them from the lists rather than failing. MSVC's needs no dependency at all. The xstd-ints pin moves to `a053f05`, the commit carrying the bit basis, in both places `CMakeLists.txt` says it must move together.

## Verification

Neither test TU compiles in full in this container — libstdc++ 13 has no `std::from_range_t`, Clang 18 has no alias-template CTAD. So I measured against a **pristine copy of `HEAD`**, sweeping all 42 test sources both ways: **exactly one file differs, `bit_array.cpp` 59 → 83**, the pre-existing clang-18 `constexpr if` limitation at its unchanged 2-per-type rate over the 12 added instantiations.

Clean under `-Wall -Wextra -Wconversion`:

- All 39 types of both containers — every position set one at a time through every block boundary and cleared back down, count checked at each step; the top position in a partial block; equality, hashing, iteration-vs-subscript. **0 failures.**
- `basic_bitset` and `basic_bit_array` over `absl::uint128` and `boost::int128::uint128` at one block and at three; `basic_bit_static_set` over both across the 128-bit boundary.
- All three dependency configurations: with deps (39 types), without (27, the `__has_include` fallback), and strict-ANSI with deps (30, the empty-first-tuple case).
- `clang-tidy` and header self-sufficiency clean on every changed header.

A new `AProxyNeverBecomesAnIntegerBlock` case pins the sequence-proxy rule both ways, so a future change cannot quietly reintroduce the ambiguity.

**Two guards this container cannot run** — `cmake` configure dies on `find_package(boost_hash2 CONFIG REQUIRED)` before either is reached — are now replicated as a script and checked before pushing: the installed HEADERS file set (in both directions) and the public-header mirror. Missing the first is what turned the whole matrix red at configure on one commit.

Still resting on CI: `_Unsigned128` as a Block in the two suites that now carry it. The last MSVC run reached **1 error and 0 warnings** — that single error being the reverted set-proxy change — with every other target built, including the four `std_set` ones the flag split was meant to recover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPyqkBWNUZaT5VUx6bbxW1