### PR TITLE
Repin xstd-ints and delete the commented-out at and set primitives

### DIFF
--- a/.github/workflows/consumption.yml
+++ b/.github/workflows/consumption.yml
@@ -28,5 +28,5 @@ jobs:
       vcpkg: true
       # The revisions CMakeLists.txt pins; install(EXPORT) cannot export a FetchContent build tree, so installed dependencies are required.
       dependency_repos: |
-        https://github.com/rhalbersma/xstd-ints.git a053f05062a12657eeaef47637b8c0be4483fc35
+        https://github.com/rhalbersma/xstd-ints.git 388a06b83b877012e4b0fa139c1e44afc0e74ff2
         https://github.com/rhalbersma/xstd-misc.git 64c9735cce92be35a174cb56d9df253da5275ff0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ if(NOT xstd-ints_FOUND)
         xstd-ints
         GIT_REPOSITORY https://github.com/rhalbersma/xstd-ints.git
         # Pinned to a commit on xstd-ints' main, not a branch head; move consumption.yml's dependency_repos with it.
-        GIT_TAG a053f05062a12657eeaef47637b8c0be4483fc35
+        GIT_TAG 388a06b83b877012e4b0fa139c1e44afc0e74ff2
     )
     FetchContent_MakeAvailable(xstd-ints)
 endif()

--- a/test/include/test/bitset/primitives.hpp
+++ b/test/include/test/bitset/primitives.hpp
@@ -294,22 +294,6 @@ struct mem_at
                 BOOST_CHECK_EQUAL(self[pos], self.test(pos));                           // [bitset.members]/31
                 BOOST_CHECK_NO_THROW(static_cast<void>(self[pos]));                     // [bitset.members]/32
         }
-
-        // auto operator()(auto& self, std::size_t pos) const
-        // {
-        //         BOOST_CHECK(pos < bs.size());                                       // [bitset.members]/47
-        //         BOOST_CHECK_EQUAL(at(bs, pos), test(bs, pos));                  // [bitset.members]/48
-        //         //BOOST_CHECK_NO_THROW(at(bs, pos));                              // [bitset.members]/49
-        // }
-
-        // auto operator()(auto& self, std::size_t pos, bool val) const
-        // {
-        //         BOOST_CHECK(pos < fn_size(bs));                                 // [bitset.members]/47
-        //         auto src = bs; set(src, pos, val);
-        //         at(bs, pos, val);
-        //         BOOST_CHECK_EQUAL(bs, src);                                     // [bitset.members]/48
-        //         //BOOST_CHECK_NO_THROW(at(bs, pos, val));                         // [bitset.members]/49
-        // }
 };
 
 

--- a/test/src/bits/std_bitset/o1.cpp
+++ b/test/src/bits/std_bitset/o1.cpp
@@ -88,27 +88,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(AtHoldsOverEveryValidPosition, T, Types)
                 on0::empty_set<T>([&](auto const& bs0) {
                         mem_at()(bs0, pos);
                 });
-                // empty_set<T>([&](auto& bs0) {
-                //         mem_at()(bs0, pos);
-                // });
-                // empty_set<T>([&](auto& bs0) {
-                //         mem_at()(bs0, pos, false);
-                // });
-                // empty_set<T>([&](auto& bs0) {
-                //         mem_at()(bs0, pos, true);
-                // });
                 on0::full_set<T>([&](auto const& bsN) {
                         mem_at()(bsN, pos);
                 });
-                // full_set<T>([&](auto& bsN) {
-                //         mem_at()(bsN, pos);
-                // });
-                // full_set<T>([&](auto& bsN) {
-                //         mem_at()(bsN, pos, false);
-                // });
-                // full_set<T>([&](auto& bsN) {
-                //         mem_at()(bsN, pos, true);
-                // });
         });
 }
 


### PR DESCRIPTION
Two unrelated bits of housekeeping.

## Repin xstd-ints

`CMakeLists.txt` and `.github/workflows/consumption.yml` pinned xstd-ints at `a053f05`, which predates the comment sweep that has since merged there. Both now point at `388a06b83b877012e4b0fa139c1e44afc0e74ff2`.

The xstd-misc pin needs no change: it already sits at `64c9735cce92be35a174cb56d9df253da5275ff0`, the tip of that repository's main.

## Delete the commented-out at and set primitives

Four commented-out `BOOST_CHECK` blocks, 34 lines across two files:

- `test/include/test/bitset/primitives.hpp` — two commented-out `operator()` overloads
- `test/src/bits/std_bitset/o1.cpp` — the `AtHoldsOverEveryValidPosition` body's disabled half

These are not disabled tests. They call an `at(bs, pos, val)` and a free `set(src, pos, val)` that exist nowhere in the repository, and they name `bs` and `fn_size`, neither of which is in scope. `git log -L` traces them back through `test/include/bitset/primitives.hpp`, a path that no longer exists — they are a fossil of an API that has since been replaced.

Nothing is lost by removing them. The non-const `at(pos) -> reference` overload they appear to guard is exercised by live tests, and the 100% line and branch coverage gate is green without them.

The diff removes no executable line: `git diff -U0` reports zero removed lines that are not a comment or blank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPyqkBWNUZaT5VUx6bbxW1


---
_Generated by [Claude Code](https://claude.ai/code/session_01LPyqkBWNUZaT5VUx6bbxW1)_