### PR TITLE
Decouple the raw bitset arms from ext, and call the blocks a range

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ target_sources(
         include/xstd/bits/detail/contiguous_bit_container.hpp
         include/xstd/bits/detail/contiguous_bit_inplace_vector.hpp
         include/xstd/bits/detail/contiguous_bit_vector.hpp
-        include/xstd/bits/detail/contiguous_block_container.hpp
+        include/xstd/bits/detail/contiguous_block_range.hpp
         include/xstd/bits/detail/hash.hpp
         include/xstd/bits/detail/intrin.hpp
         include/xstd/bits/dynamic_bitset.hpp

--- a/design.md
+++ b/design.md
@@ -9,9 +9,9 @@ out of. This file holds what has landed.
 
 ## Storage and containers
 
-### contiguous-block-container
+### contiguous-block-range
 
-`contiguous_block_container` asks whether a range **is** blocks: a regular, sized, contiguous, subscriptable
+`contiguous_block_range` asks whether a range **is** blocks: a regular, sized, contiguous, subscriptable
 range of unsigned integers. Regular is what lets `contiguous_bit_container` default its `==` over the width and
 the blocks, in that member order, so two run-time widths part on the width before a block is read. `std::array`
 and `std::vector` both qualify, and so does `std::inplace_vector` — a runtime width over static capacity, for
@@ -40,7 +40,7 @@ asks more of a block than it offers its own user, consuming numbers and yielding
 arithmetic on the way up. That is also why nesting cannot work: a `contiguous_bit_container` will have every
 operator and still no `popcount`, no `digits` and no `- 1`.
 
-The concept has a header of its own at `detail/contiguous_block_container.hpp`: the concept says what a `Blocks` **is**,
+The concept has a header of its own at `detail/contiguous_block_range.hpp`: the concept says what a `Blocks` **is**,
 the container is the vehicle built over it, and a reader asking the first question need not open the 1100 lines
 answering the second. Its includes are `<concepts>`, `<ranges>`, `<cstddef>` and the one xstd-ints concept —
 a leaf. `num_blocks_v` stays behind, being a block-count computation rather than a statement about what a
@@ -120,8 +120,8 @@ containers include only the vehicle it uses -- `bit_array` names `contiguous_bit
 `std::vector`, and the `#ifdef __cpp_lib_inplace_vector` guard sits in the one header that concerns it rather
 than in the common one.
 
-**The name says what it does to its argument.** It takes a `contiguous_block_container` — a range that *is*
-blocks ([contiguous-block-container](#contiguous-block-container)) — and adds the bit interface. In goes
+**The name says what it does to its argument.** It takes a `contiguous_block_range` — a range that *is*
+blocks ([contiguous-block-range](#contiguous-block-range)) — and adds the bit interface. In goes
 storage that answers about blocks, out comes something that answers about bits. Concept and class differ by one
 word, and it is the word that changes. The three aliases follow the same rule: `contiguous_bit_array`,
 `contiguous_bit_vector` and `contiguous_bit_inplace_vector` each name the bit container over one block
@@ -161,7 +161,7 @@ library is actually instantiated over, so an assertion about them is an assertio
 What that gives up is the negative cases a shim isolates one clause at a time, and here three of the four
 survive on ready-made types alone: `std::vector<bool>` is not contiguous, `std::vector<int>` is signed, and
 `std::array<std::bitset<64>, 4>` is the field of bits that is not a number — the one that separates
-`unsigned_integer` from `bitwise_operators` ([contiguous-block-container](#contiguous-block-container)). Only the
+`unsigned_integer` from `bitwise_operators` ([contiguous-block-range](#contiguous-block-range)). Only the
 range-subscript clause has no ready-made counterexample, and it is argued in prose there instead.
 
 `counting_blocks` in `test/src/bits/detail/contiguous_bit_container.cpp` is not an exception to this. It is a
@@ -314,7 +314,7 @@ member, so the landmine #80 recorded -- probing `clear()` on boost and emptying 
 
 `contiguous_bit_inplace_vector<Block, N>` is the third storage: a run-time width under a compile-time capacity
 of `N` bits, behind `__cpp_lib_inplace_vector` until every library in the matrix has it. It needs nothing of its
-own, `std::inplace_vector` satisfying `contiguous_block_container` as it is; `resize`, `reserve` and `push_back`
+own, `std::inplace_vector` satisfying `contiguous_block_range` as it is; `resize`, `reserve` and `push_back`
 past the capacity throw `std::bad_alloc`, as that library specifies.
 
 The adaptors take growth by detection on the storage, never through the trait: growth is a container's
@@ -1541,8 +1541,8 @@ Random access is nevertheless where the ladder stops, and it stops because of th
 `std::contiguous_iterator` requires `iter_reference_t<I>` to be a real `iter_value_t<I>&`, which no proxy is, so
 no reading here is a `contiguous_range` and no iterator here is a `contiguous_iterator`. That is asserted as a
 negative, because it is the one place the bits and the blocks part company: the **blocks** are contiguous and
-`contiguous_block_container` requires precisely that
-([contiguous-block-container](#contiguous-block-container)), while the **bits** are not addressable at all. The
+`contiguous_block_range` requires precisely that
+([contiguous-block-range](#contiguous-block-range)), while the **bits** are not addressable at all. The
 asymmetry is the reason the vehicle keeps its blocks to itself and hands out proxies above it.
 
 The walks stay qualified as `detail::bits::find_next<Traits>(...)` inside `xstd::detail::bits` itself. Dropping
@@ -1835,7 +1835,7 @@ compilers disagree about noticing: clang's `-Wshadow` rejected two such paramete
 silently. If the function has an `n` or an `i`, the constraint uses it.
 
 The same rule reaches concepts, where the argument is the type: see
-[contiguous-block-container](#contiguous-block-container), whose subscript requirement exists because the
+[contiguous-block-range](#contiguous-block-range), whose subscript requirement exists because the
 class subscripts and `std::ranges::contiguous_range` does not promise that.
 
 ### the-functor-takes-a-value

--- a/include/xstd/bits/bit_traits.hpp
+++ b/include/xstd/bits/bit_traits.hpp
@@ -366,7 +366,7 @@ concept bit_storage =
 template<class Traits, class Bits>
 concept static_bit_extent = bit_storage<Traits, Bits> and Traits::extent != std::dynamic_extent;
 
-// What the three bit containers answer in their own names, with no trait in between: the INTERSECTION of std::bitset's, boost::dynamic_bitset's and contiguous_bit_container's vocabularies, where contiguous_bit_container provides the UNION of what the three readings ask of it. [design.md#the-common-vocabulary] [design.md#contiguous-block-container]
+// What the three bit containers answer in their own names, with no trait in between: the INTERSECTION of std::bitset's, boost::dynamic_bitset's and contiguous_bit_container's vocabularies, where contiguous_bit_container provides the UNION of what the three readings ask of it. [design.md#the-common-vocabulary] [design.md#contiguous-block-range]
 template<class C>
 concept contiguous_bit_sequence =
         std::regular<C> and

--- a/include/xstd/bits/detail/contiguous_bit_container.hpp
+++ b/include/xstd/bits/detail/contiguous_bit_container.hpp
@@ -8,7 +8,7 @@
 
 #include <xstd/bits/bit_traits.hpp>                          // bit_traits
 #include <xstd/bits/detail/allocator_base_type.hpp>          // allocator_base_type
-#include <xstd/bits/detail/contiguous_block_container.hpp>   // contiguous_block_container
+#include <xstd/bits/detail/contiguous_block_range.hpp>   // contiguous_block_range
 #include <xstd/bits/detail/intrin.hpp>                       // countl_zero, countr_zero, popcount
 #include <xstd/bits/detail/pred.hpp>                         // intersects, is_subset_of, not_equal_to
 #include <xstd/bits/detail/shift.hpp>                        // shl, shr
@@ -43,7 +43,7 @@ inline constexpr auto num_blocks_v = std::ranges::max(
 );
 
 // The one vehicle: it owns the unused-tail invariant, and has no iterators. [design.md#the-one-vehicle]
-template<contiguous_block_container Blocks, std::size_t N = std::dynamic_extent>
+template<contiguous_block_range Blocks, std::size_t N = std::dynamic_extent>
 class contiguous_bit_container : public detail::bits::allocator_base_type<Blocks>
 {
 public:
@@ -90,7 +90,7 @@ private:
         using width_type = std::conditional_t<(alignof(std::size_t) >= alignof(Blocks)), std::size_t, block_type>;
         static_assert(sizeof(width_type) >= sizeof(std::size_t) and alignof(width_type) >= alignof(Blocks));
 
-        // Dynamic widths only; the tag keeps the absent member distinct from any other in an enclosing layout. [design.md#contiguous-block-container]
+        // Dynamic widths only; the tag keeps the absent member distinct from any other in an enclosing layout. [design.md#contiguous-block-range]
         [[XSTD_NO_UNIQUE_ADDRESS]]
         conditional_data_member_t<not has_static_size, width_type, struct size_tag> m_size{};
 
@@ -148,7 +148,7 @@ public:
                 return m_blocks.get_allocator();
         }
 
-        // Memberwise, width first: the unused bits are kept clear, so the blocks compare as the bits do, and a zero width through the one block it still holds. [design.md#contiguous-block-container]
+        // Memberwise, width first: the unused bits are kept clear, so the blocks compare as the bits do, and a zero width through the one block it still holds. [design.md#contiguous-block-range]
         [[nodiscard]] friend constexpr auto operator==(contiguous_bit_container const&, contiguous_bit_container const&) noexcept -> bool = default;
 
         // No operator<=>: contiguous_bit_container is pure storage with no opinion on which reading orders it, so it names all three and picks none. [design.md#two-readings-disagree]
@@ -1042,7 +1042,7 @@ private:
 
 // Nominal, never structural: a storage is ours because this says so, not because its members answer. [design.md#the-trait]
 template<class T> inline constexpr bool is_specialization_of_contiguous_bit_container_v = false;
-template<contiguous_block_container Blocks, std::size_t N> inline constexpr bool is_specialization_of_contiguous_bit_container_v<contiguous_bit_container<Blocks, N>> = true;
+template<contiguous_block_range Blocks, std::size_t N> inline constexpr bool is_specialization_of_contiguous_bit_container_v<contiguous_bit_container<Blocks, N>> = true;
 
 // A view over a const owner names Bits const, which no specialization pattern matches, so the const comes off here and nowhere else. [design.md#ownership-is-not-an-axis]
 template<class T> concept specialization_of_contiguous_bit_container = is_specialization_of_contiguous_bit_container_v<std::remove_const_t<T>>;

--- a/include/xstd/bits/detail/contiguous_block_range.hpp
+++ b/include/xstd/bits/detail/contiguous_block_range.hpp
@@ -3,18 +3,18 @@
 //    (See accompanying file LICENSE_1_0.txt or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef XSTD_BITS_DETAIL_CONTIGUOUS_BLOCK_CONTAINER_HPP
-#define XSTD_BITS_DETAIL_CONTIGUOUS_BLOCK_CONTAINER_HPP
+#ifndef XSTD_BITS_DETAIL_CONTIGUOUS_BLOCK_RANGE_HPP
+#define XSTD_BITS_DETAIL_CONTIGUOUS_BLOCK_RANGE_HPP
 
 #include <xstd/ints/concepts/unsigned_integer.hpp>  // unsigned_integer
 #include <concepts>                                 // regular, same_as
-#include <ranges>                                   // contiguous_range, range_reference_t, range_value_t, sized_range
+#include <ranges>                                   // contiguous_range, range_const_reference_t, range_reference_t, range_value_t, sized_range
 
 namespace xstd::detail::bits {
 
-// Whether a range IS blocks; block_readable asks if a trait hands a container's blocks over. [design.md#contiguous-block-container]
+// Whether a range IS blocks; block_readable asks if a trait hands a container's blocks over. [design.md#contiguous-block-range]
 template<class C>
-concept contiguous_block_container =
+concept contiguous_block_range =
         std::regular<C> and
         std::ranges::sized_range<C> and
         std::ranges::contiguous_range<C> and
@@ -22,11 +22,12 @@ concept contiguous_block_container =
         requires (C& c, C::size_type n) {
                 { c[n] } -> std::same_as<std::ranges::range_reference_t<C>>;
         } and
+        // range_const_reference_t<C>, not range_reference_t<C const>: the latter quietly also asks C const to be a range. [design.md#contiguous-block-range]
         requires (C const& c, C::size_type n) {
-                { c[n] } -> std::same_as<std::ranges::range_reference_t<C const>>;
+                { c[n] } -> std::same_as<std::ranges::range_const_reference_t<C>>;
         }
 ;
 
 }       // namespace xstd::detail::bits
 
-#endif  // XSTD_BITS_DETAIL_CONTIGUOUS_BLOCK_CONTAINER_HPP
+#endif  // XSTD_BITS_DETAIL_CONTIGUOUS_BLOCK_RANGE_HPP

--- a/include/xstd/bits/detail/contiguous_block_range.hpp
+++ b/include/xstd/bits/detail/contiguous_block_range.hpp
@@ -8,7 +8,7 @@
 
 #include <xstd/ints/concepts/unsigned_integer.hpp>  // unsigned_integer
 #include <concepts>                                 // regular, same_as
-#include <ranges>                                   // contiguous_range, range_const_reference_t, range_reference_t, range_value_t, sized_range
+#include <ranges>                                   // contiguous_range, range_reference_t, range_value_t, sized_range
 
 namespace xstd::detail::bits {
 
@@ -22,9 +22,9 @@ concept contiguous_block_range =
         requires (C& c, C::size_type n) {
                 { c[n] } -> std::same_as<std::ranges::range_reference_t<C>>;
         } and
-        // range_const_reference_t<C>, not range_reference_t<C const>: the latter quietly also asks C const to be a range. [design.md#contiguous-block-range]
+        // range_reference_t<C const>, not P2278's range_const_reference_t: libc++ has no such alias, and the two name the same type for every backend this admits. [design.md#contiguous-block-range]
         requires (C const& c, C::size_type n) {
-                { c[n] } -> std::same_as<std::ranges::range_const_reference_t<C>>;
+                { c[n] } -> std::same_as<std::ranges::range_reference_t<C const>>;
         }
 ;
 

--- a/test/include/test/bitset/primitives.hpp
+++ b/test/include/test/bitset/primitives.hpp
@@ -10,9 +10,11 @@
 #include <xstd/bits/bit_set_view.hpp> // view
 #include <xstd/bits/ownership.hpp>    // owned_storage
 #include <boost/test/unit_test.hpp>   // BOOST_CHECK, BOOST_CHECK_EQUAL, BOOST_CHECK_NE, BOOST_CHECK_THROW
+#include <algorithm>                  // all_of, any_of, equal, fold_left
 #include <cstddef>                    // size_t
 #include <functional>                 // hash
 #include <memory>                     // addressof
+#include <ranges>                     // iota, transform
 #include <set>                        // set
 #include <sstream>                    // istringstream, stringstream
 #include <stdexcept>                  // invalid_argument, out_of_range
@@ -338,20 +340,23 @@ struct mem_equal_to
                                 return self[i] == rhs[i];
                         })
                 );                                                              // [bitset.members]/45
-                auto const lhs_view = xstd::bit_set_view(self);
-                auto const rhs_view = xstd::bit_set_view(rhs);
+                // The set reading cross-check is ours to make: a foreign bitset has no view. [design.md#owning-is-ours]
+                if constexpr (requires { xstd::bit_set_view(self); }) {
+                        auto const lhs_view = xstd::bit_set_view(self);
+                        auto const rhs_view = xstd::bit_set_view(rhs);
 #ifdef _MSC_VER
-                BOOST_CHECK_EQUAL(
-                        self == rhs,
-                        std::ranges::equal(
-                                lhs_view.begin(), lhs_view.end(),
-                                rhs_view.begin(), rhs_view.end()
-                        )
-                );
+                        BOOST_CHECK_EQUAL(
+                                self == rhs,
+                                std::ranges::equal(
+                                        lhs_view.begin(), lhs_view.end(),
+                                        rhs_view.begin(), rhs_view.end()
+                                )
+                        );
 #else
-                // range version not working with Visual C++
-                BOOST_CHECK_EQUAL(self == rhs, std::ranges::equal(lhs_view, rhs_view));
+                        // range version not working with Visual C++
+                        BOOST_CHECK_EQUAL(self == rhs, std::ranges::equal(lhs_view, rhs_view));
 #endif
+                }
         }
 };
 
@@ -374,15 +379,18 @@ struct mem_compare_three_way
         template<class X>
         auto operator()(const X& self, const X& rhs) const noexcept
         {
-                auto const lhs_view = xstd::bit_set_view(self);
-                auto const rhs_view = xstd::bit_set_view(rhs);
-                BOOST_CHECK(
-                        (lhs_view <=> rhs_view) ==
-                        std::lexicographical_compare_three_way(
-                                lhs_view.begin(), lhs_view.end(),
-                                rhs_view.begin(), rhs_view.end()
-                        )
-                );
+                // The set ordering is ours to check: a foreign bitset has no view. [design.md#owning-is-ours]
+                if constexpr (requires { xstd::bit_set_view(self); }) {
+                        auto const lhs_view = xstd::bit_set_view(self);
+                        auto const rhs_view = xstd::bit_set_view(rhs);
+                        BOOST_CHECK(
+                                (lhs_view <=> rhs_view) ==
+                                std::lexicographical_compare_three_way(
+                                        lhs_view.begin(), lhs_view.end(),
+                                        rhs_view.begin(), rhs_view.end()
+                                )
+                        );
+                }
                 if constexpr (requires { self <=> rhs; }) {
                         BOOST_CHECK((self <=> rhs) == (bit_string(self) <=> bit_string(rhs)));
                 } else if constexpr (requires { self < rhs; }) {
@@ -435,7 +443,7 @@ struct mem_is_subset_of
                 if constexpr (requires { lhs.is_subset_of(rhs); }) {
                         return lhs.is_subset_of(rhs);
                 } else {
-                        return xstd::bit_set_view(lhs).is_subset_of(xstd::bit_set_view(rhs));
+                        return std::ranges::all_of(std::views::iota(0UZ, lhs.size()), [&](auto i) { return not lhs[i] or rhs[i]; });
                 }
         }
 
@@ -454,7 +462,7 @@ struct mem_is_proper_subset_of
                 if constexpr (requires { lhs.is_proper_subset_of(rhs); }) {
                         return lhs.is_proper_subset_of(rhs);
                 } else {
-                        return xstd::bit_set_view(lhs).is_proper_subset_of(xstd::bit_set_view(rhs));
+                        return std::ranges::all_of(std::views::iota(0UZ, lhs.size()), [&](auto i) { return not lhs[i] or rhs[i]; }) and lhs != rhs;
                 }
         }
 
@@ -496,7 +504,7 @@ struct mem_intersects
                 if constexpr (requires { lhs.intersects(rhs); }) {
                         return lhs.intersects(rhs);
                 } else {
-                        return xstd::bit_set_view(lhs).intersects(xstd::bit_set_view(rhs));
+                        return std::ranges::any_of(std::views::iota(0UZ, lhs.size()), [&](auto i) { return lhs[i] and rhs[i]; });
                 }
         }
 

--- a/test/src/bits/bit_array.cpp
+++ b/test/src/bits/bit_array.cpp
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ItsIteratorIsRandomAccess, T, Types)
         static_assert(std::random_access_iterator<I>);
 }
 
-// Random access is where it stops: the blocks underneath are contiguous, the bits are not addressable, and a proxy reference is what forbids the last rung. [design.md#contiguous-block-container]
+// Random access is where it stops: the blocks underneath are contiguous, the bits are not addressable, and a proxy reference is what forbids the last rung. [design.md#contiguous-block-range]
 BOOST_AUTO_TEST_CASE_TEMPLATE(ItIsNotAContiguousRange, T, Types)
 {
         static_assert(not std::ranges::contiguous_range<T>);

--- a/test/src/bits/detail/contiguous_bit_container.cpp
+++ b/test/src/bits/detail/contiguous_bit_container.cpp
@@ -9,7 +9,7 @@
 #include <xstd/bits/bit_traits.hpp>                           // bit_storage, bit_traits, block_readable, static_bit_extent
 #include <xstd/bits/detail/contiguous_bit_array.hpp>          // contiguous_bit_array
 #include <xstd/bits/detail/contiguous_bit_container.hpp>      // contiguous_bit_container
-#include <xstd/bits/detail/contiguous_block_container.hpp>    // contiguous_block_container
+#include <xstd/bits/detail/contiguous_block_range.hpp>    // contiguous_block_range
 #include <xstd/bits/detail/contiguous_bit_inplace_vector.hpp> // IWYU pragma: keep; contiguous_bit_inplace_vector, named only under TEST_HAS_INPLACE_VECTOR
 #include <xstd/bits/detail/contiguous_bit_vector.hpp>         // contiguous_bit_vector
 #include <boost/test/unit_test.hpp>                           // BOOST_CHECK_EQUAL, BOOST_AUTO_TEST_CASE, BOOST_AUTO_TEST_CASE_TEMPLATE, BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END
@@ -346,17 +346,17 @@ constexpr auto a_run_time_width_is_constexpr()
 
 } // namespace
 
-// Both shipped vehicles satisfy contiguous_block_container: growth is detected where it exists, never required.
+// Both shipped vehicles satisfy contiguous_block_range: growth is detected where it exists, never required.
 BOOST_AUTO_TEST_CASE(ItsStorageIsAContiguousSizedRangeOfUnsignedIntegers)
 {
-        static_assert(xstd::detail::bits::contiguous_block_container<std::array<std::uint8_t, 4>>);
-        static_assert(xstd::detail::bits::contiguous_block_container<std::vector<std::uint64_t>>);
+        static_assert(xstd::detail::bits::contiguous_block_range<std::array<std::uint8_t, 4>>);
+        static_assert(xstd::detail::bits::contiguous_block_range<std::vector<std::uint64_t>>);
 
-        static_assert(not xstd::detail::bits::contiguous_block_container<std::vector<bool>>);      // not a contiguous range
-        static_assert(not xstd::detail::bits::contiguous_block_container<std::vector<int>>);       // nor unsigned integers
+        static_assert(not xstd::detail::bits::contiguous_block_range<std::vector<bool>>);      // not a contiguous range
+        static_assert(not xstd::detail::bits::contiguous_block_range<std::vector<int>>);       // nor unsigned integers
 
-        // The element clause is unsigned_integer and not the wider bitwise_operators, which std::bitset would satisfy: a block is asked for the <bit> intrinsics too, and they are constrained on unsigned_integer. [design.md#contiguous-block-container]
-        static_assert(not xstd::detail::bits::contiguous_block_container<std::array<std::bitset<64>, 4>>);
+        // The element clause is unsigned_integer and not the wider bitwise_operators, which std::bitset would satisfy: a block is asked for the <bit> intrinsics too, and they are constrained on unsigned_integer. [design.md#contiguous-block-range]
+        static_assert(not xstd::detail::bits::contiguous_block_range<std::array<std::bitset<64>, 4>>);
 }
 
 // The semantic half a concept cannot check: a[i] is *(begin(a) + i), the same object and not merely an equal one.
@@ -386,7 +386,7 @@ namespace {
 int g_storage_swaps = 0;
 int g_storage_moves = 0;
 
-// A storage satisfying contiguous_block_container whose swap and moves are distinguishable.
+// A storage satisfying contiguous_block_range whose swap and moves are distinguishable.
 struct counting_blocks
 {
         using size_type = std::size_t;
@@ -752,7 +752,7 @@ BOOST_AUTO_TEST_CASE(AnInplaceVectorIsARunTimeWidthUnderAStaticCapacity)
 {
         using T = xstd::detail::bits::contiguous_bit_inplace_vector<std::uint8_t, 24>;
         static_assert(not T::has_static_size);
-        static_assert(xstd::detail::bits::contiguous_block_container<std::inplace_vector<std::uint8_t, 3>>);
+        static_assert(xstd::detail::bits::contiguous_block_range<std::inplace_vector<std::uint8_t, 3>>);
 
         BOOST_CHECK_EQUAL(sweep(T(17)), 0);
 

--- a/test/src/bits/std_bitset/o0.cpp
+++ b/test/src/bits/std_bitset/o0.cpp
@@ -8,6 +8,7 @@
 #include <test/uint128.hpp>                       // TEST_HAS_UINT128, uint128
 #include <xstd/bits/bitset.hpp>                   // bitset
 #include <xstd/bits/dynamic_bitset.hpp>           // dynamic_bitset
+#include <boost/dynamic_bitset.hpp>              // dynamic_bitset
 #include <boost/test/unit_test.hpp>               // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE_TEMPLATE
 #include <bitset>                                 // bitset
 #include <cstdint>                                // uint8_t, uint16_t, uint32_t, uint64_t

--- a/test/src/bits/std_bitset/o0.cpp
+++ b/test/src/bits/std_bitset/o0.cpp
@@ -8,8 +8,6 @@
 #include <test/uint128.hpp>                       // TEST_HAS_UINT128, uint128
 #include <xstd/bits/bitset.hpp>                   // bitset
 #include <xstd/bits/dynamic_bitset.hpp>           // dynamic_bitset
-#include <xstd/bits/ext/boost/dynamic_bitset.hpp> // dynamic_bitset
-#include <xstd/bits/ext/std/bitset.hpp>           // bitset
 #include <boost/test/unit_test.hpp>               // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE_TEMPLATE
 #include <bitset>                                 // bitset
 #include <cstdint>                                // uint8_t, uint16_t, uint32_t, uint64_t

--- a/test/src/bits/std_bitset/o1.cpp
+++ b/test/src/bits/std_bitset/o1.cpp
@@ -8,6 +8,7 @@
 #include <test/uint128.hpp>                       // TEST_HAS_UINT128, uint128
 #include <xstd/bits/bitset.hpp>                   // bitset
 #include <xstd/bits/dynamic_bitset.hpp>           // dynamic_bitset
+#include <boost/dynamic_bitset.hpp>              // dynamic_bitset
 #include <boost/test/unit_test.hpp>               // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE_TEMPLATE
 #include <bitset>                                 // bitset
 #include <cstdint>                                // uint8_t, uint16_t, uint32_t, uint64_t

--- a/test/src/bits/std_bitset/o1.cpp
+++ b/test/src/bits/std_bitset/o1.cpp
@@ -8,8 +8,6 @@
 #include <test/uint128.hpp>                       // TEST_HAS_UINT128, uint128
 #include <xstd/bits/bitset.hpp>                   // bitset
 #include <xstd/bits/dynamic_bitset.hpp>           // dynamic_bitset
-#include <xstd/bits/ext/boost/dynamic_bitset.hpp> // dynamic_bitset
-#include <xstd/bits/ext/std/bitset.hpp>           // bitset
 #include <boost/test/unit_test.hpp>               // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE_TEMPLATE
 #include <bitset>                                 // bitset
 #include <cstdint>                                // uint8_t, uint16_t, uint32_t, uint64_t

--- a/test/src/bits/std_bitset/o2.cpp
+++ b/test/src/bits/std_bitset/o2.cpp
@@ -8,6 +8,7 @@
 #include <test/uint128.hpp>                       // TEST_HAS_UINT128, uint128
 #include <xstd/bits/bitset.hpp>                   // bitset
 #include <xstd/bits/dynamic_bitset.hpp>           // dynamic_bitset
+#include <boost/dynamic_bitset.hpp>              // dynamic_bitset
 #include <boost/test/unit_test.hpp>               // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE_TEMPLATE
 #include <bitset>                                 // bitset
 #include <cstdint>                                // uint8_t, uint16_t, uint32_t, uint64_t

--- a/test/src/bits/std_bitset/o2.cpp
+++ b/test/src/bits/std_bitset/o2.cpp
@@ -8,8 +8,6 @@
 #include <test/uint128.hpp>                       // TEST_HAS_UINT128, uint128
 #include <xstd/bits/bitset.hpp>                   // bitset
 #include <xstd/bits/dynamic_bitset.hpp>           // dynamic_bitset
-#include <xstd/bits/ext/boost/dynamic_bitset.hpp> // dynamic_bitset
-#include <xstd/bits/ext/std/bitset.hpp>           // bitset
 #include <boost/test/unit_test.hpp>               // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE_TEMPLATE
 #include <bitset>                                 // bitset
 #include <cstdint>                                // uint8_t, uint16_t, uint32_t, uint64_t

--- a/test/src/bits/std_bitset/o3.cpp
+++ b/test/src/bits/std_bitset/o3.cpp
@@ -8,6 +8,7 @@
 #include <test/uint128.hpp>                       // TEST_HAS_UINT128, uint128
 #include <xstd/bits/bitset.hpp>                   // bitset
 #include <xstd/bits/dynamic_bitset.hpp>           // dynamic_bitset
+#include <boost/dynamic_bitset.hpp>              // dynamic_bitset
 #include <boost/test/unit_test.hpp>               // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE_TEMPLATE
 #include <bitset>                                 // bitset
 #include <cstdint>                                // uint8_t, uint16_t, uint32_t, uint64_t

--- a/test/src/bits/std_bitset/o3.cpp
+++ b/test/src/bits/std_bitset/o3.cpp
@@ -8,8 +8,6 @@
 #include <test/uint128.hpp>                       // TEST_HAS_UINT128, uint128
 #include <xstd/bits/bitset.hpp>                   // bitset
 #include <xstd/bits/dynamic_bitset.hpp>           // dynamic_bitset
-#include <xstd/bits/ext/boost/dynamic_bitset.hpp> // dynamic_bitset
-#include <xstd/bits/ext/std/bitset.hpp>           // bitset
 #include <boost/test/unit_test.hpp>               // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE_TEMPLATE
 #include <bitset>                                 // bitset
 #include <cstdint>                                // uint8_t, uint16_t, uint32_t, uint64_t

--- a/test/src/bits/std_bitset/o4.cpp
+++ b/test/src/bits/std_bitset/o4.cpp
@@ -8,6 +8,7 @@
 #include <test/uint128.hpp>                       // TEST_HAS_UINT128, uint128
 #include <xstd/bits/bitset.hpp>                   // bitset
 #include <xstd/bits/dynamic_bitset.hpp>           // dynamic_bitset
+#include <boost/dynamic_bitset.hpp>              // dynamic_bitset
 #include <boost/test/unit_test.hpp>               // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE_TEMPLATE
 #include <bitset>                                 // bitset
 #include <cstdint>                                // uint8_t, uint16_t, uint32_t, uint64_t

--- a/test/src/bits/std_bitset/o4.cpp
+++ b/test/src/bits/std_bitset/o4.cpp
@@ -8,8 +8,6 @@
 #include <test/uint128.hpp>                       // TEST_HAS_UINT128, uint128
 #include <xstd/bits/bitset.hpp>                   // bitset
 #include <xstd/bits/dynamic_bitset.hpp>           // dynamic_bitset
-#include <xstd/bits/ext/boost/dynamic_bitset.hpp> // dynamic_bitset
-#include <xstd/bits/ext/std/bitset.hpp>           // bitset
 #include <boost/test/unit_test.hpp>               // BOOST_AUTO_TEST_SUITE, BOOST_AUTO_TEST_SUITE_END, BOOST_AUTO_TEST_CASE_TEMPLATE
 #include <bitset>                                 // bitset
 #include <cstdint>                                // uint8_t, uint16_t, uint32_t, uint64_t


### PR DESCRIPTION
Groundwork for removing `ext/` and `bit_traits`, in two parts.

## 1. The raw bitset arms no longer route through the foreign traits

`test/include/test/bitset/primitives.hpp` drives `xstd::bitset` and raw `std::bitset` through one duck-typed functor — that shared body is what proves `xstd::bitset<N>` is a strict extension of `std::bitset<N>`. The functors contain no `bit_traits` and no `Traits::`; they call plain members.

Two of them reached for a `bit_set_view` anyway, and a view over `std::bitset` needs the `ext/` trait. So the raw arms pulled in foreign adaptation to test something unrelated to it, and `o0..o4` each carried two `ext/` includes for that reason alone.

- The set-reading cross-checks in `mem_equal_to` and `mem_compare_three_way` are guarded on `requires { xstd::bit_set_view(self); }`. Sound because `X` is a template parameter — measured on GCC 14 in the harness's own shape, the guard is `1` for an adapted type and `0` for an unadapted one. On a *concrete* type the same expression is a hard error, a trap this repository has hit before, but the functors are templates so that case does not arise.
- The `is_subset_of`, `is_proper_subset_of` and `intersects` fallbacks existed only for `std::bitset`, boost having those members natively. They re-derive from positions instead of through a view, staying independent of what they are checked against.
- `o0..o4` drop their `ext/` includes and name `<boost/dynamic_bitset.hpp>` directly: `factory.hpp` supplies only the forward declaration, and the `ext/` header was the only thing dragging the definition in.
- `<algorithm>` and `<ranges>` are named rather than reached transitively; the file already used `views::iota` fifteen times and `ranges::all_of` three with neither include present.

## 2. `contiguous_block_container` → `contiguous_block_range`

The concept asks only for a regular, sized, contiguous range of unsigned integers with a subscript, and a `std::array` is no container. The header, the design section and its anchor follow the name.

### A tightening tried and withdrawn

`range_const_reference_t<C>` would say the const clause without also, quietly, requiring `C const` to be a range — which nothing else in the concept asks for. It is P2278R4, and apple_clang / Xcode 16.4 rejected it:

```
error: no template named 'range_const_reference_t' in namespace 'std::__1::ranges';
       did you mean 'range_common_reference_t'?
```

Everything after that followed from the concept going unsatisfied: `contiguous_bit_vector` stopped being a `contiguous_bit_container`, so `xstd::dynamic_bitset` was never declared and the benchmark could not name it.

The two alias to the same type for every backend the concept admits — `std::array`, `std::vector`, `std::inplace_vector`, and proxy ranges like `vector<bool>` and `iota_view` besides — so the tightening bought nothing a backend can observe and is not worth a feature-test macro. `range_reference_t<C const>` stays, with a comment recording why.

## Verification

A local toolchain now exists for this: **g++-14 clears both blockers** that made these translation units unbuildable here — deducing-this (`block_mask(this auto&& self, …)`) and alias-template CTAD (`bit_set_view`). Boost.Test is installed alongside.

Compiling every TU under `test/src`, against `main` and against this branch:

| | pass | fail |
| --- | ---: | ---: |
| baseline at `main` | 18 | 24 |
| this branch | 23 | 19 |

Five fixed, none broken. The remaining 19 fail identically on `main` — libstdc++-14 and dependencies absent from this environment — so they are not this diff. The concept is checked directly over all three backends and the three non-matches, and `xstd::dynamic_bitset`, `bit_vector` and `bit_set` build, that being the path apple_clang cascaded on.

`ext/` is untouched and still tested; this only clears the way so the deletion does not have to move the oracle at the same time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPyqkBWNUZaT5VUx6bbxW1
